### PR TITLE
perf: warm the first panel first and sooner on paneled pages

### DIFF
--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -336,15 +336,11 @@ void MangaReaderActivity::loop() {
 
   const auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
   if (!prevTriggered && !nextTriggered) {
-    // Idle tick: after a dwell, warm the pixel cache the user is most likely to need next, so the
-    // render hits the cache instead of running a fresh JPEG decode. The dwell gate keeps rapid
-    // back-to-back presses from queueing a blocking decode between them.
-    //
-    // On a paneled full page the FIRST PANEL is warmed first and on a shorter dwell (see the
-    // constants): zooming in is the likely next action there and its cold decode is the slowest
-    // step of the full-page -> panel transition, so caching it even after a brief pause makes that
-    // transition snappy. The next-page cache warms afterward on the full dwell. Pages with no crops
-    // skip straight to the next-page warm. Inside panel-zoom it's the NEXT panel (full dwell).
+    // Idle tick: after a dwell, warm the pixel cache the user is most likely to need next so the
+    // render hits it instead of a fresh JPEG decode. Dwell gates and ordering rationale live with
+    // the PREFETCH_DWELL_MS / FIRST_PANEL_PREFETCH_DWELL_MS constants above. In short: on a paneled
+    // full page warm the first panel first (shorter dwell), then the next page; pages without crops
+    // go straight to the next page; inside panel-zoom warm the next panel.
     if (viewMode == ViewMode::FullPage) {
       const unsigned long dwell = millis() - fullPageRenderedMs;
       if (pageHasPanelCrops && !firstPanelPrefetched && dwell > FIRST_PANEL_PREFETCH_DWELL_MS) {

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -232,6 +232,15 @@ void MangaReaderActivity::prevPage() {
 
 namespace {
 constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
+
+// Idle-dwell gates (ms since the last render) before speculative pixel-cache prefetch. The
+// next-page / next-panel warms wait the full dwell so rapid flipping doesn't queue a blocking
+// decode between presses. The first panel of a paneled page uses a shorter dwell and is warmed
+// *first* (ahead of the next-page cache): zooming in is the likely next action there, and its cold
+// JPEG decode is the slowest step of the full-page -> panel transition, so getting it cached even
+// after a brief pause is what makes that transition feel instant.
+constexpr unsigned long PREFETCH_DWELL_MS = 400;
+constexpr unsigned long FIRST_PANEL_PREFETCH_DWELL_MS = 150;
 }  // namespace
 
 void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption) {
@@ -327,24 +336,29 @@ void MangaReaderActivity::loop() {
 
   const auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
   if (!prevTriggered && !nextTriggered) {
-    // Idle tick: after a short dwell, warm the pixel cache the user is most likely to need
-    // next, so that render hits the cache instead of running a fresh JPEG decode. On a full
-    // page that's the NEXT page first, then (when panel-zoom is in use) this page's FIRST
-    // panel; inside panel-zoom it's the NEXT panel. The dwell gate keeps rapid back-to-back
-    // presses from queueing a blocking decode between them.
-    if (viewMode == ViewMode::FullPage && (millis() - fullPageRenderedMs) > 400) {
-      if (!nextPagePrefetched) {
-        prefetchNextPageCache();
-      } else if (!firstPanelPrefetched) {
+    // Idle tick: after a dwell, warm the pixel cache the user is most likely to need next, so the
+    // render hits the cache instead of running a fresh JPEG decode. The dwell gate keeps rapid
+    // back-to-back presses from queueing a blocking decode between them.
+    //
+    // On a paneled full page the FIRST PANEL is warmed first and on a shorter dwell (see the
+    // constants): zooming in is the likely next action there and its cold decode is the slowest
+    // step of the full-page -> panel transition, so caching it even after a brief pause makes that
+    // transition snappy. The next-page cache warms afterward on the full dwell. Pages with no crops
+    // skip straight to the next-page warm. Inside panel-zoom it's the NEXT panel (full dwell).
+    if (viewMode == ViewMode::FullPage) {
+      const unsigned long dwell = millis() - fullPageRenderedMs;
+      if (pageHasPanelCrops && !firstPanelPrefetched && dwell > FIRST_PANEL_PREFETCH_DWELL_MS) {
         prefetchPanelCache(0);
+      } else if (!nextPagePrefetched && dwell > PREFETCH_DWELL_MS) {
+        prefetchNextPageCache();
       }
-    } else if (viewMode == ViewMode::PanelZoom && (millis() - panelRenderedMs) > 400) {
+    } else if (viewMode == ViewMode::PanelZoom && (millis() - panelRenderedMs) > PREFETCH_DWELL_MS) {
       if (panelGrayPending) {
         // Dwelled on a panel still showing the fast BW-only image: upgrade it to full 4-level gray.
         // Clear panelGrayPending as we hand off so this issues requestUpdate() exactly once per
         // dwell instead of every idle tick until the render task starts the upgrade. Takes priority
         // over the speculative next-panel prefetch below -- this is the panel the reader is actually
-        // looking at. (400ms dwell shared with the prefetch gate; tunable.)
+        // looking at. (Shares the PREFETCH_DWELL_MS gate; tunable.)
         panelGrayPending = false;
         panelGrayUpgrade = true;
         requestUpdate();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the full-page → first-panel transition in the manga reader land warm more often, so entering a panel is a cache read + one fast wave instead of a cold JPEG decode + wave.
* **What changes are included?** (all in `MangaReaderActivity::loop()`'s idle-prefetch tick)
  * **Reorder:** on a page that has panel crops, the **first panel is warmed before the next-page cache**. Zooming into a panel is the likely next action on a paneled page and it's the expensive decode path, so it gets priority; the next-page cache warms afterward. Pages with no crops go straight to the next-page warm as before.
  * **Shorter dwell:** the first-panel warm uses a **150ms** gate (`FIRST_PANEL_PREFETCH_DWELL_MS`) instead of the 400ms used for the other warms, so a brief pause before reaching for zoom is enough to have it cached.
  * Extracted the two dwell values into named constants (`PREFETCH_DWELL_MS = 400`, `FIRST_PANEL_PREFETCH_DWELL_MS = 150`) so they're documented and one-line tunable.

## Additional Context

* **Why the variable cost is the decode.** The e-ink wave is unchanged — it's already `FAST_REFRESH`, the quickest LUT the panel has (a ~4-frame differential), so it's the floor. The only attackable cost left in the transition is the crop decode, which prefetch eliminates *if the panel is warmed before entry*.
* **Contention.** `prefetchPanelCache()` already backs off via `RenderLock::peek()` while the render task is busy, so the shorter 150ms dwell doesn't contend with an in-flight page render during fast flipping — it retries on a later idle tick.
* **Tradeoff.** On a paneled page the next-page cache now warms after the first panel, so turning to the next full page (instead of zooming) may hit a cold decode — the deliberate cost of prioritizing panel entry. Both dwell values are one-line tunable if on-device testing suggests otherwise.
* **Device verification pending** (this activity has no host harness): open a paneled page, pause briefly, then zoom into the first panel — it should enter without a decode stall; confirm fast page-flipping still feels responsive.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z)_