### PR TITLE
fix: vertical rotated-run layout could loop forever inside styled blocks

### DIFF
--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -69,8 +69,16 @@ std::string encodeCp(uint32_t cp) {
   } else if (cp < 0x800) {
     out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
     out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else {
+  } else if (cp < 0x10000) {
     out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+  } else {
+    // Supplementary plane (4-byte). Reachable: rare CJK ideographs like U+23D40 (a Vita
+    // Sexualis gaiji) do occur in Aozora-derived EPUBs; the old 3-byte fallthrough emitted an
+    // invalid sequence for them (high bits truncated into a wrong lead byte).
+    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
     out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
     out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
   }
@@ -1130,27 +1138,39 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         }
 
         if (breakAt == std::string::npos) {
-          // No space-break fits — move to a fresh column.
-          if (row != 0) {
+          // No space-break fits. Retry from a fresh column ONLY when the current position is
+          // deeper than where a fresh column would start; otherwise force-place. The comparison
+          // MUST be against columnStartRow(false), not 0: inside a styled block (start-Xem, e.g.
+          // Aozora/EBPAJ div.mtN margins, defined up to 22em+) fresh columns begin at a non-zero
+          // row, and comparing against 0 made this branch loop forever -- every retry re-seeded
+          // row = startRows != 0, the force-place arm below was unreachable, and the layout
+          // marched through columns/pages without consuming a single byte ("Indexing" never
+          // finished; host-reproduced with a mtN block whose start offset left fewer rows than a
+          // short embedded Latin word needs). After one retry row == columnStartRow(false), so
+          // the force-place arm is guaranteed on the next pass -- termination is structural.
+          if (row > columnStartRow(false)) {
             column++;
             row = 0;
             finalizePageIfNeeded();
             row = columnStartRow(false);
           } else {
-            // Already at top of column and still doesn't fit — force-place
-            // the whole thing to avoid an infinite loop.
+            // At (or above) a fresh column's start row and still doesn't fit — force-place the
+            // whole thing at the CURRENT row to guarantee progress. It may overrun the column
+            // bottom (the renderer clips); an unbreakable over-long run has no better placement.
+            const int topY = row * cellPx;
             VerticalGlyph g;
             g.codepoint = 0;
             g.column = column;
-            g.row = 0;
+            g.row = row;
             g.x = static_cast<uint16_t>(columnLeftX(column) + cellPx - ascender);
-            g.y = static_cast<uint16_t>(runDownNudge);
+            g.y = static_cast<uint16_t>(topY + runDownNudge);
             g.paragraphIndex = pc.paragraphIndex;
             g.byteOffset = pc.byteOffset;
+            g.style = pc.style;
             g.renderKind = VerticalGlyph::RotatedRun;
             g.rotatedRunText = remaining;
             pushGlyph(page.glyphs, g);
-            row = std::min(remRows, rowsPerColumn);
+            row = static_cast<uint16_t>(std::min<int>(row + remRows, rowsPerColumn));
             if (row >= rowsPerColumn) {
               column++;
               row = 0;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the reported "EPUB indexes forever" hang (Aozora-derived vertical book, *Vita Sexualis*). The vertical layout engine's rotated-run (embedded Latin text) placement contains an infinite loop, **reproduced on host with the actual reported chapter** via `dev/vertical_host_test`.
* **Root cause.** When no space-break of a Latin run fits the current column, the fallback retried from a fresh column gated on `row != 0`. But inside a styled block (`start-Xem` — Aozora/EBPAJ CSS defines `div.mtN` margins up to 22em+), `columnStartRow(false)` re-seeds every fresh column at a **non-zero** row, so the force-place escape arm was unreachable: the loop advanced columns and pages forever without consuming a byte, streaming endless empty pages to SD — exactly "Indexing" that never finishes. Ruby-dense chapters make this easy to hit: the ruby lane roughly halves `rowsPerColumn`, so `min(rowsPerColumn−1, startRows)` clamps deep offsets to a 1-row column no word fits. Caught red-handed in gdb: `remaining="Sexual "`, `remRows=3`, `availRows=1`, looping.
* **The fix.** Gate the fresh-column retry on `row > columnStartRow(false)` and force-place at the *current* row otherwise (the old force-place arm also hardcoded row 0/top-nudge and dropped the run's style — both corrected). Termination is structural: after one retry, `row == columnStartRow(false)`, so the force-place arm is guaranteed on the next pass.
* **Also:** `encodeCp` emitted an invalid UTF-8 sequence for supplementary-plane codepoints (≥ 0x10000 fell into the 3-byte branch, truncating the lead byte). Not theoretical — the reported book contains U+23D40 (𣵀) sixteen times.

## Additional Context

* **Host-verified with the reported book's actual chapter** (592 paragraphs, 905 ruby annotations, embedded German/English):
  * Pre-fix: hangs at block offsets ≥ 15em (watchdog + gdb backtrace confirm the loop at the retry site).
  * Post-fix: terminates at **every** offset 0–31em; the synthetic minimal repro also terminates.
  * **Regression: page counts at offsets 0/1/4/8em are byte-identical to pre-fix** (314/339/404/551 pages) — the changed branch only executes in the formerly-hanging case, so existing vertical section caches remain valid (no cache version bump).
* At absurd offsets (≥ 20em) layout degrades to few-rows-per-column pages — garbage-in-degraded-out, but always terminating; the alternative (clamping start offsets) would change legitimate layouts and is out of scope.
* **Known follow-up, not included:** `dev/vertical_host_test`'s stub renderer has drifted from the current `GfxRenderer` API (missing `getGlyphMetrics`/`getRenderAdvanceX`/`ensureSdCardFontReady`, `VerticalTextBlock` needs more), so the bundled `main_test.cpp` no longer builds as-is; I extended a local stub to run this investigation. Worth restoring separately — this harness is what made the bug reproducible and the fix provable.
* **Device verification:** open the reported EPUB — indexing should complete (chapter 1 is ~314 pages at default settings). Also worth checking a page containing 𣵀 renders a placeholder rather than mojibake.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z)_