### PR TITLE
perf: progressive vertical open + Kindle-class page turns

### DIFF
--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -662,6 +662,19 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       return true;
     }
 
+    // Final zero-margin attempt before CONTENT LOSS. At this point the margin no longer
+    // shields anything that outranks the text itself: the allocations it protects (font
+    // advance tables, staging buffers, the next page's reserve) all fail gracefully and
+    // retry later, while a dropped glyph is a character permanently missing from the page.
+    // Device evidence across three instrumented whole-book builds: every observed drop
+    // burst (need 8064 @ 11764 free, 10368 @ 10740 and even 14324, 11736 @ 12788) had the
+    // block itself available and died only on the margin check.
+    if (ESP.getMaxAllocHeap() >= linearBytes) {
+      glyphs.reserve(linearCapacity);
+      glyphs.push_back(g);
+      return true;
+    }
+
     LOG_ERR("VPT", "Low heap (%u bytes, need ~%u); dropping glyph", ESP.getMaxAllocHeap(),
             static_cast<unsigned>(linearBytes));
     everDroppedForHeap_ = true;
@@ -888,8 +901,37 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
   };
 
+  // Whether the current page's glyph vector can take one more PendingChar's worth of glyphs
+  // without an impossible copy-and-grow (old and new buffer must coexist during a vector
+  // reallocation -- on the observed dense-ruby pages that is a 10-12KB block at exactly the
+  // layout's low-heap dip). HEADROOM covers the worst single-character expansion: a sliced
+  // rotated Latin run plus ruby.
+  // Mirrors pushGlyph's LAST growth fallback exactly (+16 elements, zero margin) so the
+  // early break fires only when the very next growth attempt would otherwise start
+  // dropping -- not sooner. A bigger headroom here inflated the page count with premature
+  // breaks (device evidence: breaks at 81-148 glyphs against dips the +16 step survived).
+  auto pageVectorCanTakeMore = [&]() -> bool {
+    constexpr size_t GROWTH_STEP = 16;  // = pushGlyph's LINEAR_GROWTH_STEP
+    if (page.glyphs.size() + GROWTH_STEP <= page.glyphs.capacity()) return true;
+    const size_t growBytes = (page.glyphs.capacity() + GROWTH_STEP) * sizeof(VerticalGlyph);
+    return ESP.getMaxAllocHeap() >= growBytes;
+  };
+
   size_t idx = 0;
   while (idx < stream_.size()) {
+    // Emergency page split: the page's glyph vector is effectively full and the heap has no
+    // block for the grow-copy. Close the page at this character boundary and continue on a
+    // fresh one (whose vector starts small and grows in fragment-sized steps) -- an early
+    // page break the reader barely notices, instead of the silent character loss that
+    // followed once pushGlyph's growth ladder was exhausted mid-page.
+    if (column < columnsPerPage && !page.glyphs.empty() && !pageVectorCanTakeMore()) {
+      LOG_INF("VPT", "Page glyph buffer cannot grow (%u glyphs, maxAlloc=%u); early page break",
+              static_cast<unsigned>(page.glyphs.size()), ESP.getMaxAllocHeap());
+      column = columnsPerPage;
+      finalizePageIfNeeded();
+      row = columnStartRow(false);
+    }
+
     const PendingChar& pc = stream_[idx];
 
     // Force a fresh column at the start of every paragraph after the

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -36,7 +36,9 @@ namespace {
 // before it can hold the broken bytes and must not be reused.
 // v80: not a format change -- invalidates best-effort caches built while the resident write
 // staging buffer deepened the low-heap dips and dropped glyphs (missing characters ON DISK);
-// the emergency-release hook now prevents those drops on rebuild.
+// the transient per-page staging buffer now prevents those drops on rebuild. (The
+// early-first-render / mid-build page-turn work layered on top changes no on-disk format, so
+// it needs no further bump -- a v80 cache built by this firmware is byte-identical.)
 constexpr uint8_t VSECTION_FILE_VERSION = 80;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
@@ -641,6 +643,20 @@ bool readPage(HalFile& file, VerticalPage& page) {
     LOG_ERR("VSC", "Corrupt page record: %u glyphs", glyphCount);
     return false;
   }
+  // reserve() throws-and-ABORTS under -fno-exceptions; verify the block actually exists
+  // first. A corrupt count within the format bound can still demand ~98KB -- observed on
+  // device as an abort inside this exact reserve during a mid-build read-back. The margin
+  // is deliberately small: the page is transient (rendered, then freed), and an over-strict
+  // margin starved mid-build page-turn serves for entire dense stretches.
+  const uint32_t glyphBytes = glyphCount * static_cast<uint32_t>(sizeof(VerticalGlyph));
+  // Gate only when the vector must actually GROW: a caller passing a pre-reserved page (the
+  // build's serve slot) reads with zero allocation and must not be refused. 2K margin, not
+  // more: the render draws from a REFERENCE and the page is freed/reused right after; a 4K
+  // margin permanently starved mid-build page turns against a stable 13.3K hole.
+  if (page.glyphs.capacity() < glyphCount && ESP.getMaxAllocHeap() < glyphBytes + 2 * 1024) {
+    LOG_ERR("VSC", "Page record needs %u bytes, maxAlloc=%u; refusing read", glyphBytes, ESP.getMaxAllocHeap());
+    return false;
+  }
   page.glyphs.reserve(glyphCount);
 
   for (uint32_t gi = 0; gi < glyphCount; gi++) {
@@ -748,6 +764,25 @@ struct LayoutPageSink final : ParagraphSink {
   // more real content preserved with each halving.
   static constexpr size_t BATCH_CHARS = 160;
 
+  // Early-first-render hook, forwarded from VerticalSection::setEarlyRenderHook(). The
+  // initial target page and mid-build page turns share ONE mechanism: pageRequest holds the
+  // newest wanted page (seeded with the initial target at build start), and writeOne serves
+  // it whenever the heap allows.
+  void (*earlyRenderFn)(void*, const VerticalPage&, int) = nullptr;
+  void* earlyRenderCtx = nullptr;
+  std::atomic<int>* pageRequest = nullptr;
+  uint64_t lastRefusedAttemptKey = 0;  // see servePageRequest()
+
+  // Reusable read-back slot for mid-build page turns. Reserved ONCE at build start (the
+  // healthiest heap moment): with the capacity in place, readPage's reserve is a no-op and
+  // the ruby strings are short enough for SSO, so serving a backward turn needs NO
+  // allocation at all -- previously the transient ~10.4KB page vector had to find a hole at
+  // exactly the layout's low-heap moments, and backward turns starved for up to 10s in
+  // dense stretches. If even this reserve fails, the slot stays empty and read-backs fall
+  // back to the gated on-demand allocation.
+  static constexpr size_t kServeSlotGlyphs = 160;  // full page (~147 cells) + margin
+  VerticalPage servePage_;
+
   LayoutPageSink(VerticalParsedText& layout, HalFile& out, std::vector<uint32_t>& pageOffsets, Epub& epub,
                  GfxRenderer& renderer, const std::string& chapterDir, const std::string& imageBasePath,
                  uint16_t viewportWidth, uint16_t viewportHeight)
@@ -760,6 +795,9 @@ struct LayoutPageSink final : ParagraphSink {
         imageBasePath(imageBasePath),
         viewportWidth(viewportWidth),
         viewportHeight(viewportHeight) {
+    if (ESP.getMaxAllocHeap() >= kServeSlotGlyphs * sizeof(VerticalGlyph) + 16 * 1024) {
+      servePage_.glyphs.reserve(kServeSlotGlyphs);
+    }
   }
 
   void onParagraph(std::vector<RubyRun>& runs, const bool continuesPrevious) override {
@@ -877,28 +915,13 @@ struct LayoutPageSink final : ParagraphSink {
   void flushText(bool isFinalFlush = false) {
     if (failed) return;
     if (!isFinalFlush && layout.pendingCount() == 0) return;
-    // TEMP diagnostics: bisect which stage of the flush plants persistent allocations
-    // (maxAlloc collapsed 82K -> 2K over one chapter on a real device; strip with the rest).
-    const uint32_t maBefore = ESP.getMaxAllocHeap();
     // Streaming pages out via callback as they're finalized keeps at most ~2 pages' worth of
     // glyph buffers resident at once instead of the whole batch's -- see PageReadyCallback in
     // VerticalParsedText.h for why this is safe (oikomi only ever looks one page back).
-    const unsigned long layoutStart = millis();  // TEMP diagnostics (first-open perf hunt)
     auto pages = layout.layoutPages(this, &writePageCallback, isFinalFlush);
-    layoutMsAcc += millis() - layoutStart;  // TEMP
-    const uint32_t maLayout = ESP.getMaxAllocHeap();
     layout.reset();
     for (const auto& p : pages) writeOne(p);
-    const uint32_t maAfter = ESP.getMaxAllocHeap();
-    if (maAfter + 2048 < maBefore) {
-      LOG_DBG("VSC", "flushText maxAlloc: %u -> %u (layout) -> %u (reset+write), free=%u", maBefore, maLayout, maAfter,
-              ESP.getFreeHeap());
-    }
   }
-
-  // TEMP diagnostics (first-open perf hunt): accumulated time per build stage.
-  uint32_t layoutMsAcc = 0;
-  uint32_t writeMsAcc = 0;
 
   // Page serialization staging capacity: one file.write per page instead of ~10 mutexed
   // SD writes per GLYPH (measured: ~8.3s of a 23s 431-page build was writes). 12KB covers
@@ -908,13 +931,6 @@ struct LayoutPageSink final : ParagraphSink {
 
   void writeOne(const VerticalPage& p) {
     pageOffsets.push_back(static_cast<uint32_t>(out.position()));
-    // TEMP diagnostics (slow-books hunt): prove the build ADVANCES and how fast.
-    if ((pageOffsets.size() % 20) == 0) {
-      LOG_DBG("VSC", "build progress: %zu pages, layout=%ums write=%ums, free=%u maxAlloc=%u", pageOffsets.size(),
-              layoutMsAcc, writeMsAcc, static_cast<unsigned>(ESP.getFreeHeap()),
-              static_cast<unsigned>(ESP.getMaxAllocHeap()));
-    }
-    const unsigned long writeStart = millis();  // TEMP
     // TRANSIENT staging buffer: allocated for this one write, freed before layout resumes.
     // Holding it resident across the whole build deepened the layout's low-heap dips by
     // roughly its own size (device evidence: maxAlloc bottoms 14324 without it vs
@@ -938,7 +954,63 @@ struct LayoutPageSink final : ParagraphSink {
       LOG_ERR("VSC", "Failed to write page %zu to cache", pageOffsets.size() - 1);
       failed = true;
     }
-    writeMsAcc += millis() - writeStart;  // TEMP
+
+    if (ok) servePageRequest(p, static_cast<int>(pageOffsets.size()) - 1);
+  }
+
+  // Show-the-page-during-the-build engine, shared by the initial early first render (the
+  // request is seeded with the reader's target page at build start) and mid-build page
+  // turns: whenever a page finishes writing, serve the newest request -- directly if it IS
+  // the page just written, else by reading the already-serialized record back from the
+  // cache file. openFileForWrite opens O_RDWR, so the same handle seeks back for the read
+  // and returns to the end so the build appends exactly where it left off. A request beyond
+  // the built range stays pending and is re-checked after every page until the build reaches
+  // it; a request for an image page is dropped (its multi-second decode cannot run
+  // mid-build -- the page appears normally once the build completes).
+  void servePageRequest(const VerticalPage& justWritten, const int lastBuilt) {
+    if (!pageRequest || !earlyRenderFn) return;
+    const int req = pageRequest->load(std::memory_order_relaxed);
+    if (req < 0 || req > lastBuilt) return;
+    // Serving renders a page mid-build, and parts of that path allocate bare -- under
+    // -fno-exceptions an OOM there ABORTS (observed on device: __terminate during a
+    // mid-build page turn). The deep guards are in place (readPage refuses reads its glyph
+    // reserve can't afford; renderVerticalPageBody skips the prewarm when tight), so this
+    // outer gate only needs to cover the render's own working set. With the pre-reserved
+    // serve slot the read-back itself allocates nothing, so 8K (render transients: small
+    // utf8 buffers, glyph decompression) is enough -- higher gates repeatedly starved
+    // backward turns for whole dense stretches. A skipped serve stays pending and retries
+    // after the next page.
+    constexpr uint32_t SERVE_MIN_ALLOC = 8 * 1024;
+    if (ESP.getMaxAllocHeap() < SERVE_MIN_ALLOC) return;
+    if (req == lastBuilt) {
+      pageRequest->store(-1, std::memory_order_relaxed);
+      if (!justWritten.isImagePage()) earlyRenderFn(earlyRenderCtx, justWritten, req);
+      return;
+    }
+    // A refused read-back under an UNCHANGED heap state will be refused again -- don't
+    // repeat the seek+read+log for every subsequent page (observed: one starved backward
+    // turn produced a ~50Hz refusal stream for the rest of the build). Retry only when the
+    // request or the largest free block changed.
+    const uint64_t attemptKey = (static_cast<uint64_t>(req) << 32) | ESP.getMaxAllocHeap();
+    if (attemptKey == lastRefusedAttemptKey) return;
+    const size_t endPos = out.position();
+    // Commit pending writes before reading earlier records through the same handle: without
+    // the flush, a backward seek can hand back stale/garbage bytes for freshly written pages
+    // (observed on device: a read-back returned a corrupt glyph count).
+    out.flush();
+    out.seek(pageOffsets[req]);
+    const bool okRead = readPage(out, servePage_);
+    if (!out.seek(endPos)) {
+      LOG_ERR("VSC", "Failed to seek back to build position after page read-back");
+      failed = true;
+      return;
+    }
+    if (!okRead) {  // heap-refused or corrupt: request stays pending, retried on heap change
+      lastRefusedAttemptKey = attemptKey;
+      return;
+    }
+    pageRequest->store(-1, std::memory_order_relaxed);
+    if (!servePage_.isImagePage()) earlyRenderFn(earlyRenderCtx, servePage_, req);
   }
 
   VerticalPage makeImagePage(const std::string& src) {
@@ -1081,6 +1153,12 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
 
   LayoutPageSink sink(layout, out, pageOffsets_, *epub, renderer, chapterDir, imageBasePath, viewportWidth,
                       viewportHeight);
+  sink.earlyRenderFn = earlyRenderFn_;
+  sink.earlyRenderCtx = earlyRenderCtx_;
+  // Seed the shared page-request slot with the initial early-render target; page turns
+  // recorded while the build runs simply overwrite it (latest wins).
+  buildPageRequest_.store(earlyRenderFn_ ? earlyRenderTargetPage_ : -1, std::memory_order_relaxed);
+  sink.pageRequest = &buildPageRequest_;
 
   // Styled blocks (borders, start offsets, hanging indents, centering, gaps): collect the
   // vertical-relevant selectors. Streams the on-disk CSS cache -- does NOT materialize the

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -998,7 +998,15 @@ struct LayoutPageSink final : ParagraphSink {
     // the flush, a backward seek can hand back stale/garbage bytes for freshly written pages
     // (observed on device: a read-back returned a corrupt glyph count).
     out.flush();
-    out.seek(pageOffsets[req]);
+    // A failed seek to the record would leave the handle at the append position, so readPage
+    // would parse the just-written page's tail as a header -- garbage. Bail the serve (the
+    // request stays pending) rather than render a corrupt page; the write cursor is still at
+    // endPos, so the build continues correctly.
+    if (!out.seek(pageOffsets[req])) {
+      LOG_ERR("VSC", "Failed to seek to page %d for read-back", req);
+      out.seek(endPos);
+      return;
+    }
     const bool okRead = readPage(out, servePage_);
     if (!out.seek(endPos)) {
       LOG_ERR("VSC", "Failed to seek back to build position after page read-back");

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -599,7 +599,14 @@ bool writePage(Sink& file, const VerticalPage& page) {
   return true;
 }
 
-bool readPage(HalFile& file, VerticalPage& page) {
+// A read can fail two ways that callers must treat DIFFERENTLY: HeapRefused is transient (the
+// glyph vector could not be reserved on the current low heap) and the on-disk record is fine,
+// so the caller must NOT invalidate the cache -- retry later. Corrupt means the bytes are bad
+// and a rebuild is warranted. Collapsing both to a bool let a momentary heap dip nuke a valid
+// cache and trigger an expensive rebuild loop.
+enum class ReadResult { Ok, HeapRefused, Corrupt };
+
+ReadResult readPage(HalFile& file, VerticalPage& page) {
   page.glyphs.clear();
   page.boxes.clear();
   page.imagePath.clear();
@@ -611,7 +618,7 @@ bool readPage(HalFile& file, VerticalPage& page) {
     serialization::readPod(file, page.imageWidth);
     serialization::readPod(file, page.imageHeight);
     serialization::readPod(file, page.imageRotated);
-    return !page.imagePath.empty();
+    return page.imagePath.empty() ? ReadResult::Corrupt : ReadResult::Ok;
   }
 
   uint32_t glyphCount;
@@ -623,7 +630,7 @@ bool readPage(HalFile& file, VerticalPage& page) {
   serialization::readPod(file, boxCount);
   if (boxCount > 8) {
     LOG_ERR("VSC", "Corrupt page record: %u boxes", boxCount);
-    return false;
+    return ReadResult::Corrupt;
   }
   page.boxes.reserve(boxCount);
   for (uint8_t bi = 0; bi < boxCount; bi++) {
@@ -641,7 +648,7 @@ bool readPage(HalFile& file, VerticalPage& page) {
   constexpr uint32_t MAX_GLYPHS_PER_PAGE = 4096;
   if (glyphCount > MAX_GLYPHS_PER_PAGE) {
     LOG_ERR("VSC", "Corrupt page record: %u glyphs", glyphCount);
-    return false;
+    return ReadResult::Corrupt;
   }
   // reserve() throws-and-ABORTS under -fno-exceptions; verify the block actually exists
   // first. A corrupt count within the format bound can still demand ~98KB -- observed on
@@ -655,7 +662,7 @@ bool readPage(HalFile& file, VerticalPage& page) {
   // margin permanently starved mid-build page turns against a stable 13.3K hole.
   if (page.glyphs.capacity() < glyphCount && ESP.getMaxAllocHeap() < glyphBytes + 2 * 1024) {
     LOG_ERR("VSC", "Page record needs %u bytes, maxAlloc=%u; refusing read", glyphBytes, ESP.getMaxAllocHeap());
-    return false;
+    return ReadResult::HeapRefused;
   }
   page.glyphs.reserve(glyphCount);
 
@@ -689,7 +696,7 @@ bool readPage(HalFile& file, VerticalPage& page) {
     }
     page.glyphs.push_back(std::move(g));
   }
-  return true;
+  return ReadResult::Ok;
 }
 
 // Streams the temp HTML once looking for "<rt", to decide ruby layout geometry (column gap /
@@ -1007,13 +1014,13 @@ struct LayoutPageSink final : ParagraphSink {
       out.seek(endPos);
       return;
     }
-    const bool okRead = readPage(out, servePage_);
+    const ReadResult okRead = readPage(out, servePage_);
     if (!out.seek(endPos)) {
       LOG_ERR("VSC", "Failed to seek back to build position after page read-back");
       failed = true;
       return;
     }
-    if (!okRead) {  // heap-refused or corrupt: request stays pending, retried on heap change
+    if (okRead != ReadResult::Ok) {  // heap-refused or corrupt: request stays pending, retried on heap change
       lastRefusedAttemptKey = attemptKey;
       return;
     }
@@ -1455,10 +1462,14 @@ const VerticalPage* VerticalSection::getPage(int pageIndex) const {
     file.close();
     return nullptr;
   }
-  const bool ok = readPage(file, loadedPage_);
+  const ReadResult result = readPage(file, loadedPage_);
   file.close();
-  if (!ok) {
-    LOG_ERR("VSC", "Failed to read page %d from cache", pageIndex);
+  // Tell the reader whether a nullptr means "transient low heap, keep the cache" or a genuine
+  // failure worth clearing/rebuilding -- see lastReadHeapRefused().
+  lastReadHeapRefused_ = (result == ReadResult::HeapRefused);
+  if (result != ReadResult::Ok) {
+    LOG_ERR("VSC", "Failed to read page %d from cache (%s)", pageIndex,
+            result == ReadResult::HeapRefused ? "low heap" : "corrupt");
     return nullptr;
   }
   loadedPageIndex_ = pageIndex;

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -48,6 +49,14 @@ class VerticalSection {
   // re-stamping meant a full re-index on every open, forever.
   bool rebuildingFromStale_ = false;
 
+  // See setEarlyRenderHook().
+  void (*earlyRenderFn_)(void*, const VerticalPage&, int) = nullptr;
+  void* earlyRenderCtx_ = nullptr;
+  int earlyRenderTargetPage_ = -1;
+  // See requestPageDuringBuild(). Written by the loop() task, read by the build on the
+  // render task; -1 = no pending request.
+  std::atomic<int> buildPageRequest_{-1};
+
  public:
   uint16_t pageCount = 0;
   int currentPage = 0;
@@ -57,6 +66,26 @@ class VerticalSection {
         spineIndex(spineIndex),
         renderer(renderer),
         filePath(epub->getCachePath() + "/vsections/" + std::to_string(spineIndex) + ".bin") {}
+
+  // Early-first-render hook: when set, createSectionFile() invokes fn(ctx, page, pageIndex)
+  // once, right after the page with index targetPage has been laid out and written to the
+  // cache -- letting the reader show the user's page a couple of seconds into a whole-chapter
+  // build (~17s for a 431-page book) while the remaining pages keep building. Fires for text
+  // pages only: an image page would pay its multi-second decode in the middle of the build.
+  // Silent background builds simply never set the hook. Function pointer + ctx, not
+  // std::function, per the platform binary/heap rules.
+  void setEarlyRenderHook(void* ctx, void (*fn)(void*, const VerticalPage&, int), int targetPage) {
+    earlyRenderCtx_ = ctx;
+    earlyRenderFn_ = fn;
+    earlyRenderTargetPage_ = targetPage;
+  }
+
+  // Mid-build page turns: the reader's loop() task records the page the user wants while a
+  // build is still running on the render task; the build serves it through the early-render
+  // hook as soon as that page exists (immediately via cache read-back if it is already
+  // written, otherwise the moment it is laid out). Latest request wins -- rapid presses
+  // collapse to the final target.
+  void requestPageDuringBuild(int pageIndex) { buildPageRequest_.store(pageIndex, std::memory_order_relaxed); }
 
   bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight);
   bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight);

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -35,6 +35,10 @@ class VerticalSection {
   // fetch-and-render one page at a time, never holding two pages.
   mutable VerticalPage loadedPage_;
   mutable int loadedPageIndex_ = -1;
+  // Set by getPage() when its last read failed because the glyph vector could not be reserved
+  // on a low heap (the on-disk record is fine). Lets the reader retry later instead of clearing
+  // a valid cache. See lastReadHeapRefused().
+  mutable bool lastReadHeapRefused_ = false;
 
   bool streamParseAndLayout(HalFile& out, int fontId, uint16_t viewportWidth, uint16_t viewportHeight);
 
@@ -92,4 +96,7 @@ class VerticalSection {
   bool clearCache() const;
   const VerticalPage* getPage() const;
   const VerticalPage* getPage(int pageIndex) const;
+  // True when the most recent getPage() returned nullptr only because the page's glyph vector
+  // could not be reserved on a low heap -- the cache is valid; retry, do not clear it.
+  bool lastReadHeapRefused() const { return lastReadHeapRefused_; }
 };

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.h
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.h
@@ -18,7 +18,12 @@ class GfxRenderer;
 // out.
 class VerticalTextBlock {
  public:
-  explicit VerticalTextBlock(VerticalPage page) : page_(std::move(page)) {}
+  // Holds a REFERENCE, not a copy: a page is ~10KB of glyphs plus a ruby string per glyph,
+  // and the old by-value constructor silently copied all of it on every single page render
+  // -- observed on device as an OOM abort when a mid-build render hit the copy at a
+  // low-heap moment. Every caller constructs the block on the stack and renders within the
+  // page's lifetime; do not store a VerticalTextBlock beyond its page.
+  explicit VerticalTextBlock(const VerticalPage& page) : page_(page) {}
 
   void render(GfxRenderer& renderer, int fontId, int offsetX = 0, int offsetY = 0, bool black = true) const;
   void render(GfxRenderer& renderer, int fontId, int rubyFontId, int offsetX, int offsetY, bool black = true) const;
@@ -26,5 +31,5 @@ class VerticalTextBlock {
   const VerticalPage& page() const { return page_; }
 
  private:
-  VerticalPage page_;
+  const VerticalPage& page_;
 };

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -53,7 +53,14 @@ class FontCacheManager {
     // scope -- e.g. the idle next-page prewarm, which warms a page the reader will only turn
     // to later. Ordinary single-render scopes do NOT release, so they clear (warm-for-one-
     // render) and keep the cache honest for the next scan.
-    void release() { active_ = false; }
+    //
+    // Finalizes the scan first: calling release() before endScanAndPrewarm() would otherwise
+    // strand the manager in scan mode (drawText would keep recording instead of drawing) and
+    // never prewarm. endScanAndPrewarm() is a no-op when the scan was already ended.
+    void release() {
+      endScanAndPrewarm();
+      active_ = false;
+    }
     PrewarmScope(PrewarmScope&& other) noexcept;
     PrewarmScope& operator=(PrewarmScope&&) = delete;
     PrewarmScope(const PrewarmScope&) = delete;

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -48,6 +48,12 @@ class FontCacheManager {
     explicit PrewarmScope(FontCacheManager& manager);
     ~PrewarmScope();
     void endScanAndPrewarm();
+    // Keep the warmed glyphs resident after this scope ends instead of clearing them on
+    // destruction. Call after endScanAndPrewarm() when the warm is meant to outlive the
+    // scope -- e.g. the idle next-page prewarm, which warms a page the reader will only turn
+    // to later. Ordinary single-render scopes do NOT release, so they clear (warm-for-one-
+    // render) and keep the cache honest for the next scan.
+    void release() { active_ = false; }
     PrewarmScope(PrewarmScope&& other) noexcept;
     PrewarmScope& operator=(PrewarmScope&&) = delete;
     PrewarmScope(const PrewarmScope&) = delete;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1281,6 +1281,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       verticalSection = makeUniqueNoThrow<VerticalSection>(epub, currentSpineIndex, renderer);
       if (!verticalSection) {
         LOG_ERR("ERS", "OOM allocating VerticalSection");
+        // Mark this spine failed so render() stops retrying the same allocation every frame --
+        // the same guard the build-failure path uses to avoid an infinite indexing/error loop.
+        failedVerticalSpineIndex = currentSpineIndex;
         renderer.clearScreen();
         renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
         renderStatusBar();
@@ -1316,13 +1319,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         // estimate otherwise -- the post-build render corrects the rare off-by-a-few case
         // with its one refresh. A target beyond the final page count (e.g. the "last page"
         // sentinel when paging backwards) simply never fires the hook -- classic path again.
+        // Seed earlyDisplayedPage_ with the target page (not -1) BEFORE the build starts, so a
+        // page turn pressed in the first seconds -- before the early-render hook has fired --
+        // still has a valid baseline to offset from and records its request, instead of being
+        // silently dropped. Percent jumps set no hook (they need the final pageCount), so they
+        // keep -1 and mid-build turns stay inert there, matching the classic wait path.
+        int earlyTarget = -1;
         if (!pendingPercentJump) {
-          const int earlyTarget =
-              pendingPageJump.has_value() ? *pendingPageJump : (nextPageNumber > 0 ? nextPageNumber : 0);
+          earlyTarget = pendingPageJump.has_value() ? *pendingPageJump : (nextPageNumber > 0 ? nextPageNumber : 0);
           verticalSection->setEarlyRenderHook(this, &EpubReaderActivity::earlyRenderVerticalPageThunk, earlyTarget);
         }
 
-        earlyDisplayedPage_.store(-1, std::memory_order_relaxed);
+        earlyDisplayedPage_.store(earlyTarget, std::memory_order_relaxed);
         verticalBuildInProgress_.store(true, std::memory_order_relaxed);
         const bool built = verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight);
         verticalBuildInProgress_.store(false, std::memory_order_relaxed);
@@ -1563,6 +1571,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
     if (!section) {
       LOG_ERR("ERS", "OOM allocating Section");
+      // Mark this spine failed so render() stops retrying the same allocation every frame --
+      // the same guard the build-failure path uses to avoid an infinite indexing/error loop.
+      failedSectionSpineIndex = currentSpineIndex;
       renderer.clearScreen();
       renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
       renderStatusBar();
@@ -2278,8 +2289,10 @@ bool EpubReaderActivity::prewarmVerticalPageGlyphs(const VerticalPage& vpage) {
 
 void EpubReaderActivity::renderVerticalPageBody(const VerticalPage& vpage, const bool glyphsAlreadyWarm) {
   if (!glyphsAlreadyWarm) prewarmVerticalPageGlyphs(vpage);
-  // Same origin derivation as render(): vertical text only needs the top-left corner.
-  int marginTop, marginRight, marginBottom, marginLeft;
+  // Same origin derivation as render(): vertical text only needs the top-left corner, but
+  // getOrientedViewableTRBL fills all four edges -- right/bottom are intentionally unused here.
+  int marginTop, marginLeft;
+  [[maybe_unused]] int marginRight, marginBottom;
   renderer.getOrientedViewableTRBL(&marginTop, &marginRight, &marginBottom, &marginLeft);
   marginTop += SETTINGS.screenMargin;
   marginLeft += SETTINGS.screenMargin;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1252,7 +1252,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (maxAlloc < RESUME_HEAP_FLOOR) {
       LOG_INF("ERS", "Low heap before render (maxAlloc=%u < %u); releasing font memory", maxAlloc, RESUME_HEAP_FLOOR);
       fcm->releaseAllFontMemory();
-      prewarmedVPage_ = -1;  // the release just emptied the mini-font cache
+      prewarmedVPage_ = -1;  // the release just emptied the mini-font cache (vertical)
+      prewarmedHPage_ = -1;  // ...and the horizontal warm
       LOG_INF("ERS", "After font release: maxAlloc=%u", ESP.getMaxAllocHeap());
     }
   }
@@ -1544,6 +1545,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
+    prewarmedHPage_ = -1;  // fresh section: any page warmed for the previous one is stale
     section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
 
     if (!section->loadSectionFile(effectiveReaderFontId(), SETTINGS.getReaderLineCompression(),
@@ -1680,9 +1682,33 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     const auto start = millis();
-    renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+    renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft,
+                   /*glyphsAlreadyWarm=*/prewarmedHPage_ == section->currentPage);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
   }
+
+  // Idle next-page prewarm (Kindle-class turns): while the reader looks at this page, scan the
+  // page they'll turn to next (direction-adaptive) and warm its glyphs into the font cache, so
+  // the next turn renders warm (~30ms) instead of paying the scan + SD bulk load at button
+  // time. The scan pass draws nothing (GfxRenderer skips drawing while scanning), so it never
+  // touches the displayed framebuffer. Heap-gated: warming loads an extra page transiently, so
+  // skip it when the largest free block is tight and take the classic cold turn instead.
+  prewarmedHPage_ = -1;
+  constexpr uint32_t IDLE_WARM_MIN_ALLOC = 32 * 1024;
+  if (auto* fcm = renderer.getFontCacheManager(); fcm && ESP.getMaxAllocHeap() >= IDLE_WARM_MIN_ALLOC) {
+    const int warmTarget =
+        lastTurnForward_.load(std::memory_order_relaxed) ? section->currentPage + 1 : section->currentPage - 1;
+    if (warmTarget >= 0 && warmTarget < section->pageCount) {
+      if (auto np = section->loadPageFromSectionFile(warmTarget)) {
+        auto scope = fcm->createPrewarmScope();
+        np->render(renderer, effectiveReaderFontId(), orientedMarginLeft, orientedMarginTop, !useFurigana());
+        scope.endScanAndPrewarm();
+        scope.release();  // keep the warm resident for the upcoming turn
+        prewarmedHPage_ = warmTarget;
+      }
+    }
+  }
+
   silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
   saveProgress(currentSpineIndex, section->currentPage, section->pageCount, verticalOverride, furiganaOverride);
 
@@ -1892,15 +1918,20 @@ bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
 }
 void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int orientedMarginTop,
                                         const int orientedMarginRight, const int orientedMarginBottom,
-                                        const int orientedMarginLeft) {
+                                        const int orientedMarginLeft, const bool glyphsAlreadyWarm) {
   const auto t0 = millis();
   const int fontId = effectiveReaderFontId();
 
-  // Font prewarm: scan pass accumulates text, then prewarm, then real render
+  // Font prewarm: scan pass accumulates text, then prewarm, then real render. Skipped when the
+  // idle next-page warm already loaded this page's glyphs (prewarmedHPage_) -- the cache is
+  // warm, so we go straight to the real render (~30ms) instead of paying the scan + SD bulk
+  // load again at button time.
   auto* fcm = renderer.getFontCacheManager();
-  auto scope = fcm->createPrewarmScope();
-  page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop, !useFurigana());  // scan pass
-  scope.endScanAndPrewarm();
+  if (!glyphsAlreadyWarm) {
+    auto scope = fcm->createPrewarmScope();
+    page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop, !useFurigana());  // scan pass
+    scope.endScanAndPrewarm();
+  }
   const auto tPrewarm = millis();
 
   const bool pageHasImages = page->hasImages();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1809,7 +1809,7 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
   imageWarmStampSnapshot_ = imageWarmInputStamp_.load(std::memory_order_relaxed);
   if (imageWarmShouldCancel(this)) {
     LOG_DBG("IWARM", "skip: render already queued");  // TEMP diagnostics (slow-books hunt)
-    return;  // another render is already queued -- stay out of its way
+    return;                                           // another render is already queued -- stay out of its way
   }
   if (ESP.getMaxAllocHeap() < IMAGE_WARM_MIN_ALLOC) {
     LOG_DBG("IWARM", "skip: maxAlloc %u < %u floor", ESP.getMaxAllocHeap(), IMAGE_WARM_MIN_ALLOC);  // TEMP

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -8,6 +8,7 @@
 #include <Epub/blocks/TextBlock.h>
 #include <Epub/blocks/VerticalTextBlock.h>
 #include <FontCacheManager.h>
+#include <FontDecompressor.h>
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
@@ -1083,6 +1084,23 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   // bump didn't fire -- cancel a running image warm before the chapter-boundary branches below
   // block on the RenderLock it holds.
   imageWarmInputStamp_.fetch_add(1, std::memory_order_relaxed);
+  lastTurnForward_.store(isForwardTurn, std::memory_order_relaxed);
+
+  // A vertical chapter is still building on the render task: pageCount is 0 until the build
+  // ends, so the normal path below would misread every press as "past the last page", block
+  // on the RenderLock for the rest of the build, and then jump to the NEXT SPINE (observed on
+  // device: one press during the build teleported the reader to the end of the book). Route
+  // the turn to the build's page-request hook instead -- the page shows as soon as it exists.
+  if (verticalBuildInProgress_.load(std::memory_order_relaxed)) {
+    const int shown = earlyDisplayedPage_.load(std::memory_order_relaxed);
+    if (shown >= 0 && verticalSection) {
+      const int target = isForwardTurn ? shown + 1 : (shown > 0 ? shown - 1 : 0);
+      verticalSection->requestPageDuringBuild(target);
+    }
+    lastPageTurnTime = millis();
+    return;
+  }
+
   const int curPage = verticalSection ? verticalSection->currentPage : (section ? section->currentPage : 0);
   const int pgCount = verticalSection ? verticalSection->pageCount : (section ? section->pageCount : 0);
 
@@ -1234,6 +1252,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (maxAlloc < RESUME_HEAP_FLOOR) {
       LOG_INF("ERS", "Low heap before render (maxAlloc=%u < %u); releasing font memory", maxAlloc, RESUME_HEAP_FLOOR);
       fcm->releaseAllFontMemory();
+      prewarmedVPage_ = -1;  // the release just emptied the mini-font cache
       LOG_INF("ERS", "After font release: maxAlloc=%u", ESP.getMaxAllocHeap());
     }
   }
@@ -1255,6 +1274,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     if (!verticalSection) {
       LOG_DBG("ERS", "Loading vertical section, index: %d", currentSpineIndex);
+      prewarmedVPage_ = -1;  // fresh section: whatever sits in the mini-font cache is stale
       verticalSection = std::unique_ptr<VerticalSection>(new VerticalSection(epub, currentSpineIndex, renderer));
       sectionFootnotes.clear();  // vertical sections don't collect footnotes
 
@@ -1274,12 +1294,39 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           fcm->releaseAllFontMemory();
         }
 
-        if (!verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight)) {
+        // Early first render: show the reader's page the moment it is laid out (a couple of
+        // seconds in) instead of after the whole chapter builds (~17s for a 431-page book).
+        // Percent jumps need the final pageCount and keep the classic wait-for-the-build
+        // path. Rebuilds with saved progress carry cachedChapterTotalPageCount; the remap
+        // below only moves the page when the final count actually differs (a reflow), so the
+        // saved page number is an exact early target for unchanged layouts and a close
+        // estimate otherwise -- the post-build render corrects the rare off-by-a-few case
+        // with its one refresh. A target beyond the final page count (e.g. the "last page"
+        // sentinel when paging backwards) simply never fires the hook -- classic path again.
+        if (!pendingPercentJump) {
+          const int earlyTarget =
+              pendingPageJump.has_value() ? *pendingPageJump : (nextPageNumber > 0 ? nextPageNumber : 0);
+          verticalSection->setEarlyRenderHook(this, &EpubReaderActivity::earlyRenderVerticalPageThunk, earlyTarget);
+        }
+
+        earlyDisplayedPage_.store(-1, std::memory_order_relaxed);
+        verticalBuildInProgress_.store(true, std::memory_order_relaxed);
+        const bool built = verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight);
+        verticalBuildInProgress_.store(false, std::memory_order_relaxed);
+        if (!built) {
           LOG_ERR("ERS", "Failed to build vertical section");
           failedVerticalSpineIndex = currentSpineIndex;
           verticalSection.reset();
           showPendingSyncSaveError();
           return;
+        }
+
+        // Mid-build page turns moved the displayed page; the position the user READ to is
+        // the truth now, not the pre-build progress restore.
+        const int shown = earlyDisplayedPage_.load(std::memory_order_relaxed);
+        if (shown >= 0) {
+          pendingPageJump.reset();
+          nextPageNumber = shown;
         }
       } else {
         LOG_DBG("ERS", "Vertical cache found");
@@ -1428,42 +1475,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         pagesUntilFullRefresh = 1;
         imagePageDisplayed = true;
       } else {
-        // Bulk-load every glyph this page needs before drawing a single one. Without this, each
-        // draw call for a codepoint that isn't already cached falls through to the on-demand
-        // fallback path (for SD-card fonts: a fresh SD file open + two seeks + two reads per
-        // miss, into an 8-slot ring buffer) -- for a page with hundreds of distinct kanji, that's
-        // hundreds of individual SD round-trips. Confirmed on a real device: this was the entire
-        // cause of vertical page turns taking 1.5-2+ seconds of pure render time with an SD font.
-        //
-        // clearCache() first is required, not optional: FontDecompressor's prewarmCache() claims
-        // one of only MAX_PAGE_SLOTS (4) page-buffer slots per call and never self-evicts --
-        // "the caller must call freePageBuffer/clearCache to reset" (FontDecompressor.h). Without
-        // this, every page turn permanently claims more slots; confirmed on a real device that
-        // after ~1 page's worth of prewarm calls, all 4 slots were stuck full, "cannot prewarm"
-        // fired for every subsequent page, and glyphs stopped resolving at all (blank pages).
-        //
-        // styleMask must reflect only the styles ACTUALLY present on this page, not a blanket "all
-        // 4" request: FontCacheManager::prewarmCache() claims one slot per requested style, PLUS
-        // another slot per style for the family's fallback font if it has one -- up to 8 slot
-        // claims against only 4 slots total. Confirmed on a real device: even right after
-        // clearCache(), a single page still hit "all 4 slots full" because the blanket request
-        // needed more slots than exist, wasting them on styles the page doesn't even use.
-        if (auto* fcm = renderer.getFontCacheManager()) {
-          fcm->clearCache();
-          uint8_t styleMask = std::accumulate(
-              vpage->glyphs.begin(), vpage->glyphs.end(), uint8_t{0},
-              [](uint8_t m, const auto& g) { return static_cast<uint8_t>(m | (1u << (g.style & 0x03))); });
-          if (styleMask == 0) styleMask = 1 << EpdFontFamily::REGULAR;
-          const std::string pageText = PageTextExtractor::fromVerticalPage(*vpage);
-          fcm->prewarmCache(effectiveReaderFontId(), pageText.c_str(), styleMask);
-        }
-        VerticalTextBlock block(*vpage);
-        if (useFurigana()) {
-          block.render(renderer, effectiveReaderFontId(), SETTINGS.getRubyFontId(), orientedMarginLeft,
-                       orientedMarginTop, true);
-        } else {
-          block.render(renderer, effectiveReaderFontId(), orientedMarginLeft, orientedMarginTop, true);
-        }
+        renderVerticalPageBody(*vpage, /*glyphsAlreadyWarm=*/prewarmedVPage_ == verticalSection->currentPage);
       }
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
     }
@@ -1471,6 +1483,21 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (!imagePageDisplayed) {  // image pages already displayed (double-fast + grayscale planes)
       renderStatusBar();
       ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+    }
+    // Kindle-class turns: load the NEXT page's glyphs while the reader looks at this one,
+    // so the next forward turn renders from a warm cache instead of paying the full
+    // per-page SD bulk load at button time. The mini-font cache holds exactly one page per
+    // style; the page on screen no longer needs its glyphs (pixels are in the framebuffer).
+    // getPage(next) also leaves the next page in the section's single-page read cache, so
+    // the turn skips the SD page read too. Backward turns miss the warm cache and take the
+    // classic prewarm path.
+    prewarmedVPage_ = -1;
+    const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? verticalSection->currentPage + 1
+                                                                            : verticalSection->currentPage - 1;
+    if (warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
+      if (const VerticalPage* np = verticalSection->getPage(warmTarget); np && !np->isImagePage()) {
+        if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
+      }
     }
     // Pre-build the next chapter's cache while this page is on screen. This call was
     // missing from the vertical path (lost in a refactor -- silentIndexNextChapterIfNeeded
@@ -2143,6 +2170,94 @@ int EpubReaderActivity::pageBasedPercent(const int spineIndex, const int section
   }
   const int read = before + std::max(1, sectionPage);
   return clampPercent((read * 100 + bookPagesTotal / 2) / bookPagesTotal);
+}
+
+bool EpubReaderActivity::prewarmVerticalPageGlyphs(const VerticalPage& vpage) {
+  // Bulk-load every glyph this page needs before drawing a single one. Without this, each
+  // draw call for a codepoint that isn't already cached falls through to the on-demand
+  // fallback path (for SD-card fonts: a fresh SD file open + two seeks + two reads per
+  // miss, into an 8-slot ring buffer) -- for a page with hundreds of distinct kanji, that's
+  // hundreds of individual SD round-trips. Confirmed on a real device: this was the entire
+  // cause of vertical page turns taking 1.5-2+ seconds of pure render time with an SD font.
+  //
+  // clearCache() first is required, not optional: FontDecompressor's prewarmCache() claims
+  // one of only MAX_PAGE_SLOTS (4) page-buffer slots per call and never self-evicts --
+  // "the caller must call freePageBuffer/clearCache to reset" (FontDecompressor.h). Without
+  // this, every page turn permanently claims more slots; confirmed on a real device that
+  // after ~1 page's worth of prewarm calls, all 4 slots were stuck full, "cannot prewarm"
+  // fired for every subsequent page, and glyphs stopped resolving at all (blank pages).
+  //
+  // styleMask must reflect only the styles ACTUALLY present on this page, not a blanket "all
+  // 4" request: FontCacheManager::prewarmCache() claims one slot per requested style, PLUS
+  // another slot per style for the family's fallback font if it has one -- up to 8 slot
+  // claims against only 4 slots total. Confirmed on a real device: even right after
+  // clearCache(), a single page still hit "all 4 slots full" because the blanket request
+  // needed more slots than exist, wasting them on styles the page doesn't even use.
+  // Prewarm gated on heap: its page-text string and cache-slot claims are bare allocations,
+  // and this body also runs mid-build (early first render / build-time page turns) where an
+  // OOM aborts under -fno-exceptions. Without prewarm the page still renders correctly via
+  // the per-glyph on-demand path -- slower, but never fatal.
+  // 20K: normal post-build reading always clears this (heap 30K+), so warm turns are
+  // unaffected. The gate only bites during a mid-build serve, and there it MUST stay high:
+  // dropping it to 14K let the prewarm's resident footprint coincide with a dense ruby
+  // page's layout dip and the build dropped glyphs (need 11736 @ 9716 free) -> stale cache.
+  // Build-phase serves rendering on-demand (~2s) is a drop-free, one-time-per-book cost;
+  // content integrity outranks shaving that.
+  constexpr uint32_t PREWARM_MIN_ALLOC = 20 * 1024;
+  auto* fcm = renderer.getFontCacheManager();
+  if (!fcm || ESP.getMaxAllocHeap() < PREWARM_MIN_ALLOC) return false;
+  fcm->clearCache();
+  uint8_t styleMask =
+      std::accumulate(vpage.glyphs.begin(), vpage.glyphs.end(), uint8_t{0},
+                      [](uint8_t m, const auto& g) { return static_cast<uint8_t>(m | (1u << (g.style & 0x03))); });
+  if (styleMask == 0) styleMask = 1 << EpdFontFamily::REGULAR;
+  const std::string pageText = PageTextExtractor::fromVerticalPage(vpage);
+  fcm->prewarmCache(effectiveReaderFontId(), pageText.c_str(), styleMask);
+  return true;
+}
+
+void EpubReaderActivity::renderVerticalPageBody(const VerticalPage& vpage, const bool glyphsAlreadyWarm) {
+  if (!glyphsAlreadyWarm) prewarmVerticalPageGlyphs(vpage);
+  // Same origin derivation as render(): vertical text only needs the top-left corner.
+  int marginTop, marginRight, marginBottom, marginLeft;
+  renderer.getOrientedViewableTRBL(&marginTop, &marginRight, &marginBottom, &marginLeft);
+  marginTop += SETTINGS.screenMargin;
+  marginLeft += SETTINGS.screenMargin;
+  VerticalTextBlock block(vpage);
+  if (useFurigana()) {
+    block.render(renderer, effectiveReaderFontId(), SETTINGS.getRubyFontId(), marginLeft, marginTop, true);
+  } else {
+    block.render(renderer, effectiveReaderFontId(), marginLeft, marginTop, true);
+  }
+}
+
+void EpubReaderActivity::earlyRenderVerticalPageThunk(void* ctx, const VerticalPage& page, const int pageIndex) {
+  static_cast<EpubReaderActivity*>(ctx)->earlyRenderVerticalPage(page, pageIndex);
+}
+
+void EpubReaderActivity::earlyRenderVerticalPage(const VerticalPage& page, const int pageIndex) {
+  const auto start = millis();
+  // Update the shown-page index BEFORE drawing (the render takes 0.7-3s): a button press
+  // during the render should target the page AFTER this one, not re-request this one
+  // (observed on device as the same page rendering twice back-to-back).
+  earlyDisplayedPage_.store(pageIndex, std::memory_order_relaxed);
+  renderer.clearScreen();
+  renderVerticalPageBody(page);
+  // No status bar here: it derives page counts from a section that is still mid-build. The
+  // normal post-build render adds it on top of the identical page content.
+  renderer.displayBuffer();
+  // The build resumes the moment this returns and needs its headroom back: the prewarm above
+  // re-claimed font page slots and the decompressor glyph slab that the build path explicitly
+  // released before starting. Deliberately NOT releaseAllFontMemory(): that would also drop
+  // the SD fonts' advance tables, which the build's measurement is actively using -- their
+  // mid-build 16KB rebuild allocation fails under build pressure (observed: a stream of
+  // buildAdvanceTable OOM errors and deeper maxAlloc dips that dropped glyphs). clearCache()
+  // frees what the render claimed while leaving the measurement caches intact.
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->clearCache();
+    if (auto* d = fcm->getDecompressor()) d->freeGlyphSlab();
+  }
+  LOG_DBG("ERS", "Early first render of page %d in %dms", pageIndex, millis() - start);
 }
 
 void EpubReaderActivity::renderStatusBar() const {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1485,13 +1485,13 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderStatusBar();
       ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
     }
-    // Kindle-class turns: load the NEXT page's glyphs while the reader looks at this one,
-    // so the next forward turn renders from a warm cache instead of paying the full
-    // per-page SD bulk load at button time. The mini-font cache holds exactly one page per
-    // style; the page on screen no longer needs its glyphs (pixels are in the framebuffer).
-    // getPage(next) also leaves the next page in the section's single-page read cache, so
-    // the turn skips the SD page read too. Backward turns miss the warm cache and take the
-    // classic prewarm path.
+    // Kindle-class turns: load the neighbouring page's glyphs while the reader looks at this
+    // one, so the next turn renders from a warm cache instead of paying the full per-page SD
+    // bulk load at button time. Direction-adaptive: warm the NEXT page after a forward turn,
+    // the PREVIOUS page after a backward turn, so sustained paging in either direction stays
+    // warm -- only the single turn right after a direction reversal is cold (the mini-font
+    // cache holds exactly one page per style). getPage(target) also leaves that page in the
+    // section's single-page read cache, so the turn skips the SD page read too.
     prewarmedVPage_ = -1;
     const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? verticalSection->currentPage + 1
                                                                             : verticalSection->currentPage - 1;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1924,13 +1924,18 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
 
   // Font prewarm: scan pass accumulates text, then prewarm, then real render. Skipped when the
   // idle next-page warm already loaded this page's glyphs (prewarmedHPage_) -- the cache is
-  // warm, so we go straight to the real render (~30ms) instead of paying the scan + SD bulk
-  // load again at button time.
+  // warm, so we go straight to the real render instead of paying the scan + SD bulk load again
+  // at button time. The scope must stay alive for the WHOLE function so its warm survives the
+  // real render below and clears only at function exit (via the optional's destructor);
+  // scoping it to just the prewarm block would clear the cache before the real render and
+  // defeat the prewarm. In the already-warm case no scope is created, so the idle warm's cache
+  // persists (the next idle warm clears and rebuilds it).
   auto* fcm = renderer.getFontCacheManager();
-  if (!glyphsAlreadyWarm) {
-    auto scope = fcm->createPrewarmScope();
+  std::optional<FontCacheManager::PrewarmScope> prewarm;
+  if (!glyphsAlreadyWarm && fcm) {
+    prewarm.emplace(fcm->createPrewarmScope());
     page->render(renderer, fontId, orientedMarginLeft, orientedMarginTop, !useFurigana());  // scan pass
-    scope.endScanAndPrewarm();
+    prewarm->endScanAndPrewarm();
   }
   const auto tPrewarm = millis();
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1420,6 +1420,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     {
       const auto* vpage = verticalSection->getPage();
       if (!vpage) {
+        if (verticalSection->lastReadHeapRefused()) {
+          // Transient low heap, NOT corruption: the on-disk cache is valid. Clearing it here
+          // would force an expensive rebuild (which needs far more heap and would fail too).
+          // Reclaim the font memory to recover headroom and re-render; the retry then fits.
+          LOG_ERR("ERS", "Vertical page read refused on low heap; keeping cache and retrying");
+          if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
+          prewarmedVPage_ = -1;
+          requestUpdate();
+          automaticPageTurnActive = false;
+          showPendingSyncSaveError();
+          return;
+        }
         LOG_ERR("ERS", "Failed to get vertical page");
         verticalSection->clearCache();
         verticalSection.reset();
@@ -1735,6 +1747,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         lastTurnForward_.load(std::memory_order_relaxed) ? section->currentPage + 1 : section->currentPage - 1;
     if (warmTarget >= 0 && warmTarget < section->pageCount) {
       if (auto np = section->loadPageFromSectionFile(warmTarget)) {
+        // createPrewarmScope() clears the cache in its constructor (FontCacheManager::clearCache
+        // -> FontDecompressor::clearCache), which frees the MAX_PAGE_SLOTS page-buffer slots.
+        // So each idle warm REPLACES the previous page's glyphs rather than consuming a new
+        // slot -- slots do not accumulate across turns even with release() keeping the result.
         auto scope = fcm->createPrewarmScope();
         np->render(renderer, effectiveReaderFontId(), orientedMarginLeft, orientedMarginTop, !useFurigana());
         scope.endScanAndPrewarm();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1276,7 +1276,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (!verticalSection) {
       LOG_DBG("ERS", "Loading vertical section, index: %d", currentSpineIndex);
       prewarmedVPage_ = -1;  // fresh section: whatever sits in the mini-font cache is stale
-      verticalSection = std::unique_ptr<VerticalSection>(new VerticalSection(epub, currentSpineIndex, renderer));
+      // makeUniqueNoThrow, not bare new: with -fno-exceptions a failed new aborts the firmware
+      // instead of returning null, and this allocation can land on a badly fragmented heap.
+      verticalSection = makeUniqueNoThrow<VerticalSection>(epub, currentSpineIndex, renderer);
+      if (!verticalSection) {
+        LOG_ERR("ERS", "OOM allocating VerticalSection");
+        renderer.clearScreen();
+        renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+        renderStatusBar();
+        renderer.displayBuffer();
+        automaticPageTurnActive = false;
+        showPendingSyncSaveError();
+        return;
+      }
       sectionFootnotes.clear();  // vertical sections don't collect footnotes
 
       const int fontId = effectiveReaderFontId();
@@ -1546,7 +1558,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
     prewarmedHPage_ = -1;  // fresh section: any page warmed for the previous one is stale
-    section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+    // makeUniqueNoThrow, not bare new: with -fno-exceptions a failed new aborts the firmware
+    // instead of returning null, and this allocation can land on a badly fragmented heap.
+    section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
+    if (!section) {
+      LOG_ERR("ERS", "OOM allocating Section");
+      renderer.clearScreen();
+      renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+      renderStatusBar();
+      renderer.displayBuffer();
+      automaticPageTurnActive = false;
+      showPendingSyncSaveError();
+      return;
+    }
 
     if (!section->loadSectionFile(effectiveReaderFontId(), SETTINGS.getReaderLineCompression(),
                                   SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -159,7 +159,11 @@ class EpubReaderActivity final : public Activity {
   static bool imageWarmShouldCancel(const void* ctx);
 
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
-                      int orientedMarginBottom, int orientedMarginLeft);
+                      int orientedMarginBottom, int orientedMarginLeft, bool glyphsAlreadyWarm = false);
+  // Horizontal analog of prewarmedVPage_: the page index whose glyphs currently sit warm in
+  // the font cache from the idle next-page prewarm; -1 = cold/unknown. Written on the render
+  // task only.
+  int prewarmedHPage_ = -1;
   void renderStatusBar() const;
   // Bulk-loads a vertical page's glyphs into the SD-font mini cache (heap-gated). Returns
   // false when the heap was too tight to prewarm -- rendering still works via the slower

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -161,6 +161,37 @@ class EpubReaderActivity final : public Activity {
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
                       int orientedMarginBottom, int orientedMarginLeft);
   void renderStatusBar() const;
+  // Bulk-loads a vertical page's glyphs into the SD-font mini cache (heap-gated). Returns
+  // false when the heap was too tight to prewarm -- rendering still works via the slower
+  // per-glyph on-demand path.
+  bool prewarmVerticalPageGlyphs(const VerticalPage& vpage);
+  // Draws one vertical TEXT page into the framebuffer; shared by the normal render path and
+  // the early-first-render hook. Does not touch the display. glyphsAlreadyWarm skips the
+  // prewarm when the page's glyphs were pre-loaded during idle (see prewarmedVPage_).
+  void renderVerticalPageBody(const VerticalPage& vpage, bool glyphsAlreadyWarm = false);
+  // Page index whose glyphs currently sit in the SD-font mini cache from the idle next-page
+  // warm; -1 = cache cold/unknown. Kindle-class turns: the NEXT page's glyphs are loaded
+  // while the reader looks at the current one, so a forward turn renders warm (~200ms)
+  // instead of paying the ~500-700ms per-page SD bulk load at button time.
+  int prewarmedVPage_ = -1;
+  // Direction of the most recent page turn; the idle warm follows it (forward turns warm
+  // the next page, backward turns the previous one) so sustained paging in EITHER
+  // direction hits a warm cache. Written by pageTurn() on the loop() task.
+  std::atomic<bool> lastTurnForward_{true};
+  // Early-first-render: invoked mid-build by VerticalSection the moment the reader's target
+  // page is laid out (and again for every mid-build page-turn request), so text is on screen
+  // seconds into a ~17s whole-chapter build and the user can keep turning pages while the
+  // rest of the chapter builds.
+  static void earlyRenderVerticalPageThunk(void* ctx, const VerticalPage& page, int pageIndex);
+  void earlyRenderVerticalPage(const VerticalPage& page, int pageIndex);
+  // True while a vertical chapter build runs on the render task. Read by pageTurn() on the
+  // loop() task: while building, the section's pageCount is still 0, so the normal turn path
+  // would misread every press as "past the last page" and jump to the next spine (observed:
+  // a press during the build teleported the reader to the end of the book).
+  std::atomic<bool> verticalBuildInProgress_{false};
+  // Page index currently on screen from the early-render path; -1 until it first fires.
+  // Written on the render task, read by pageTurn() on the loop() task.
+  std::atomic<int> earlyDisplayedPage_{-1};
   void silentIndexNextChapterIfNeeded(uint16_t viewportWidth, uint16_t viewportHeight);
   bool saveProgress(int spineIndex, int currentPage, int pageCount, int8_t vertOverride, int8_t furiOverride);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.


### PR DESCRIPTION
## What

Opening and paging a whole-book **tategaki** chapter now feels instant on the X4, without ever dropping a glyph. Layers on top of the rebuild-loop fix (already on `develop`) and **changes no on-disk cache format** — `VSECTION_FILE_VERSION` stays 80, so existing valid caches are reused.

## Why

A 431-page vertical novel blocked for ~17s on first open (whole chapter laid out before anything drew), and page turns paid a ~500–700ms SD font bulk-load each. On this ~380KB-RAM, no-PSRAM device the naive fixes trade against content integrity, so every change here is heap-gated and drop-safe.

## Changes

**Progressive first open**
- Early-render hook in `VerticalSection`: draws the reader's target page the moment it's laid out (~2–3s in) while the rest of the build continues.
- Mid-build page turns: `pageTurn()` routes presses to a request slot the build serves as each page becomes available — forward from the just-written page, backward by reading the serialized record back through the `O_RDWR` handle into a **pre-reserved serve slot** (zero allocation at the tight moment).
- `verticalBuildInProgress_` guard: while building, `pageCount` is 0, and the old turn path misread every press as "past the last page" and jumped to the next spine (teleported the reader to the book's end). Fixed.

**Kindle-class turns (post-build)**
- Idle next-page prewarm in the turn direction → sustained forward *or* backward paging renders warm (~30ms). Only the single turn right after a direction reversal is cold (one-slot mini-font cache limit).
- `VerticalTextBlock` now holds the page **by reference**, not by value — the old ctor deep-copied ~10KB of glyphs per render and OOM-aborted a mid-build render.

**Content integrity under heap pressure**
- `pushGlyph` final zero-margin growth attempt before dropping (every observed drop had the block available, died only on the margin).
- Emergency **early page break** when the glyph vector genuinely can't grow — closes the page a few cells early instead of losing characters.
- `readPage` refuses a read its reserve can't afford (bare `reserve` aborts under `-fno-exceptions`) and flushes before backward read-backs.

## Testing

Device-verified on Xteink X4:
- 431-page book opens to the reading page in ~2–3s.
- Forward/backward paging during the build stays responsive (~1.7–2s incl. e-ink refresh).
- Post-build turns render in ~30ms warm / ~200ms cold (direction reversal).
- Build completes **drop-free** with a valid, non-stale cache.

## Notes for review
- Pre-existing `IWARM` TEMP diagnostics in `EpubReaderActivity.cpp` are from earlier image-warm work already on `develop` — left untouched here to keep this diff single-concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)