### PR TITLE
fix: move manga prefetch decodes off the input-polling task

### DIFF
--- a/lib/Epub/Epub/converters/BmpToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/BmpToFramebufferConverter.cpp
@@ -30,6 +30,13 @@ bool BmpToFramebufferConverter::isMonochromeStatic(const std::string& imagePath)
 
 bool BmpToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath, GfxRenderer& renderer,
                                                     const RenderConfig& config) {
+  // Cache-only prefetch decodes are meaningless for BMP: this converter never streams a .2bp
+  // cache (see the header). The manga prefetch already skips BMP assets; reject defensively so
+  // a future caller can't silently decode into the framebuffer without the rendering mutex.
+  if (config.cacheOnly) {
+    LOG_ERR("BMP", "cacheOnly decode not supported: %s", imagePath.c_str());
+    return false;
+  }
   HalFile file;
   if (!Storage.openFileForRead("BMP", imagePath, file)) return false;
   Bitmap bmp(file, config.useDithering);

--- a/lib/Epub/Epub/converters/ImageDecoderFactory.cpp
+++ b/lib/Epub/Epub/converters/ImageDecoderFactory.cpp
@@ -3,19 +3,20 @@
 #include <Logging.h>
 
 #include <cctype>
-#include <memory>
-#include <new>
 #include <string>
 
 #include "BmpToFramebufferConverter.h"
 #include "JpegToFramebufferConverter.h"
 #include "PngToFramebufferConverter.h"
 
-std::unique_ptr<JpegToFramebufferConverter> ImageDecoderFactory::jpegDecoder = nullptr;
-std::unique_ptr<PngToFramebufferConverter> ImageDecoderFactory::pngDecoder = nullptr;
-std::unique_ptr<BmpToFramebufferConverter> ImageDecoderFactory::bmpDecoder = nullptr;
-
 namespace {
+// Shared stateless converter instances. Static-init construction (single-threaded, before any
+// task starts) instead of lazy allocation -- see the rationale in ImageDecoderFactory.h. The
+// constructors are trivial (no data members), so there is no static-init-order hazard.
+JpegToFramebufferConverter jpegDecoder;
+PngToFramebufferConverter pngDecoder;
+BmpToFramebufferConverter bmpDecoder;
+
 // Lower-cased file extension (including the dot), or "" if none. Shared by getDecoder() and
 // isFormatSupported() so both agree on what a "supported format" is.
 std::string lowerExtension(const std::string& imagePath) {
@@ -30,37 +31,15 @@ std::string lowerExtension(const std::string& imagePath) {
 ImageToFramebufferDecoder* ImageDecoderFactory::getDecoder(const std::string& imagePath) {
   const std::string ext = lowerExtension(imagePath);
 
-  // new (std::nothrow): bare new aborts the firmware on OOM under -fno-exceptions (see CLAUDE.md).
-  // A null decoder propagates through get() and every caller already handles a null decoder
-  // (renderFullPage/renderPanelZoom show a load error / fall back; prefetch skips).
-  if (JpegToFramebufferConverter::supportsFormat(ext)) {
-    if (!jpegDecoder) {
-      jpegDecoder.reset(new (std::nothrow) JpegToFramebufferConverter());
-      if (!jpegDecoder) LOG_ERR("DEC", "OOM allocating JPEG decoder for: %s", imagePath.c_str());
-    }
-    return jpegDecoder.get();
-  } else if (PngToFramebufferConverter::supportsFormat(ext)) {
-    if (!pngDecoder) {
-      pngDecoder.reset(new (std::nothrow) PngToFramebufferConverter());
-      if (!pngDecoder) LOG_ERR("DEC", "OOM allocating PNG decoder for: %s", imagePath.c_str());
-    }
-    return pngDecoder.get();
-  } else if (BmpToFramebufferConverter::supportsFormat(ext)) {
-    if (!bmpDecoder) {
-      bmpDecoder.reset(new (std::nothrow) BmpToFramebufferConverter());
-      if (!bmpDecoder) LOG_ERR("DEC", "OOM allocating BMP decoder for: %s", imagePath.c_str());
-    }
-    return bmpDecoder.get();
-  }
+  if (JpegToFramebufferConverter::supportsFormat(ext)) return &jpegDecoder;
+  if (PngToFramebufferConverter::supportsFormat(ext)) return &pngDecoder;
+  if (BmpToFramebufferConverter::supportsFormat(ext)) return &bmpDecoder;
 
   LOG_ERR("DEC", "No decoder found for image: %s", imagePath.c_str());
   return nullptr;
 }
 
 bool ImageDecoderFactory::isFormatSupported(const std::string& imagePath) {
-  // Format support is a static property of the extension -- decide it WITHOUT allocating a decoder.
-  // (getDecoder now returns nullptr on OOM via nothrow allocation, so delegating here would wrongly
-  // report a supported format as unsupported under memory pressure.)
   const std::string ext = lowerExtension(imagePath);
   return JpegToFramebufferConverter::supportsFormat(ext) || PngToFramebufferConverter::supportsFormat(ext) ||
          BmpToFramebufferConverter::supportsFormat(ext);

--- a/lib/Epub/Epub/converters/ImageDecoderFactory.h
+++ b/lib/Epub/Epub/converters/ImageDecoderFactory.h
@@ -1,22 +1,19 @@
 #pragma once
-#include <cstdint>
-#include <memory>
 #include <string>
 
 #include "ImageToFramebufferDecoder.h"
 
-class JpegToFramebufferConverter;
-class PngToFramebufferConverter;
-class BmpToFramebufferConverter;
-
 class ImageDecoderFactory {
  public:
-  // Returns non-owning pointer - factory owns the decoder lifetime
+  // Returns a non-owning pointer to a shared, STATELESS converter instance (or nullptr for an
+  // unsupported extension). The instances are file-scope statics constructed during static init,
+  // before any task exists -- deliberately NOT lazily allocated: getDecoder is called from the
+  // render task, the loop task, and the manga prefetch worker, and an unsynchronized first-use
+  // `if (!ptr) ptr.reset(new ...)` between two tasks is a use-after-free waiting to happen
+  // (task A's reset can delete the instance task B just obtained). Each converter is
+  // vtable-pointer-sized with no data members; the heavy per-decode state (JPEGDEC ~20KB /
+  // PNGdec ~44KB) is still heap-allocated on demand inside decodeToFramebuffer, so eager
+  // construction costs a few bytes of BSS and removes both the race and the OOM path entirely.
   static ImageToFramebufferDecoder* getDecoder(const std::string& imagePath);
   static bool isFormatSupported(const std::string& imagePath);
-
- private:
-  static std::unique_ptr<JpegToFramebufferConverter> jpegDecoder;
-  static std::unique_ptr<PngToFramebufferConverter> pngDecoder;
-  static std::unique_ptr<BmpToFramebufferConverter> bmpDecoder;
 };

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.cpp
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.cpp
@@ -2,10 +2,15 @@
 
 #include <Logging.h>
 
+#include <cstdint>
+
 bool ImageToFramebufferDecoder::validateImageDimensions(int width, int height, const std::string& format) {
-  if (width * height > MAX_SOURCE_PIXELS) {
-    LOG_ERR("IMG", "Image too large (%dx%d = %d pixels %s), max supported: %d pixels", width, height, width * height,
-            format.c_str(), MAX_SOURCE_PIXELS);
+  // 64-bit product: decoder headers can claim up to 65535 per axis, and 65535*65535 overflows a
+  // 32-bit int -- a malformed file could wrap the product negative and slip past the cap.
+  const int64_t pixels = static_cast<int64_t>(width) * height;
+  if (pixels > MAX_SOURCE_PIXELS) {
+    LOG_ERR("IMG", "Image too large (%dx%d = %lld pixels %s), max supported: %d pixels", width, height,
+            static_cast<long long>(pixels), format.c_str(), MAX_SOURCE_PIXELS);
     return false;
   }
   return true;

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <HalStorage.h>
+#include <stdint.h>
 
 #include <memory>
 #include <string>
@@ -65,8 +66,16 @@ class ImageToFramebufferDecoder {
   virtual const char* getFormatName() const = 0;
 
  protected:
-  // Size validation helpers
-  static constexpr int MAX_SOURCE_PIXELS = 3145728;  // 2048 * 1536
+  // Sanity cap on source image AREA, aligned with the BMP path's existing per-axis caps in
+  // Bitmap.cpp (2048 x 3072). The old 2048x1536-equivalent cap rejected completely ordinary
+  // manga page scans (observed on-device: a 1500x2250 PNG page -> blank page, since the decode
+  // failed after the geometry was already committed). Area is NOT what bounds memory in these
+  // streamed decoders -- their working set scales with WIDTH, and each converter has its own
+  // real guard for that (PNG: the PNG_MAX_BUFFERED_PIXELS runtime check against the source
+  // pitch; JPEG: JPEGDEC chunks MCU rows internally and our callback allocates nothing
+  // width-dependent; the pixel-cache band is destination-sized, <= screen). This cap only
+  // bounds worst-case decode TIME for pathological inputs.
+  static constexpr int32_t MAX_SOURCE_PIXELS = 2048 * 3072;
 
   bool validateImageDimensions(int width, int height, const std::string& format);
   void warnUnsupportedFeature(const std::string& feature, const std::string& imagePath);

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -50,8 +50,8 @@ struct RenderConfig {
   // NOTE (verified against JPEGDEC @86282979 jpeg.inl DecodeJPEG): an aborted decode still
   // returns success (iErr stays 0 on early exit), so converters must track cancellation
   // themselves and treat an aborted decode as failure -- never finalize a partial cache.
-  bool (*shouldCancel)(void* ctx) = nullptr;
-  void* cancelCtx = nullptr;
+  bool (*shouldCancel)(const void* ctx) = nullptr;
+  const void* cancelCtx = nullptr;
 };
 
 class ImageToFramebufferDecoder {

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -34,6 +34,24 @@ struct RenderConfig {
   // pixel is written opaquely -- including white, which the normal BW path leaves
   // untouched. Sources without an alpha channel render fully opaque. PNG only.
   bool alphaMask = false;
+
+  // Background-prefetch mode: stream ONLY the .2bp pixel cache (cachePath, required) to SD and
+  // never touch the framebuffer or read any renderer state. Because nothing shared with the
+  // render task is accessed, the decode needs no rendering mutex and no framebuffer snapshot --
+  // this is what lets the manga prefetch worker run off the render/input tasks. JPEG/PNG only
+  // (BMP never streams a cache); decodeToFramebuffer fails fast if cachePath is empty or the
+  // cache stream can't start, since the decode would produce nothing.
+  bool cacheOnly = false;
+
+  // Cooperative cancellation, polled once per decode block/scanline. Return true to abort: the
+  // decode stops within one block and the partial cache file is dropped, so a background warm
+  // gets out of the way the moment a real render (or activity teardown) needs the CPU/SD.
+  // Plain function pointer + context, not std::function (see CLAUDE.md on closure bloat).
+  // NOTE (verified against JPEGDEC @86282979 jpeg.inl DecodeJPEG): an aborted decode still
+  // returns success (iErr stays 0 on early exit), so converters must track cancellation
+  // themselves and treat an aborted decode as failure -- never finalize a partial cache.
+  bool (*shouldCancel)(void* ctx) = nullptr;
+  void* cancelCtx = nullptr;
 };
 
 class ImageToFramebufferDecoder {

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -46,6 +46,14 @@ struct JpegContext {
 
   PixelCache cache;
   bool caching{false};
+
+  // Cache-only decode (background prefetch): skip every DirectPixelWriter/renderer access.
+  bool cacheOnly{false};
+  // Set when config->shouldCancel asked for an abort. REQUIRED to detect cancellation: JPEGDEC's
+  // DecodeJPEG returns success after a callback-initiated early exit (iErr stays 0), so the rc
+  // alone cannot distinguish "decoded fully" from "aborted mid-image" -- and finalizing the cache
+  // for an aborted decode would persist a half-written .2bp as if it were complete.
+  bool cancelled{false};
 };
 
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
@@ -122,6 +130,13 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   JpegContext* ctx = reinterpret_cast<JpegContext*>(pDraw->pUser);
   if (!ctx || !ctx->config || !ctx->renderer) return 0;
 
+  // Cooperative cancel: polled once per MCU block (~10-30ms of decode), so an abort request
+  // takes effect almost immediately. Returning 0 makes DecodeJPEG's bContinue loops exit.
+  if (ctx->config->shouldCancel && ctx->config->shouldCancel(ctx->config->cancelCtx)) {
+    ctx->cancelled = true;
+    return 0;
+  }
+
   // In EIGHT_BIT_GRAYSCALE mode, pPixels contains 8-bit grayscale values
   // Buffer is densely packed: stride = pDraw->iWidth, valid columns = pDraw->iWidthUsed
   uint8_t* pixels = reinterpret_cast<uint8_t*>(pDraw->pPixels);
@@ -132,6 +147,11 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   if (stride <= 0 || blockH <= 0 || validW <= 0) return 1;
 
   const bool useDithering = ctx->config->useDithering;
+  // Cache-only prefetch never touches the framebuffer: pw stays uninitialized (init reads
+  // renderer state, which a lock-free background decode must not do), so every pw call below
+  // is guarded. The branch is constant per decode -- perfectly predicted, same cost class as
+  // the existing per-pixel `if (caching)`.
+  const bool cacheOnly = ctx->cacheOnly;
   bool caching = ctx->caching;
   const int32_t fineScaleFPX = ctx->fineScaleFPX;
   const int32_t invScaleFPX = ctx->invScaleFPX;
@@ -168,8 +188,8 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   if (dstYStart >= dstYEnd || dstXStart >= dstXEnd) return 1;
 
   // Pre-compute orientation and render-mode state once per callback invocation
-  DirectPixelWriter pw;
-  pw.init(renderer);
+  DirectPixelWriter pw{};  // value-init: cacheOnly leaves it untouched (all uses below are guarded)
+  if (!cacheOnly) pw.init(renderer);
 
   // The cache streams to disk one MCU-row band at a time. Flushing rows below
   // this block (raster order guarantees they are final) repositions the band;
@@ -192,7 +212,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   if (fineScaleFPX == FP_ONE && fineScaleFPY == FP_ONE) {
     for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
       const int outY = cfgY + dstY;
-      pw.beginRow(outY);
+      if (!cacheOnly) pw.beginRow(outY);
       if (caching) cw.beginRow(outY, cacheOriginY);
       const uint8_t* row = &pixels[(dstY - blockY) * stride];
       for (int dstX = dstXStart; dstX < dstXEnd; dstX++) {
@@ -205,7 +225,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
     }
@@ -226,7 +246,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
 
     for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
       const int outY = cfgY + dstY;
-      pw.beginRow(outY);
+      if (!cacheOnly) pw.beginRow(outY);
       if (caching) cw.beginRow(outY, cacheOriginY);
       const int32_t srcFyFP = dstY * invScaleFPY;
       const int32_t fy = srcFyFP & FP_MASK;
@@ -264,7 +284,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
 
@@ -287,7 +307,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
 
@@ -313,7 +333,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
     }
@@ -323,7 +343,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   // === Nearest-neighbor (downscale: fineScale < 1.0) ===
   for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
     const int outY = cfgY + dstY;
-    pw.beginRow(outY);
+    if (!cacheOnly) pw.beginRow(outY);
     if (caching) cw.beginRow(outY, cacheOriginY);
     const int32_t srcFyFP = dstY * invScaleFPY;
     int ly = (srcFyFP >> FP_SHIFT) - blockY;
@@ -346,7 +366,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
         dithered = gray / 85;
         if (dithered > 3) dithered = 3;
       }
-      pw.writePixel(outX, dithered);
+      if (!cacheOnly) pw.writePixel(outX, dithered);
       if (caching) cw.writePixel(outX, dithered);
     }
   }
@@ -402,8 +422,19 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
   JpegContext ctx;
   ctx.renderer = &renderer;
   ctx.config = &config;
-  ctx.screenWidth = renderer.getScreenWidth();
-  ctx.screenHeight = renderer.getScreenHeight();
+  ctx.cacheOnly = config.cacheOnly;
+  if (ctx.cacheOnly) {
+    // Cache-only decode produces nothing without a cache stream, and it must not read renderer
+    // state (it runs without the rendering mutex): screen bounds are substituted with exact
+    // no-clip values once the destination size is known, further down.
+    if (config.cachePath.empty()) {
+      LOG_ERR("JPG", "cacheOnly decode without cachePath: %s", imagePath.c_str());
+      return false;
+    }
+  } else {
+    ctx.screenWidth = renderer.getScreenWidth();
+    ctx.screenHeight = renderer.getScreenHeight();
+  }
 
   int rc = jpeg->open(imagePath.c_str(), jpegOpen, jpegClose, jpegRead, jpegSeek, jpegDrawCallback);
   const ScopedCleanup cleanup{[&jpeg]() { jpeg->close(); }};
@@ -479,6 +510,14 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
   ctx.scaledSrcHeight = (srcHeight + jpegScaleDenom - 1) / jpegScaleDenom;
   ctx.dstWidth = destWidth;
   ctx.dstHeight = destHeight;
+  if (ctx.cacheOnly) {
+    // Exact no-clip screen bounds: the callback's clamp `screen - cfg < dst` never triggers, so
+    // the full destWidth x destHeight lands in the cache. Manga geometry always fits on screen
+    // anyway (applyFullPageGeometry/applyPanelGeometry produce on-screen rects), so this matches
+    // what a locked, framebuffer-backed decode of the same image would have cached.
+    ctx.screenWidth = config.x + destWidth;
+    ctx.screenHeight = config.y + destHeight;
+  }
   ctx.fineScaleFPX = (int32_t)((int64_t)destWidth * FP_ONE / ctx.scaledSrcWidth);
   ctx.invScaleFPX = (int32_t)((int64_t)ctx.scaledSrcWidth * FP_ONE / destWidth);
   ctx.fineScaleFPY = (int32_t)((int64_t)destHeight * FP_ONE / ctx.scaledSrcHeight);
@@ -499,6 +538,11 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
   if (ctx.caching) {
     const int maxBlockDstRows = (int)(((int64_t)16 * ctx.fineScaleFPY) >> FP_SHIFT) + 2;
     if (!ctx.cache.begin(config.cachePath, destWidth, destHeight, config.x, config.y, maxBlockDstRows)) {
+      if (ctx.cacheOnly) {
+        // The cache IS the output here -- decoding without it would be pure wasted work.
+        LOG_ERR("JPG", "cacheOnly: cache stream failed to start, skipping decode");
+        return false;
+      }
       LOG_ERR("JPG", "Failed to start cache stream, continuing without caching");
       ctx.caching = false;
     }
@@ -508,8 +552,15 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
   rc = jpeg->decode(0, 0, jpegScaleOption);
   unsigned long decodeTime = millis() - decodeStart;
 
-  if (rc != 1) {
-    LOG_ERR("JPG", "Decode failed (rc=%d, lastError=%d)", rc, jpeg->getLastError());
+  // A cancelled decode reports SUCCESS from JPEGDEC (early exit leaves iErr==0) -- ctx.cancelled
+  // is the only reliable signal. Either way the image is incomplete: drop the partial cache so a
+  // later warm or render decode recreates it, and report failure to the caller.
+  if (rc != 1 || ctx.cancelled) {
+    if (ctx.cancelled) {
+      LOG_DBG("JPG", "Decode cancelled: %s", imagePath.c_str());
+    } else {
+      LOG_ERR("JPG", "Decode failed (rc=%d, lastError=%d)", rc, jpeg->getLastError());
+    }
     if (ctx.caching) ctx.cache.abort();
     return false;
   }

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -37,6 +37,13 @@ struct PngContext {
   PixelCache cache;
   bool caching{false};
 
+  // Cache-only decode (background prefetch): skip every DirectPixelWriter/renderer access.
+  bool cacheOnly{false};
+  // Set when config->shouldCancel asked for an abort. PNGdec does surface a callback abort as
+  // PNG_QUIT_EARLY, but we track it explicitly anyway (uniform with the JPEG converter, where
+  // the library reports success after an abort) so a partial cache can never be finalized.
+  bool cancelled{false};
+
   uint8_t* grayLineBuffer{nullptr};
   uint8_t* alphaLineBuffer{nullptr};  // per-pixel source alpha; only allocated for alphaMask
 };
@@ -192,6 +199,13 @@ int pngDrawCallback(PNGDRAW* pDraw) {
   PngContext* ctx = reinterpret_cast<PngContext*>(pDraw->pUser);
   if (!ctx || !ctx->config || !ctx->renderer || !ctx->grayLineBuffer) return 0;
 
+  // Cooperative cancel: polled once per scanline. Returning 0 makes PNGdec stop with
+  // PNG_QUIT_EARLY (verified in png.inl 1.1.6).
+  if (ctx->config->shouldCancel && ctx->config->shouldCancel(ctx->config->cancelCtx)) {
+    ctx->cancelled = true;
+    return 0;
+  }
+
   int srcY = pDraw->y;
   int srcWidth = ctx->srcWidth;
 
@@ -227,11 +241,17 @@ int pngDrawCallback(PNGDRAW* pDraw) {
   int screenWidth = ctx->screenWidth;
   bool useDithering = ctx->config->useDithering;
   bool caching = ctx->caching;
+  // Cache-only prefetch never touches the framebuffer: pw stays uninitialized (init reads
+  // renderer state, which a lock-free background decode must not do), so every pw call below is
+  // guarded. Constant per decode -- perfectly predicted, same cost class as `if (caching)`.
+  const bool cacheOnly = ctx->cacheOnly;
 
   // Pre-compute orientation and render-mode state once per row
-  DirectPixelWriter pw;
-  pw.init(*ctx->renderer);
-  pw.beginRow(outY);
+  DirectPixelWriter pw{};  // value-init: cacheOnly leaves it untouched (all uses below are guarded)
+  if (!cacheOnly) {
+    pw.init(*ctx->renderer);
+    pw.beginRow(outY);
+  }
 
   // The cache streams to disk one row at a time. Flushing rows below this one
   // (PNGdec delivers scanlines top to bottom) repositions the single-row band.
@@ -265,10 +285,12 @@ int pngDrawCallback(PNGDRAW* pDraw) {
         ditheredGray = gray / 85;
         if (ditheredGray > 3) ditheredGray = 3;
       }
-      if (alphaMask) {
-        pw.writePixelOpaque(outX, ditheredGray);
-      } else {
-        pw.writePixel(outX, ditheredGray);
+      if (!cacheOnly) {
+        if (alphaMask) {
+          pw.writePixelOpaque(outX, ditheredGray);
+        } else {
+          pw.writePixel(outX, ditheredGray);
+        }
       }
       if (caching) cw.writePixel(outX, ditheredGray);
     }
@@ -334,8 +356,19 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
   PngContext ctx;
   ctx.renderer = &renderer;
   ctx.config = &config;
-  ctx.screenWidth = renderer.getScreenWidth();
-  ctx.screenHeight = renderer.getScreenHeight();
+  ctx.cacheOnly = config.cacheOnly;
+  if (ctx.cacheOnly) {
+    // Cache-only decode produces nothing without a cache stream, and it must not read renderer
+    // state (it runs without the rendering mutex): screen bounds are substituted with exact
+    // no-clip values once the destination size is known, further down.
+    if (config.cachePath.empty()) {
+      LOG_ERR("PNG", "cacheOnly decode without cachePath: %s", imagePath.c_str());
+      return false;
+    }
+  } else {
+    ctx.screenWidth = renderer.getScreenWidth();
+    ctx.screenHeight = renderer.getScreenHeight();
+  }
 
   int rc = png->open(imagePath.c_str(), pngOpenWithHandle, pngCloseWithHandle, pngReadWithHandle, pngSeekWithHandle,
                      pngDrawCallback);
@@ -378,6 +411,12 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
     ctx.dstHeight = (int)(ctx.srcHeight * ctx.scale);
   }
   ctx.lastDstY = -1;  // Reset row tracking
+  if (ctx.cacheOnly) {
+    // Exact no-clip screen bounds so the full dstWidth x dstHeight lands in the cache -- same
+    // rationale as the JPEG converter (manga geometry is always on-screen anyway).
+    ctx.screenWidth = config.x + ctx.dstWidth;
+    ctx.screenHeight = config.y + ctx.dstHeight;
+  }
 
   LOG_DBG("PNG", "PNG %dx%d -> %dx%d (scale %.2f), bpp: %d", ctx.srcWidth, ctx.srcHeight, ctx.dstWidth, ctx.dstHeight,
           ctx.scale, png->getBpp());
@@ -422,6 +461,15 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
   ctx.caching = !config.cachePath.empty();
   if (ctx.caching) {
     if (!ctx.cache.begin(config.cachePath, ctx.dstWidth, ctx.dstHeight, config.x, config.y, 1)) {
+      if (ctx.cacheOnly) {
+        // The cache IS the output here -- decoding without it would be pure wasted work.
+        LOG_ERR("PNG", "cacheOnly: cache stream failed to start, skipping decode");
+        free(ctx.grayLineBuffer);
+        ctx.grayLineBuffer = nullptr;
+        free(ctx.alphaLineBuffer);
+        ctx.alphaLineBuffer = nullptr;
+        return false;
+      }
       LOG_ERR("PNG", "Failed to start cache stream, continuing without caching");
       ctx.caching = false;
     }
@@ -436,8 +484,14 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
   free(ctx.alphaLineBuffer);
   ctx.alphaLineBuffer = nullptr;
 
-  if (rc != PNG_SUCCESS) {
-    LOG_ERR("PNG", "Decode failed: %d", rc);
+  // A cancelled decode surfaces as PNG_QUIT_EARLY; ctx.cancelled double-checks it. Either way the
+  // image is incomplete: drop the partial cache and report failure.
+  if (rc != PNG_SUCCESS || ctx.cancelled) {
+    if (ctx.cancelled) {
+      LOG_DBG("PNG", "Decode cancelled: %s", imagePath.c_str());
+    } else {
+      LOG_ERR("PNG", "Decode failed: %d", rc);
+    }
     if (ctx.caching) ctx.cache.abort();
     return false;
   }

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -321,6 +321,8 @@ RenderLock::RenderLock([[maybe_unused]] Activity&) {
   isLocked = true;
 }
 
+RenderLock::RenderLock(Try) { isLocked = (xSemaphoreTake(activityManager.renderingMutex, 0) == pdTRUE); }
+
 RenderLock::~RenderLock() {
   if (isLocked) {
     xSemaphoreGive(activityManager.renderingMutex);

--- a/src/activities/RenderLock.h
+++ b/src/activities/RenderLock.h
@@ -7,11 +7,21 @@ class RenderLock {
   bool isLocked = false;
 
  public:
+  // Tag for the non-blocking constructor below.
+  struct Try {};
+
   explicit RenderLock();
   explicit RenderLock(Activity&);  // unused for now, but keep for compatibility
+  // Non-blocking acquire (zero timeout): check held() for the outcome. On failure the object is
+  // inert -- the destructor releases nothing. This exists because peek()-then-RenderLock has a
+  // TOCTOU window: another task can take the mutex between the check and the constructor, turning
+  // the "guarded" acquire into a full block. Use this from any task that must never wait on a
+  // render (e.g. the input-polling loop task).
+  explicit RenderLock(Try);
   RenderLock(const RenderLock&) = delete;
   RenderLock& operator=(const RenderLock&) = delete;
   ~RenderLock();
+  bool held() const { return isLocked; }
   void unlock();
   static bool peek();
 };

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -1053,7 +1053,15 @@ void MangaReaderActivity::workerWarmNextPage() {
   if (decoder->decodeToFramebuffer(prefetchJob.imgPath, renderer, config)) {
     // SdFat rename fails (O_CREAT|O_EXCL) if the destination exists -- exactly what we want when
     // a foreground render published the real cache first. Losing the race just drops our tmp.
+    // Any OTHER rename failure (I/O error, card full) leaves no cache; the job is still marked
+    // completed rather than retried: the done flags mean "stop warming this asset", NOT "cache
+    // guaranteed present" -- every render path probes the cache file itself and falls back to an
+    // on-demand decode, and retrying on a failing/full card would churn the worker forever.
+    // Same give-up-once policy as a decode failure below; log it so it isn't silent.
     if (!Storage.rename(tmpPath.c_str(), prefetchJob.cachePath.c_str())) {
+      if (!Storage.exists(prefetchJob.cachePath.c_str())) {
+        LOG_ERR("MRA", "Prefetch cache publish failed: %s", prefetchJob.cachePath.c_str());
+      }
       Storage.remove(tmpPath.c_str());
     }
     prefetchResult.completed = true;
@@ -1133,7 +1141,13 @@ void MangaReaderActivity::workerWarmPanel() {
   const std::string tmpPath = prefetchJob.cachePath + ".tmp";
   config.cachePath = tmpPath;
   if (decoder->decodeToFramebuffer(prefetchJob.imgPath, renderer, config)) {
+    // See workerWarmNextPage: rename-fails-because-destination-exists is the by-design lost
+    // race; any other failure still completes the job (done flags mean "stop warming", not
+    // "cache present" -- renders probe the file and fall back to decoding) but gets logged.
     if (!Storage.rename(tmpPath.c_str(), prefetchJob.cachePath.c_str())) {
+      if (!Storage.exists(prefetchJob.cachePath.c_str())) {
+        LOG_ERR("MRA", "Prefetch cache publish failed: %s", prefetchJob.cachePath.c_str());
+      }
       Storage.remove(tmpPath.c_str());
     }
     prefetchResult.completed = true;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -37,6 +37,30 @@
 #include "util/BookmarkUtil.h"
 #include "util/ScreenshotUtil.h"
 
+namespace {
+constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
+
+// Idle-dwell gates (ms since the last render) before speculative pixel-cache prefetch. The
+// next-page / next-panel warms wait the full dwell so rapid flipping doesn't queue a blocking
+// decode between presses. The first panel of a paneled page uses a shorter dwell and is warmed
+// *first* (ahead of the next-page cache): zooming in is the likely next action there, and its cold
+// JPEG decode is the slowest step of the full-page -> panel transition, so getting it cached even
+// after a brief pause is what makes that transition feel instant.
+constexpr unsigned long PREFETCH_DWELL_MS = 400;
+constexpr unsigned long FIRST_PANEL_PREFETCH_DWELL_MS = 150;
+
+// Heap floor before a background decode starts. The old in-loop prefetch also needed a ~48KB
+// framebuffer snapshot; the cache-only worker doesn't (it never touches the framebuffer), but
+// the decoder (~20KB JPEG / ~44KB PNG) plus the streaming cache band (<=24KB) still want real
+// headroom -- and a foreground render may now allocate concurrently. Keep the old conservative
+// floor rather than shaving it.
+constexpr uint32_t PREFETCH_HEAP_FLOOR = 60000;
+
+// Prefetch worker stack, in bytes. Mirrors the render task (ActivityManager::begin), which runs
+// these same JPEG/PNG decode paths -- the one stack size proven for them on hardware.
+constexpr uint32_t PREFETCH_TASK_STACK = 8192;
+}  // namespace
+
 void MangaReaderActivity::onEnter() {
   Activity::onEnter();
 
@@ -260,30 +284,6 @@ void MangaReaderActivity::prevPage() {
     requestUpdate();
   }
 }
-
-namespace {
-constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
-
-// Idle-dwell gates (ms since the last render) before speculative pixel-cache prefetch. The
-// next-page / next-panel warms wait the full dwell so rapid flipping doesn't queue a blocking
-// decode between presses. The first panel of a paneled page uses a shorter dwell and is warmed
-// *first* (ahead of the next-page cache): zooming in is the likely next action there, and its cold
-// JPEG decode is the slowest step of the full-page -> panel transition, so getting it cached even
-// after a brief pause is what makes that transition feel instant.
-constexpr unsigned long PREFETCH_DWELL_MS = 400;
-constexpr unsigned long FIRST_PANEL_PREFETCH_DWELL_MS = 150;
-
-// Heap floor before a background decode starts. The old in-loop prefetch also needed a ~48KB
-// framebuffer snapshot; the cache-only worker doesn't (it never touches the framebuffer), but
-// the decoder (~20KB JPEG / ~44KB PNG) plus the streaming cache band (<=24KB) still want real
-// headroom -- and a foreground render may now allocate concurrently. Keep the old conservative
-// floor rather than shaving it.
-constexpr uint32_t PREFETCH_HEAP_FLOOR = 60000;
-
-// Prefetch worker stack, in bytes. Mirrors the render task (ActivityManager::begin), which runs
-// these same JPEG/PNG decode paths -- the one stack size proven for them on hardware.
-constexpr uint32_t PREFETCH_TASK_STACK = 8192;
-}  // namespace
 
 void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption) {
   if (selectedPageTurnOption == 0 || selectedPageTurnOption >= std::size(PAGE_TURN_RATES)) {

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -989,6 +989,12 @@ void MangaReaderActivity::applyPrefetchResult() {
   // panelDims write keeps the established "loop task writes under RenderLock" discipline, and
   // the worker can stay lock-free (see the header: onExit() joins it while HOLDING RenderLock).
   if (prefetchBusy || !prefetchResult.pending) return;
+  // NEVER block the input task on the rendering mutex: if a render is in flight, taking the lock
+  // below would stall loop() -- and button polling with it -- for the render's whole duration
+  // (observed on-device: a 2.7s loop stall when a cancelled warm's dims were applied during a
+  // 3.3s panel decode). Defer instead; the result stays pending and a later tick applies it.
+  // postPrefetchJob refuses new jobs while a result is pending, so nothing is lost or clobbered.
+  if (prefetchResult.dimsValid && RenderLock::peek()) return;
   const bool genOk = (prefetchJob.gen == pageGeneration);
   if (prefetchResult.dimsValid && genOk) {
     RenderLock lock;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -654,6 +654,10 @@ void MangaReaderActivity::renderFullPage() {
 }
 
 void MangaReaderActivity::prefetchNextPageCache() {
+  // Don't even build a job while a render is active/queued: the worker would only defer via its
+  // cancel probe, so posting now is pure churn -- a task wake-up plus fresh path strings every
+  // idle tick for the render's whole duration (heap-fragmentation smell). Retry next tick.
+  if (RenderLock::peek()) return;
   if (!book) {
     nextPagePrefetched = true;
     return;
@@ -903,6 +907,8 @@ MangaReaderActivity::PanelGeom MangaReaderActivity::applyPanelGeometry(const int
 // dimension slot) so entering the panel costs a cache read instead of a JPEG decode. This is
 // only the loop-side gate; the SD probes and the decode itself run on the prefetch worker.
 void MangaReaderActivity::prefetchPanelCache(const int panelIdx) {
+  // See prefetchNextPageCache: no job building while a render is active/queued.
+  if (RenderLock::peek()) return;
   std::atomic<bool>& doneFlag = (viewMode == ViewMode::FullPage) ? firstPanelPrefetched : nextPanelPrefetched;
   if (!book || panelIdx < 0 || panelIdx >= static_cast<int>(panels.size())) {
     doneFlag = true;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -71,6 +71,10 @@ void MangaReaderActivity::onEnter() {
   if (!book) return;
 
   ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
+  // Base screen dims for the prefetch worker's geometry math -- captured here, the one moment
+  // that is single-threaded by construction (no render has been requested yet). See the header.
+  baseScreenW = renderer.getScreenWidth();
+  baseScreenH = renderer.getScreenHeight();
   loadProgress();
   loadCachedBookmarks();
   updateBookmarkFlag();
@@ -723,9 +727,9 @@ void MangaReaderActivity::renderPanelZoom() {
   const std::string panelImgPath = panelCropPath(currentPanel);
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(panelImgPath);
   if (!decoder) {
-    // A null decoder is a transient condition (getDecoder allocates its decoder with nothrow and
-    // returns null on OOM), NOT a permanently missing/unsupported crop -- so DON'T poison the
-    // dims slot with -1 here. Fall back this frame; a later entry retries once memory recovers.
+    // Defensive: getDecoder returns null only for an unsupported extension, and crop paths are
+    // always .jpg/.bmp -- shouldn't happen. Fall back to the full page without poisoning the
+    // dims slot.
     renderFullPage();
     return;
   }
@@ -973,12 +977,10 @@ void MangaReaderActivity::postPrefetchJob(PrefetchJob&& job) {
   // No worker (task creation failed at onEnter): prefetching is disabled; mark nothing.
   if (!prefetchTaskHandle || prefetchBusy || prefetchResult.pending) return;
   prefetchJob = std::move(job);
-  // Screen dims for the pure geometry math, captured once here. A render running concurrently
-  // inside its locked section may have the orientation transiently rotated, which could yield
-  // swapped dims -- benign: the resulting cache fails renderFromCache's dimension check and the
-  // entry falls back to a normal decode (self-healing miss, never a corrupt render).
-  prefetchJob.screenW = renderer.getScreenWidth();
-  prefetchJob.screenH = renderer.getScreenHeight();
+  // Base dims captured once at onEnter -- no renderer read here, so posting can never race a
+  // render task's transient orientation change (see the header note on baseScreenW/baseScreenH).
+  prefetchJob.screenW = baseScreenW;
+  prefetchJob.screenH = baseScreenH;
   prefetchResult = PrefetchResult{};
   prefetchBusy = true;
   xTaskNotifyGive(prefetchTaskHandle);
@@ -1085,9 +1087,9 @@ void MangaReaderActivity::workerWarmPanel() {
     // skip an already-done probe would need RenderLock, which this task must never take -- so we
     // probe unconditionally: at worst one redundant header parse per panel per page, off-hot-path.)
     const ImageToFramebufferDecoder* warmDecoder = ImageDecoderFactory::getDecoder(prefetchJob.imgPath);
-    // Null decoder = transient OOM (nothrow getDecoder), not a bad crop -- leave the slot
-    // unprobed so a later entry retries. Only a non-null decoder whose header parse fails is a
-    // genuinely bad crop worth caching as -1.
+    // Defensive: getDecoder returns null only for an unsupported extension (decoder instances
+    // are static, no allocation involved) -- leave the slot unprobed. Only a non-null decoder
+    // whose header parse fails is a genuinely bad crop worth caching as -1.
     if (warmDecoder) {
       ImageDimensions warmDims = {0, 0};
       const bool warmOk =
@@ -1108,8 +1110,8 @@ void MangaReaderActivity::workerWarmPanel() {
   }
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(prefetchJob.imgPath);  // non-const: decodes
   if (!decoder) {
-    // Transient (nothrow getDecoder returns null on OOM), not a missing/bad crop -- finish this
-    // job without poisoning the slot; the panel-entry render re-probes and retries.
+    // Defensive: getDecoder returns null only for an unsupported extension. Finish the job
+    // without poisoning the dims slot; the panel-entry render re-probes if ever hit.
     prefetchResult.completed = true;
     return;
   }

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstring>
 #include <ctime>
+#include <utility>
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
@@ -65,11 +66,36 @@ void MangaReaderActivity::onEnter() {
 
   readingSessionStartMs = millis();
 
+  // Background prefetch worker (see the header doc block). Same priority as the loop and render
+  // tasks so it timeslices instead of starving either; stack mirrors the render task, which runs
+  // these same decode paths. Creation failure (OOM) just disables prefetching -- postPrefetchJob
+  // no-ops on a null handle and every render path decodes on demand exactly as before.
+  if (xTaskCreate(&prefetchTaskTrampoline, "MangaPrefetch", PREFETCH_TASK_STACK, this, 1, &prefetchTaskHandle) !=
+      pdPASS) {
+    prefetchTaskHandle = nullptr;
+    LOG_ERR("MRA", "Failed to create prefetch worker; prefetch disabled");
+  }
+
   loadCurrentPagePanels();
   requestUpdate();
 }
 
 void MangaReaderActivity::onExit() {
+  // Join the prefetch worker FIRST, before any teardown below: it may be mid-decode against book
+  // paths and activity members. The exit flag makes the decode's cancel probe abort within one
+  // MCU block/scanline (partial tmp dropped by the converter), so this spin is short -- worst
+  // case one in-flight SD transaction plus cleanup. Deadlock-free even though ActivityManager's
+  // pop path calls onExit() while holding RenderLock: the worker never takes that lock (see the
+  // header doc block).
+  if (prefetchTaskHandle) {
+    prefetchExitRequested = true;
+    xTaskNotifyGive(prefetchTaskHandle);  // wake it if idle-blocked on the notification
+    while (!prefetchTaskExited) {
+      vTaskDelay(1);
+    }
+    prefetchTaskHandle = nullptr;
+  }
+
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop() (see ReaderUtils::flushReadingStats).
   ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true);
@@ -143,6 +169,11 @@ void MangaReaderActivity::loadCurrentPagePanels() {
   const bool armFirst = panelPrefetchArmed && hasCrops;
   {
     RenderLock lock;  // callers are all loop/onEnter/result-handler context -- never already held
+    // Invalidate any in-flight prefetch-worker job: its results were computed against the OLD
+    // page's panels/panelDims and must be dropped by applyPrefetchResult's generation check.
+    // Bumped inside the same locked section as the panelDims swap so a job can never observe
+    // the new vector with the old generation.
+    pageGeneration++;
     panels = std::move(loadedPanels);
     panelsLoaded = loaded;
     pageHasPanelCrops = hasCrops;
@@ -241,6 +272,17 @@ constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
 // after a brief pause is what makes that transition feel instant.
 constexpr unsigned long PREFETCH_DWELL_MS = 400;
 constexpr unsigned long FIRST_PANEL_PREFETCH_DWELL_MS = 150;
+
+// Heap floor before a background decode starts. The old in-loop prefetch also needed a ~48KB
+// framebuffer snapshot; the cache-only worker doesn't (it never touches the framebuffer), but
+// the decoder (~20KB JPEG / ~44KB PNG) plus the streaming cache band (<=24KB) still want real
+// headroom -- and a foreground render may now allocate concurrently. Keep the old conservative
+// floor rather than shaving it.
+constexpr uint32_t PREFETCH_HEAP_FLOOR = 60000;
+
+// Prefetch worker stack, in bytes. Mirrors the render task (ActivityManager::begin), which runs
+// these same JPEG/PNG decode paths -- the one stack size proven for them on hardware.
+constexpr uint32_t PREFETCH_TASK_STACK = 8192;
 }  // namespace
 
 void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption) {
@@ -257,6 +299,11 @@ void MangaReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
   ReaderUtils::flushReadingStats(readingSessionStartMs);
+
+  // Publish any finished prefetch-worker result (panelDims slot + done flags) under the loop
+  // task's normal locking rules. Runs before everything else so a completed warm is visible to
+  // this very tick's input handling, and so the single job slot frees up for the next post.
+  applyPrefetchResult();
 
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
     showBookmarkMessage = false;
@@ -427,26 +474,26 @@ void MangaReaderActivity::render(RenderLock&&) {
   }
 }
 
-MangaReaderActivity::FullPageGeom MangaReaderActivity::applyFullPageGeometry(const int imgWidth, const int imgHeight) {
+MangaReaderActivity::FullPageGeom MangaReaderActivity::computeFullPageGeom(const int imgWidth, const int imgHeight,
+                                                                           int screenW, int screenH) {
   FullPageGeom g;
-  g.savedOrientation = renderer.getOrientation();
-  g.screenW = renderer.getScreenWidth();
-  g.screenH = renderer.getScreenHeight();
 
   // Rotate when the page's aspect doesn't match the screen's -- same
   // fill-the-screen behavior as panel-zoom (renderPanelZoom): this lets a
   // portrait manga page fill a landscape-oriented screen edge-to-edge
   // instead of shrinking to a small centered box. The user tilts the
-  // device to read a rotated page.
-  const bool screenIsPortrait = g.screenH > g.screenW;
+  // device to read a rotated page. Pure math (no renderer access, so the
+  // lock-free prefetch worker can call it): a 90-degree orientation change
+  // is exactly a screen-dim swap, which is what the applying wrapper's
+  // setOrientation((o+3)%4) produces via getScreenWidth/Height.
+  const bool screenIsPortrait = screenH > screenW;
   const bool pageIsLandscape = imgWidth > imgHeight;
   g.rotated = screenIsPortrait == pageIsLandscape;
   if (g.rotated) {
-    const auto rotatedOrientation = static_cast<GfxRenderer::Orientation>((g.savedOrientation + 3) % 4);
-    renderer.setOrientation(rotatedOrientation);
-    g.screenW = renderer.getScreenWidth();
-    g.screenH = renderer.getScreenHeight();
+    std::swap(screenW, screenH);
   }
+  g.screenW = screenW;
+  g.screenH = screenH;
 
   g.destWidth = imgWidth;
   g.destHeight = imgHeight;
@@ -465,6 +512,16 @@ MangaReaderActivity::FullPageGeom MangaReaderActivity::applyFullPageGeometry(con
   } else {
     g.x = (g.screenW - imgWidth) / 2;
     g.y = (g.screenH - imgHeight) / 2;
+  }
+  return g;
+}
+
+MangaReaderActivity::FullPageGeom MangaReaderActivity::applyFullPageGeometry(const int imgWidth, const int imgHeight) {
+  const int savedOrientation = renderer.getOrientation();
+  FullPageGeom g = computeFullPageGeom(imgWidth, imgHeight, renderer.getScreenWidth(), renderer.getScreenHeight());
+  g.savedOrientation = savedOrientation;
+  if (g.rotated) {
+    renderer.setOrientation(static_cast<GfxRenderer::Orientation>((savedOrientation + 3) % 4));
   }
   return g;
 }
@@ -607,59 +664,21 @@ void MangaReaderActivity::prefetchNextPageCache() {
     return;
   }
   // BMP pages don't stream a .2bp cache (the BMP converter renders straight to the framebuffer),
-  // so there's nothing to warm -- and probing Storage.exists() below would never become true,
-  // re-running this every idle tick. BMP is uncompressed, so the page-turn decode is cheap
-  // anyway. Skip prefetch for a BMP next page.
-  if (FsHelpers::hasBmpExtension(book->getPageImagePath(upcomingPage))) {
-    nextPagePrefetched = true;
-    return;
-  }
-  const std::string cachePath = book->getCachePath() + "/page_" + std::to_string(upcomingPage) + ".2bp";
-  if (Storage.exists(cachePath.c_str())) {
-    nextPagePrefetched = true;
-    return;
-  }
-  // The decode needs working buffers plus the 48KB framebuffer snapshot below; under pressure,
-  // skip permanently for this page (the page-turn decode handles it as before).
-  if (ESP.getMaxAllocHeap() < 60000) {
-    nextPagePrefetched = true;
-    return;
-  }
-  // The renderer belongs to the render task; only touch it under the rendering mutex, and don't
-  // stall a queued render -- retry on a later idle tick instead.
-  if (RenderLock::peek()) return;
-
+  // so there's nothing to warm. BMP is uncompressed, so the page-turn decode is cheap anyway.
   const std::string imgPath = book->getPageImagePath(upcomingPage);
-  ImageToFramebufferDecoder* decoder = imgPath.empty() ? nullptr : ImageDecoderFactory::getDecoder(imgPath);
-  ImageDimensions dims = {0, 0};
-  if (!decoder || !decoder->getDimensions(imgPath, dims) || dims.width <= 0 || dims.height <= 0) {
+  if (imgPath.empty() || FsHelpers::hasBmpExtension(imgPath)) {
     nextPagePrefetched = true;
     return;
   }
-
-  RenderLock lock;
-  // The decode scribbles the framebuffer (RAM only -- nothing is displayed here); snapshot and
-  // restore it so the on-screen frame survives for later partial redraws and overlays.
-  if (!renderer.storeBwBuffer()) {
-    nextPagePrefetched = true;
-    return;
-  }
-  LOG_DBG("MRA", "Prefetching pixel cache for page %u", static_cast<unsigned>(upcomingPage));
-  const FullPageGeom g = applyFullPageGeometry(dims.width, dims.height);
-  RenderConfig config;
-  config.x = g.x;
-  config.y = g.y;
-  config.maxWidth = g.screenW;
-  config.maxHeight = g.screenH;
-  config.useGrayscale = true;
-  config.useDithering = true;
-  config.cachePath = cachePath;
-  decoder->decodeToFramebuffer(imgPath, renderer, config);
-  if (g.rotated) {
-    renderer.setOrientation(static_cast<GfxRenderer::Orientation>(g.savedOrientation));
-  }
-  renderer.restoreBwBuffer();
-  nextPagePrefetched = true;
+  // Everything that touches the SD or decodes runs on the prefetch worker -- this used to decode
+  // synchronously right here on the input-polling task, which starved gpio.update() and dropped
+  // button presses for the whole ~1s decode (see the worker doc block in the header).
+  PrefetchJob job;
+  job.isPanel = false;
+  job.gen = pageGeneration;
+  job.imgPath = imgPath;
+  job.cachePath = book->getCachePath() + "/page_" + std::to_string(upcomingPage) + ".2bp";
+  postPrefetchJob(std::move(job));  // screen dims for the geometry math are captured in the post
 }
 
 void MangaReaderActivity::renderPanelZoom() {
@@ -840,24 +859,20 @@ void MangaReaderActivity::renderPanelZoom() {
   }
 }
 
-MangaReaderActivity::PanelGeom MangaReaderActivity::applyPanelGeometry(const int imgWidth, const int imgHeight) {
+MangaReaderActivity::PanelGeom MangaReaderActivity::computePanelGeom(const int imgWidth, const int imgHeight,
+                                                                     int screenW, int screenH) {
   PanelGeom g;
-  g.savedOrientation = renderer.getOrientation();
-  int screenW = renderer.getScreenWidth();
-  int screenH = renderer.getScreenHeight();
 
   // Rotate when the panel's aspect doesn't match the screen's, same as EPUB
   // full-page images: this lets a wide (landscape) panel fill a portrait
   // screen edge-to-edge instead of shrinking to fit within its width, and
-  // vice versa. The user tilts the device to view a rotated panel.
+  // vice versa. The user tilts the device to view a rotated panel. Pure math
+  // (no renderer access) -- see computeFullPageGeom for the swap rationale.
   const bool screenIsPortrait = screenH > screenW;
   const bool panelIsLandscape = imgWidth > imgHeight;
   g.rotated = screenIsPortrait == panelIsLandscape;
   if (g.rotated) {
-    const auto rotatedOrientation = static_cast<GfxRenderer::Orientation>((g.savedOrientation + 3) % 4);
-    renderer.setOrientation(rotatedOrientation);
-    screenW = renderer.getScreenWidth();
-    screenH = renderer.getScreenHeight();
+    std::swap(screenW, screenH);
   }
 
   // Fit panel image to screen preserving aspect ratio. Unlike inline EPUB
@@ -874,10 +889,19 @@ MangaReaderActivity::PanelGeom MangaReaderActivity::applyPanelGeometry(const int
   return g;
 }
 
-// Idle-time twin of renderPanelZoom's decode: writes the panel's .2bp pixel cache (and its
-// dimension slot) so entering the panel costs a cache read instead of a JPEG decode. Same
-// guard discipline as prefetchNextPageCache: heap floor, RenderLock::peek retry, framebuffer
-// snapshot around the decode scribble.
+MangaReaderActivity::PanelGeom MangaReaderActivity::applyPanelGeometry(const int imgWidth, const int imgHeight) {
+  const int savedOrientation = renderer.getOrientation();
+  PanelGeom g = computePanelGeom(imgWidth, imgHeight, renderer.getScreenWidth(), renderer.getScreenHeight());
+  g.savedOrientation = savedOrientation;
+  if (g.rotated) {
+    renderer.setOrientation(static_cast<GfxRenderer::Orientation>((savedOrientation + 3) % 4));
+  }
+  return g;
+}
+
+// Idle-time twin of renderPanelZoom's decode: warms the panel's .2bp pixel cache (and its
+// dimension slot) so entering the panel costs a cache read instead of a JPEG decode. This is
+// only the loop-side gate; the SD probes and the decode itself run on the prefetch worker.
 void MangaReaderActivity::prefetchPanelCache(const int panelIdx) {
   std::atomic<bool>& doneFlag = (viewMode == ViewMode::FullPage) ? firstPanelPrefetched : nextPanelPrefetched;
   if (!book || panelIdx < 0 || panelIdx >= static_cast<int>(panels.size())) {
@@ -891,87 +915,198 @@ void MangaReaderActivity::prefetchPanelCache(const int panelIdx) {
     doneFlag = true;
     return;
   }
-  // Don't contend on the SD mutex with an in-flight render decode: bail before ANY SD work (the
-  // cache-exists probe and header parse below both hit storage) if the render task is active, and
-  // retry on a later idle tick. Mirrors the peek guard before the framebuffer decode further down.
-  if (RenderLock::peek()) return;
-  const std::string cachePath =
-      book->getCachePath() + "/p" + std::to_string(currentPage) + "_" + std::to_string(panelIdx) + ".2bp";
-  if (Storage.exists(cachePath.c_str())) {
-    // Pixel cache already warm (commonly a .2bp persisted from a prior session), but this
-    // session's panelDims slot may still be unprobed -- so the eventual panel entry would parse
-    // the crop header on the render hot path even though the pixels are cached. Probe the header
-    // once here (idle) and publish the slot, so entry is a pure cache read.
-    // Snapshot the slot under the lock (render() writes panelDims on its own task -- see header),
-    // then do the SD probe outside the lock.
-    bool needProbe;
-    {
-      RenderLock lock;
-      needProbe = (panelDims[panelIdx].w == 0);
+  PrefetchJob job;
+  job.isPanel = true;
+  job.isFirstPanel = (viewMode == ViewMode::FullPage);
+  job.panelIdx = panelIdx;
+  job.gen = pageGeneration;
+  // Paths are built HERE, on the loop task that owns currentPage/panelCropIsBmp -- the worker
+  // must never call panelCropPath() itself, since a page turn mid-job would make it read
+  // half-updated state. A stale captured path at worst writes a correct cache for the old page.
+  job.imgPath = panelCropPath(panelIdx);
+  job.cachePath = book->getCachePath() + "/p" + std::to_string(currentPage) + "_" + std::to_string(panelIdx) + ".2bp";
+  postPrefetchJob(std::move(job));
+}
+
+// ---- Background prefetch worker (see the doc block in the header for the design invariants) ----
+
+void MangaReaderActivity::prefetchTaskTrampoline(void* param) {
+  static_cast<MangaReaderActivity*>(param)->prefetchTaskLoop();
+}
+
+void MangaReaderActivity::prefetchTaskLoop() {
+  while (true) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    if (prefetchExitRequested) break;
+    if (!prefetchBusy) continue;  // spurious/coalesced notification with no job posted
+    if (prefetchJob.isPanel) {
+      workerWarmPanel();
+    } else {
+      workerWarmNextPage();
     }
-    if (needProbe) {
-      const std::string warmCropPath = panelCropPath(panelIdx);
-      const ImageToFramebufferDecoder* warmDecoder = ImageDecoderFactory::getDecoder(warmCropPath);
-      // Null decoder = transient OOM (nothrow getDecoder), not a bad crop -- leave the slot
-      // unprobed so a later entry retries. Only a non-null decoder whose header parse fails is a
-      // genuinely bad crop worth caching as -1.
-      if (warmDecoder) {
-        ImageDimensions warmDims = {0, 0};
-        const bool warmOk =
-            warmDecoder->getDimensions(warmCropPath, warmDims) && warmDims.width > 0 && warmDims.height > 0;
-        RenderLock lock;
-        panelDims[panelIdx] = warmOk ? PanelCropDims{warmDims.width, warmDims.height} : PanelCropDims{-1, -1};
-      }
-    }
-    doneFlag = true;
-    return;
+    // Release the job slot LAST: the loop task treats busy==false as "job+result are mine".
+    prefetchBusy = false;
   }
-  const std::string cropPath = panelCropPath(panelIdx);
-  if (!Storage.exists(cropPath.c_str())) {
-    // Confirmed missing crop file (full-page panel like a cover/splash): cache -1 (under the lock
-    // -- render() reads panelDims on its own task) so a later render entry falls back without
-    // re-probing the SD.
+  // Self-terminate. The exited flag is the join signal for onExit(); nothing on this task may
+  // touch the activity after setting it.
+  prefetchTaskExited = true;
+  vTaskDelete(nullptr);
+}
+
+bool MangaReaderActivity::prefetchShouldCancel(void* selfPtr) {
+  auto* self = static_cast<MangaReaderActivity*>(selfPtr);
+  // Exit: the activity is tearing down. peek: a real render holds (or has just taken) the
+  // rendering mutex -- the foreground work the background warm must never compete with.
+  return self->prefetchExitRequested || RenderLock::peek();
+}
+
+void MangaReaderActivity::postPrefetchJob(PrefetchJob&& job) {
+  // Single-slot queue: refuse while the worker owns the slot (busy) or a finished result hasn't
+  // been applied yet (pending) -- overwriting either would break the ownership ping-pong. The
+  // caller's done-flag stays false, so the dwell logic simply retries on a later idle tick.
+  // No worker (task creation failed at onEnter): prefetching is disabled; mark nothing.
+  if (!prefetchTaskHandle || prefetchBusy || prefetchResult.pending) return;
+  prefetchJob = std::move(job);
+  // Screen dims for the pure geometry math, captured once here. A render running concurrently
+  // inside its locked section may have the orientation transiently rotated, which could yield
+  // swapped dims -- benign: the resulting cache fails renderFromCache's dimension check and the
+  // entry falls back to a normal decode (self-healing miss, never a corrupt render).
+  prefetchJob.screenW = renderer.getScreenWidth();
+  prefetchJob.screenH = renderer.getScreenHeight();
+  prefetchResult = PrefetchResult{};
+  prefetchBusy = true;
+  xTaskNotifyGive(prefetchTaskHandle);
+}
+
+void MangaReaderActivity::applyPrefetchResult() {
+  // Loop task only. Worker results are applied here -- never by the worker itself -- so every
+  // panelDims write keeps the established "loop task writes under RenderLock" discipline, and
+  // the worker can stay lock-free (see the header: onExit() joins it while HOLDING RenderLock).
+  if (prefetchBusy || !prefetchResult.pending) return;
+  const bool genOk = (prefetchJob.gen == pageGeneration);
+  if (prefetchResult.dimsValid && genOk) {
     RenderLock lock;
-    panelDims[panelIdx] = {-1, -1};
-    doneFlag = true;
-    return;
+    if (prefetchJob.panelIdx >= 0 && prefetchJob.panelIdx < static_cast<int>(panelDims.size())) {
+      panelDims[prefetchJob.panelIdx] = prefetchResult.dims;
+    }
   }
-  ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(cropPath);  // non-const: decodes below
-  if (!decoder) {
-    // Transient (nothrow getDecoder returns null on OOM), not a missing/bad crop -- skip this
-    // prefetch without poisoning the slot; the panel-entry render re-probes and retries.
+  if (prefetchResult.completed && genOk) {
+    std::atomic<bool>& doneFlag = prefetchJob.isPanel
+                                      ? (prefetchJob.isFirstPanel ? firstPanelPrefetched : nextPanelPrefetched)
+                                      : nextPagePrefetched;
     doneFlag = true;
-    return;
   }
-  // The decode needs working buffers plus the 48KB framebuffer snapshot below; under pressure,
-  // skip permanently for this slot (the panel-entry decode handles it as before).
-  if (ESP.getMaxAllocHeap() < 60000) {
-    doneFlag = true;
-    return;
-  }
-  // The renderer belongs to the render task; only touch it under the rendering mutex, and don't
-  // stall a queued render -- retry on a later idle tick instead.
-  if (RenderLock::peek()) return;
+  // A stale-generation or deferred (cancelled) job marks nothing: the flags for the current page
+  // are still false, so the dwell logic naturally re-posts a fresh job.
+  prefetchResult.pending = false;
+}
 
-  // Probe the crop's header WITHOUT the lock (SD I/O must not stall the render task), then take
-  // the lock once and publish the dimension slot (missing/corrupt cached as -1, so render never
-  // re-probes) plus do the framebuffer decode under that same lock -- every panelDims write and
-  // every renderer touch is now render-task-safe.
+void MangaReaderActivity::workerWarmNextPage() {
+  prefetchResult.pending = true;  // every exit path below hands a result (possibly a deferral) back
+  // Defer, don't consume, while a render is active or teardown started: completed stays false,
+  // so the loop retries after the next dwell.
+  if (prefetchShouldCancel(this)) return;
+  if (Storage.exists(prefetchJob.cachePath.c_str())) {
+    prefetchResult.completed = true;  // already warm (e.g. persisted from a prior session)
+    return;
+  }
+  if (ESP.getMaxAllocHeap() < PREFETCH_HEAP_FLOOR) {
+    // Under memory pressure skip permanently for this page (the page-turn decode handles it as
+    // before) -- same policy as the old in-loop prefetch.
+    prefetchResult.completed = true;
+    return;
+  }
+  ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(prefetchJob.imgPath);
   ImageDimensions dims = {0, 0};
-  const bool dimsOk = decoder->getDimensions(cropPath, dims) && dims.width > 0 && dims.height > 0;
+  if (!decoder || !decoder->getDimensions(prefetchJob.imgPath, dims) || dims.width <= 0 || dims.height <= 0) {
+    prefetchResult.completed = true;  // undecodable page: give up like the old code did
+    return;
+  }
+  LOG_DBG("MRA", "Prefetch worker: warming page cache %s", prefetchJob.cachePath.c_str());
+  const FullPageGeom g = computeFullPageGeom(dims.width, dims.height, prefetchJob.screenW, prefetchJob.screenH);
+  RenderConfig config;
+  config.x = g.x;
+  config.y = g.y;
+  config.maxWidth = g.screenW;
+  config.maxHeight = g.screenH;
+  config.useGrayscale = true;
+  config.useDithering = true;
+  config.cacheOnly = true;
+  config.shouldCancel = &prefetchShouldCancel;
+  config.cancelCtx = this;
+  // Decode into a private tmp and publish by rename -- see the header doc block for why writing
+  // the real path directly could collide with a foreground render caching the same asset.
+  const std::string tmpPath = prefetchJob.cachePath + ".tmp";
+  config.cachePath = tmpPath;
+  if (decoder->decodeToFramebuffer(prefetchJob.imgPath, renderer, config)) {
+    // SdFat rename fails (O_CREAT|O_EXCL) if the destination exists -- exactly what we want when
+    // a foreground render published the real cache first. Losing the race just drops our tmp.
+    if (!Storage.rename(tmpPath.c_str(), prefetchJob.cachePath.c_str())) {
+      Storage.remove(tmpPath.c_str());
+    }
+    prefetchResult.completed = true;
+  } else if (!prefetchShouldCancel(this)) {
+    // Genuine decode failure (not a cancellation): give up for this page, old-code policy.
+    // The converter already dropped its partial tmp.
+    prefetchResult.completed = true;
+  }
+  // Cancelled: completed stays false -> the loop re-posts after the next dwell.
+}
 
-  RenderLock lock;
-  panelDims[panelIdx] = dimsOk ? PanelCropDims{dims.width, dims.height} : PanelCropDims{-1, -1};
+void MangaReaderActivity::workerWarmPanel() {
+  prefetchResult.pending = true;  // every exit path below hands a result (possibly a deferral) back
+  if (prefetchShouldCancel(this)) return;
+
+  if (Storage.exists(prefetchJob.cachePath.c_str())) {
+    // Pixel cache already warm (commonly persisted from a prior session), but the panelDims slot
+    // may still be unprobed -- so the eventual panel entry would parse the crop header on the
+    // render hot path even though the pixels are cached. Probe the header once here and hand the
+    // dims back for the loop task to publish, so entry is a pure cache read. (Reading the slot to
+    // skip an already-done probe would need RenderLock, which this task must never take -- so we
+    // probe unconditionally: at worst one redundant header parse per panel per page, off-hot-path.)
+    const ImageToFramebufferDecoder* warmDecoder = ImageDecoderFactory::getDecoder(prefetchJob.imgPath);
+    // Null decoder = transient OOM (nothrow getDecoder), not a bad crop -- leave the slot
+    // unprobed so a later entry retries. Only a non-null decoder whose header parse fails is a
+    // genuinely bad crop worth caching as -1.
+    if (warmDecoder) {
+      ImageDimensions warmDims = {0, 0};
+      const bool warmOk =
+          warmDecoder->getDimensions(prefetchJob.imgPath, warmDims) && warmDims.width > 0 && warmDims.height > 0;
+      prefetchResult.dims = warmOk ? PanelCropDims{warmDims.width, warmDims.height} : PanelCropDims{-1, -1};
+      prefetchResult.dimsValid = true;
+    }
+    prefetchResult.completed = true;
+    return;
+  }
+  if (!Storage.exists(prefetchJob.imgPath.c_str())) {
+    // Confirmed missing crop file (full-page panel like a cover/splash): cache -1 so a later
+    // render entry falls back without re-probing the SD.
+    prefetchResult.dims = {-1, -1};
+    prefetchResult.dimsValid = true;
+    prefetchResult.completed = true;
+    return;
+  }
+  ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(prefetchJob.imgPath);  // non-const: decodes
+  if (!decoder) {
+    // Transient (nothrow getDecoder returns null on OOM), not a missing/bad crop -- finish this
+    // job without poisoning the slot; the panel-entry render re-probes and retries.
+    prefetchResult.completed = true;
+    return;
+  }
+  if (ESP.getMaxAllocHeap() < PREFETCH_HEAP_FLOOR) {
+    prefetchResult.completed = true;  // memory pressure: skip for this slot, old-code policy
+    return;
+  }
+  ImageDimensions dims = {0, 0};
+  const bool dimsOk = decoder->getDimensions(prefetchJob.imgPath, dims) && dims.width > 0 && dims.height > 0;
+  prefetchResult.dims = dimsOk ? PanelCropDims{dims.width, dims.height} : PanelCropDims{-1, -1};
+  prefetchResult.dimsValid = true;
   if (!dimsOk) {
-    doneFlag = true;
+    prefetchResult.completed = true;
     return;
   }
-  if (!renderer.storeBwBuffer()) {
-    doneFlag = true;
-    return;
-  }
-  LOG_DBG("MRA", "Prefetching panel cache p%u_%d", static_cast<unsigned>(currentPage), panelIdx);
-  const PanelGeom g = applyPanelGeometry(dims.width, dims.height);
+  LOG_DBG("MRA", "Prefetch worker: warming panel cache %s", prefetchJob.cachePath.c_str());
+  const PanelGeom g = computePanelGeom(dims.width, dims.height, prefetchJob.screenW, prefetchJob.screenH);
   RenderConfig config;
   config.x = g.x;
   config.y = g.y;
@@ -980,13 +1115,20 @@ void MangaReaderActivity::prefetchPanelCache(const int panelIdx) {
   config.useExactDimensions = true;
   config.useGrayscale = true;
   config.useDithering = true;
-  config.cachePath = cachePath;
-  decoder->decodeToFramebuffer(cropPath, renderer, config);
-  if (g.rotated) {
-    renderer.setOrientation(static_cast<GfxRenderer::Orientation>(g.savedOrientation));
+  config.cacheOnly = true;
+  config.shouldCancel = &prefetchShouldCancel;
+  config.cancelCtx = this;
+  const std::string tmpPath = prefetchJob.cachePath + ".tmp";
+  config.cachePath = tmpPath;
+  if (decoder->decodeToFramebuffer(prefetchJob.imgPath, renderer, config)) {
+    if (!Storage.rename(tmpPath.c_str(), prefetchJob.cachePath.c_str())) {
+      Storage.remove(tmpPath.c_str());
+    }
+    prefetchResult.completed = true;
+  } else if (!prefetchShouldCancel(this)) {
+    prefetchResult.completed = true;  // genuine failure: give up for this slot, old-code policy
   }
-  renderer.restoreBwBuffer();
-  doneFlag = true;
+  // Cancelled: completed stays false (dims, if probed, still get published) -> retried later.
 }
 
 void MangaReaderActivity::renderTextOverlay() {

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -954,7 +954,7 @@ void MangaReaderActivity::prefetchTaskLoop() {
 }
 
 bool MangaReaderActivity::prefetchShouldCancel(void* selfPtr) {
-  auto* self = static_cast<MangaReaderActivity*>(selfPtr);
+  const auto* self = static_cast<const MangaReaderActivity*>(selfPtr);
   // Exit: the activity is tearing down. peek: a real render holds (or has just taken) the
   // rendering mutex -- the foreground work the background warm must never compete with.
   return self->prefetchExitRequested || RenderLock::peek();

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -953,7 +953,7 @@ void MangaReaderActivity::prefetchTaskLoop() {
   vTaskDelete(nullptr);
 }
 
-bool MangaReaderActivity::prefetchShouldCancel(void* selfPtr) {
+bool MangaReaderActivity::prefetchShouldCancel(const void* selfPtr) {
   const auto* self = static_cast<const MangaReaderActivity*>(selfPtr);
   // Exit: the activity is tearing down. peek: a real render holds (or has just taken) the
   // rendering mutex -- the foreground work the background warm must never compete with.

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -991,15 +991,17 @@ void MangaReaderActivity::applyPrefetchResult() {
   // panelDims write keeps the established "loop task writes under RenderLock" discipline, and
   // the worker can stay lock-free (see the header: onExit() joins it while HOLDING RenderLock).
   if (prefetchBusy || !prefetchResult.pending) return;
-  // NEVER block the input task on the rendering mutex: if a render is in flight, taking the lock
-  // below would stall loop() -- and button polling with it -- for the render's whole duration
-  // (observed on-device: a 2.7s loop stall when a cancelled warm's dims were applied during a
-  // 3.3s panel decode). Defer instead; the result stays pending and a later tick applies it.
-  // postPrefetchJob refuses new jobs while a result is pending, so nothing is lost or clobbered.
-  if (prefetchResult.dimsValid && RenderLock::peek()) return;
   const bool genOk = (prefetchJob.gen == pageGeneration);
   if (prefetchResult.dimsValid && genOk) {
-    RenderLock lock;
+    // NEVER block the input task on the rendering mutex: a blocking acquire here stalls loop()
+    // -- and button polling with it -- for a render's whole duration (observed on-device: a
+    // 2.7s loop stall when a cancelled warm's dims were applied during a 3.3s panel decode).
+    // A peek()-then-lock guard still had a TOCTOU window (the render task can take the mutex
+    // between the check and the constructor), so use the non-blocking acquire: either we hold
+    // the lock right now, or the whole application defers to a later tick -- the result stays
+    // pending, and postPrefetchJob refuses new jobs while it is, so nothing is lost.
+    RenderLock lock{RenderLock::Try{}};
+    if (!lock.held()) return;
     if (prefetchJob.panelIdx >= 0 && prefetchJob.panelIdx < static_cast<int>(panelDims.size())) {
       panelDims[prefetchJob.panelIdx] = prefetchResult.dims;
     }

--- a/src/activities/reader/MangaReaderActivity.h
+++ b/src/activities/reader/MangaReaderActivity.h
@@ -206,7 +206,7 @@ class MangaReaderActivity final : public Activity {
 
   static void prefetchTaskTrampoline(void* param);
   void prefetchTaskLoop();
-  static bool prefetchShouldCancel(void* selfPtr);
+  static bool prefetchShouldCancel(const void* selfPtr);
   void postPrefetchJob(PrefetchJob&& job);
   void applyPrefetchResult();  // loop task: publish worker results under the normal lock rules
   void workerWarmNextPage();

--- a/src/activities/reader/MangaReaderActivity.h
+++ b/src/activities/reader/MangaReaderActivity.h
@@ -159,7 +159,8 @@ class MangaReaderActivity final : public Activity {
   //    onExit() while HOLDING RenderLock, and onExit() joins this worker -- a worker blocked on
   //    that same lock would deadlock the join. Consequently the worker also never touches the
   //    renderer: decodes run cacheOnly (see RenderConfig), and geometry comes from the pure
-  //    computeFullPageGeom/computePanelGeom helpers with screen dims captured at post time.
+  //    computeFullPageGeom/computePanelGeom helpers with screen dims captured once at onEnter
+  //    (see baseScreenW/baseScreenH above -- no renderer reads off the render task at all).
   //  * Results are handed BACK to the loop task (applyPrefetchResult), which owns the existing
   //    locked-write discipline for panelDims and the done-flags. The worker never writes them.
   //  * The worker decodes into cachePath + ".tmp" and publishes by rename. A real render may
@@ -183,6 +184,14 @@ class MangaReaderActivity final : public Activity {
   std::atomic<bool> prefetchTaskExited{false};
   std::atomic<bool> prefetchBusy{false};
   std::atomic<uint32_t> pageGeneration{0};
+  // Base (unrotated) logical screen dims for the worker's pure geometry math. Captured ONCE in
+  // onEnter(), right after applyOrientation and before any task can render: the persistent
+  // orientation cannot change while this activity is open (settings live in another activity),
+  // and transient render-time rotations are always restored under RenderLock -- so reading the
+  // renderer per-post would be an unsynchronized read racing those transient writes, for a value
+  // that never actually changes. Plain ints, written once single-threaded, read-only afterwards.
+  int baseScreenW = 0;
+  int baseScreenH = 0;
 
   struct PrefetchJob {
     bool isPanel = false;

--- a/src/activities/reader/MangaReaderActivity.h
+++ b/src/activities/reader/MangaReaderActivity.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <MangaPanel.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 #include <atomic>
 #include <memory>
@@ -80,6 +82,10 @@ class MangaReaderActivity final : public Activity {
   // NOTE: sets the renderer orientation when rotation is needed -- the caller must restore
   // savedOrientation when done.
   FullPageGeom applyFullPageGeometry(int imgWidth, int imgHeight);
+  // Pure fit/rotate math shared by applyFullPageGeometry (render path) and the prefetch worker.
+  // Touches NO renderer state: rotation is just a screen-dim swap here, which matches what
+  // setOrientation((o+3)%4) does to getScreenWidth/Height. savedOrientation is left at 0.
+  static FullPageGeom computeFullPageGeom(int imgWidth, int imgHeight, int screenW, int screenH);
 
   void prefetchNextPageCache();
 
@@ -131,13 +137,80 @@ class MangaReaderActivity final : public Activity {
     int w = 0, h = 0;
   };
   // render() (render task) reads `panels` and `panelDims` under RenderLock. Every writer on the
-  // loop task -- loadCurrentPagePanels() (whole-vector swap) and prefetchPanelCache() (per-slot)
-  // -- must take RenderLock around the write; renderPanelZoom() writes them while already
-  // holding the lock render() handed it. Keep the standalone SD probes (the panel-index load,
-  // exists(), getDimensions()) OUTSIDE the lock so they don't stall the render task; the decode
+  // loop task -- loadCurrentPagePanels() (whole-vector swap) and applyPrefetchResult() (per-slot
+  // publication of worker probes) -- must take RenderLock around the write; renderPanelZoom()
+  // writes them while already holding the lock render() handed it. The prefetch WORKER task never
+  // writes these (or takes the lock) -- it hands results to applyPrefetchResult instead; see the
+  // worker doc block below. Keep standalone SD probes (the panel-index load, exists(),
+  // getDimensions()) OUTSIDE the lock so they don't stall the render task; the render decode
   // itself necessarily runs under the lock because it draws into the renderer's framebuffer, and
   // its file read is part of that -- that is expected, not a violation of the rule above.
   std::vector<PanelCropDims> panelDims;
+
+  // ---- Background prefetch worker ----
+  // The speculative cache warms (next page / panels) used to decode JPEGs synchronously inside
+  // loop() -- on the SAME task that polls the buttons. A ~1s decode meant gpio.update() stopped
+  // being called for that whole window; button edges are events, not queued state, so presses
+  // AND releases landing inside the window simply evaporated ("takes multiple clicks to
+  // register" on JPEG books). The warms now run on this dedicated worker task instead.
+  //
+  // Design rules (each one is a hard invariant, not a preference):
+  //  * The worker is LOCK-FREE: it never takes RenderLock. ActivityManager's pop path calls
+  //    onExit() while HOLDING RenderLock, and onExit() joins this worker -- a worker blocked on
+  //    that same lock would deadlock the join. Consequently the worker also never touches the
+  //    renderer: decodes run cacheOnly (see RenderConfig), and geometry comes from the pure
+  //    computeFullPageGeom/computePanelGeom helpers with screen dims captured at post time.
+  //  * Results are handed BACK to the loop task (applyPrefetchResult), which owns the existing
+  //    locked-write discipline for panelDims and the done-flags. The worker never writes them.
+  //  * The worker decodes into cachePath + ".tmp" and publishes by rename. A real render may
+  //    decode-and-cache the SAME asset concurrently (it streams to the real path); two write
+  //    handles on one FAT file corrupt the volume. SdFat's rename opens the destination
+  //    O_CREAT|O_EXCL (verified, SdFat 2.3.1 FatFile::rename), so publish fails cleanly if the
+  //    render got there first -- the worker then just deletes its tmp.
+  //  * Cancellation: the decode's per-block cancel probe checks prefetchExitRequested and
+  //    RenderLock::peek(). The moment a real render starts (or the activity exits), the decode
+  //    aborts within one MCU block/scanline and its partial tmp is dropped -- so a background
+  //    warm never competes with a foreground render for CPU/SD beyond a few ms.
+  //  * Single-slot job queue with strict ownership ping-pong: loop() writes prefetchJob and
+  //    prefetchResult only while prefetchBusy is false and no result is pending; the worker
+  //    touches them only between the notify that follows busy=true and its own busy=false.
+  //    The strings/struct members therefore need no locking of their own.
+  //  * pageGeneration stamps jobs; loadCurrentPagePanels() bumps it (under RenderLock) on every
+  //    page change, so results of a stale in-flight warm are dropped instead of poisoning the
+  //    new page's panelDims/flags.
+  TaskHandle_t prefetchTaskHandle = nullptr;
+  std::atomic<bool> prefetchExitRequested{false};
+  std::atomic<bool> prefetchTaskExited{false};
+  std::atomic<bool> prefetchBusy{false};
+  std::atomic<uint32_t> pageGeneration{0};
+
+  struct PrefetchJob {
+    bool isPanel = false;
+    bool isFirstPanel = false;  // which done-flag a panel job resolves
+    int panelIdx = -1;
+    uint32_t gen = 0;       // pageGeneration at post time
+    int screenW = 0;        // base (unrotated) screen dims captured at post time --
+    int screenH = 0;        //   inputs to the pure geometry helpers
+    std::string imgPath;    // page image or panel crop
+    std::string cachePath;  // real .2bp target; worker writes cachePath + ".tmp", publishes by rename
+  };
+  PrefetchJob prefetchJob;
+
+  struct PrefetchResult {
+    bool pending = false;    // worker sets before clearing busy; loop clears after applying
+    bool completed = false;  // job reached a terminal state (vs deferred/cancelled -> retry later)
+    bool dimsValid = false;  // panel jobs: publish dims into panelDims[job.panelIdx]
+    PanelCropDims dims{};
+  };
+  PrefetchResult prefetchResult;
+
+  static void prefetchTaskTrampoline(void* param);
+  void prefetchTaskLoop();
+  static bool prefetchShouldCancel(void* selfPtr);
+  void postPrefetchJob(PrefetchJob&& job);
+  void applyPrefetchResult();  // loop task: publish worker results under the normal lock rules
+  void workerWarmNextPage();
+  void workerWarmPanel();
 
   // Geometry of a zoomed panel on the (possibly temporarily rotated) screen. Shared by
   // renderPanelZoom() and prefetchPanelCache() so the prefetch-written pixel cache has exactly
@@ -149,6 +222,8 @@ class MangaReaderActivity final : public Activity {
     int savedOrientation = 0;
   };
   PanelGeom applyPanelGeometry(int imgWidth, int imgHeight);
+  // Pure twin of applyPanelGeometry, same contract as computeFullPageGeom (no renderer access).
+  static PanelGeom computePanelGeom(int imgWidth, int imgHeight, int screenW, int screenH);
 
   std::string panelCropPath(int panelIdx) const;                      // uses panelCropIsBmp for the extension
   std::string panelCropPathExt(int panelIdx, const char* ext) const;  // explicit extension (format detection)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the reported JPEG-manga symptom "page turn goes blank, then it takes multiple clicks to register". Root cause: the speculative cache warms (next page / first panel / next panel) decoded JPEGs **synchronously inside `loop()` — the same task that polls the buttons**. A ~1s decode starved `gpio.update()`; button edges are events, not queued state, so presses and releases landing in that window simply evaporated. (`--mono`/BMP books skip prefetch entirely, which is why they never showed it.)
* **What changes are included?**
  * **Dedicated prefetch worker task** (`MangaPrefetch`, stack + priority mirroring the render task, which already runs these decode paths). `loop()` keeps only the cheap gating and posts jobs; buttons stay live through every warm. Task-creation failure just disables prefetch (render paths decode on demand as before).
  * **Cache-only decodes** (`RenderConfig.cacheOnly`): the JPEG/PNG converters stream ONLY the `.2bp` pixel cache — no framebuffer writes, no renderer reads. The old prefetch's ~48KB `storeBwBuffer` framebuffer snapshot is gone entirely, and the worker needs no `RenderLock` around the decode.
  * **Cooperative cancellation** (`RenderConfig.shouldCancel`, plain function pointer): polled per MCU block/scanline; the worker's probe checks `RenderLock::peek()` + the activity exit flag, so a background warm aborts within one block the moment a real render (or teardown) starts — it never competes with foreground work for CPU/SD beyond a few ms.
  * **Pure geometry helpers** `computeFullPageGeom`/`computePanelGeom` extracted from the `apply*` wrappers (rotation is exactly a screen-dim swap), so the worker computes cache geometry without touching the renderer. Render paths keep the applying wrappers — behavior unchanged.
  * **Torn-cache prevention**: the worker decodes into `cachePath + ".tmp"` and publishes by rename; a foreground render caching the same asset writes the real path. Never two write handles on one FAT file, never a partial cache at the real name.
  * **Stale-job hygiene**: `pageGeneration` (bumped under the same lock as the `panelDims` swap) stamps every job; results of a warm that outlived a page turn are dropped by `applyPrefetchResult()` instead of poisoning the new page's state.

## Additional Context

* **Verified against sources, not assumed:**
  * JPEGDEC (pinned commit, `jpeg.inl DecodeJPEG`): a draw-callback abort exits the MCU loops but **still returns success** (`iErr` stays 0) — so the converters track cancellation in their context and treat an aborted decode as failure; a partial cache is never finalized. PNGdec 1.1.6 surfaces `PNG_QUIT_EARLY`.
  * SdFat 2.3.1 `FatFile::rename` opens the destination `O_CREAT|O_EXCL` — rename **fails cleanly if the destination exists** (and every SD op is serialized by the HalStorage mutex), which is exactly the semantics the tmp-then-rename publish relies on.
* **Why the worker is lock-free (hard invariant):** `ActivityManager`'s pop path calls `onExit()` **while holding RenderLock**, and `onExit()` joins the worker. A worker blocked acquiring that lock would deadlock the join. So the worker never takes RenderLock and never touches the renderer; `panelDims`/done-flag publication is handed back to the loop task (`applyPrefetchResult`), preserving the established locking discipline.
* **Job slot**: single-slot queue with strict ownership ping-pong via the `prefetchBusy` atomic; job paths are built at post time on the loop task that owns `currentPage`/`panelCropIsBmp` (a stale captured path at worst writes a correct cache for the old page, then the generation check drops its flags).
* **Memory**: −48KB transient per warm (no framebuffer snapshot), +8KB worker stack while the manga reader is open, decode heap floor unchanged (60000).
* **Screen-dim capture race (documented, benign)**: dims for the geometry math are captured at post time without the lock; a concurrently-rendering rotation could yield swapped dims, producing a cache that fails `renderFromCache`'s dimension check → normal decode fallback. Self-healing miss, never a corrupt render.
* **Device verification pending** (no host harness): on a JPEG book, mash the page-turn button right after a page renders — presses should register immediately even while a warm is in flight; check panel entry still hits warm caches after a dwell; confirm `--mono` books behave unchanged; watch heap (`ESP.getFreeHeap()`) across several pages for leaks.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z)_