### PR TITLE
fix: clear the two cppcheck defects blocking CI

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -215,10 +215,9 @@ void RecentBooksActivity::saveLibraryIndex() {
 }
 
 const RecentBooksActivity::LibraryIndexEntry* RecentBooksActivity::findIndexEntry(const uint32_t pathHash) const {
-  for (const auto& e : libraryIndex_) {
-    if (e.pathHash == pathHash) return &e;
-  }
-  return nullptr;
+  const auto it = std::find_if(libraryIndex_.begin(), libraryIndex_.end(),
+                               [pathHash](const LibraryIndexEntry& e) { return e.pathHash == pathHash; });
+  return it != libraryIndex_.end() ? &*it : nullptr;
 }
 
 void RecentBooksActivity::recordIndexEntry(const std::string& path, const uint32_t fileSize,

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -124,7 +124,7 @@ bool UITheme::getCoverThumbSize(const std::string& coverThumbPath, int* width, i
   if (coverThumbPath.empty() || !width || !height) return false;
 
   if (FsHelpers::hasJpgExtension(coverThumbPath) || FsHelpers::hasPngExtension(coverThumbPath)) {
-    ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(coverThumbPath);
+    const ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(coverThumbPath);
     ImageDimensions dims = {0, 0};
     if (!decoder || !decoder->getDimensions(coverThumbPath, dims) || dims.width <= 0 || dims.height <= 0) return false;
     *width = dims.width;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Get `cppcheck` green again — it currently fails on `develop`'s HEAD, which blocks the release PR (#17).
* **What changes are included?** The two LOW-severity findings (`pio check` runs with `--fail-on-defect low`, so any defect fails):

| File | Finding | Fix |
| --- | --- | --- |
| `src/activities/home/RecentBooksActivity.cpp:219` | `useStlAlgorithm` — raw search loop | `std::find_if` |
| `src/components/UITheme.cpp:127` | `constVariablePointer` — `decoder` can be pointer-to-const | `const ImageToFramebufferDecoder*` |

Behavior is unchanged in both cases.

## Additional Context

* `std::find_if` matches the prevailing idiom in `RecentBooksActivity.cpp` (already used at 8 other sites) and `<algorithm>` was already included, so this adds no new dependency or template instantiation the file didn't already have.
* Only the `getCoverThumbSize` decoder became const. The other two decoder sites in `UITheme.cpp` (lines ~150 and ~200) stay non-const because they go on to call the non-const `decodeToFramebuffer()` — that's also why cppcheck flagged only the one.
* Verified against the failing run's log: these are exactly the two defects reported (`0 HIGH / 0 MEDIUM / 2 LOW`).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — diagnosed from the failing CI log and fixed with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8m8yQDHu4vgFkcJHgwk5Z)_