### PR TITLE
chore: merge upstream develop (dictionary perf, content-based sync, deque tokens)

### DIFF
--- a/.github/workflows/pr-formatting-check.yml
+++ b/.github/workflows/pr-formatting-check.yml
@@ -21,7 +21,14 @@ jobs:
         with:
           egress-policy: audit
 
+      # Upstream-merge PRs ("Merge/upstream <ref>") are exempt via the step condition:
+      # their titles are not conventional commits. Do NOT try to express the exemption
+      # inside a custom headerPattern -- the parser maps capture groups to
+      # type/scope/subject, and an alternation cannot fill those groups for both title
+      # shapes, so the check ends up failing every title (see the 2026-08 incident where
+      # a two-group pattern made this check red on all PRs).
       - name: Check PR Title
+        if: ${{ !startsWith(github.event.pull_request.title, 'Merge/upstream ') }}
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -367,7 +367,7 @@ It also interoperates with KOReader apps/devices when they use the same server a
 
 ##### Option A: CrossPoint Sync Server (`sync.crosspointreader.com`, default)
 
-When **Sync Server URL** is left empty, CrossPoint uses the free CrossPoint sync server at `https://sync.crosspointreader.com`. It speaks the standard KOReader sync protocol (so KOReader apps can use it too) and additionally stores an exact spine/page position for lossless CrossPoint-to-CrossPoint sync.
+When **Sync Server URL** is left empty, CrossPoint uses the free CrossPoint sync server at `https://sync.crosspointreader.com`. It speaks the standard KOReader sync protocol (so KOReader apps can use it too). CrossPoint records page starts as chapter-content offsets and sends the corresponding standard KOReader XPath, so devices with different fonts or layouts can return to the same text.
 
 1. On each CrossPoint device:
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -154,9 +154,11 @@ Typical persisted areas on SD:
   state.json
 ```
 
-`sections/*.bin` contains rendered pages plus anchor, paragraph, and list-item
-lookup tables used for TOC/footnote jumps and KOReader sync refinement. For
-binary cache formats, see `docs/file-formats.md`.
+`sections/*.bin` contains rendered pages plus anchor, paragraph, list-item, and
+page-start visible-text-offset lookup tables. The offset table makes reading
+positions content-based: KOReader XPaths resolve to an exact chapter offset,
+and the current layout derives the corresponding page. For binary cache
+formats, see `docs/file-formats.md`.
 
 ## Networking architecture
 

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,11 +90,14 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 30
+### Version 35
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Version 35 adds a header offset and a `uint32_t` entry per page for the
+visible-text offset LUT. The other section LUTs remain unchanged.
 
 Version 34 is binary-identical to version 33. The version was bumped because
 word-gap suppression was narrowed to tokens glued together in the source: v33
@@ -113,8 +116,9 @@ superscript, and subscript. The format also includes:
 - cache-busting fields for paragraph alignment, hyphenation, embedded CSS,
   image rendering mode, and Focus Reading
 - page offset LUT
+- per-page visible-text offset LUT (zero-based Unicode codepoints in `<body>`)
 - anchor-to-page map for fragment and footnote navigation
-- paragraph and list-item LUTs used by KOReader sync page refinement
+- paragraph and list-item LUTs retained for navigation and legacy sync fallback
 - optional per-word Focus Reading split metadata
 - per-page footnote entries
 - serialized word style bits for underline, strikethrough, superscript, and
@@ -131,7 +135,7 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define EXPECTED_VERSION 30
+#define EXPECTED_VERSION 35
 #define MAX_STRING_LENGTH 65535
 #define FOOTNOTE_NUMBER_LEN 32
 #define FOOTNOTE_HREF_LEN 96
@@ -299,6 +303,7 @@ struct SectionBin {
     u32 anchorMapOffset;
     u32 paragraphLutOffset;
     u32 listItemLutOffset;
+    u32 visibleTextLutOffset;
 
     Page pages[pageCount];
 
@@ -319,6 +324,10 @@ struct SectionBin {
 
     if (listItemLutOffset != 0 && paragraphLutOffset != 0) {
         u16 listItemIndex[paragraphLut.count] @ listItemLutOffset;
+    }
+
+    if (visibleTextLutOffset != 0) {
+	u32 visibleTextOffset[pageCount] @ visibleTextLutOffset;
     }
 };
 

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -1362,7 +1362,7 @@ int SdCardFont::buildAdvanceTable(const char* utf8Text, uint8_t styleMask, const
   return buildAdvanceTableRange(&utf8Text, &utf8Text + 1, false, false, styleMask, extraText);
 }
 
-int SdCardFont::buildAdvanceTable(const std::vector<std::string>& words, bool includeHyphen, uint8_t styleMask,
+int SdCardFont::buildAdvanceTable(const std::deque<std::string>& words, bool includeHyphen, uint8_t styleMask,
                                   const char* extraText) {
   return buildAdvanceTableRange(words.begin(), words.end(), words.size() > 1, includeHyphen, styleMask, extraText);
 }

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <string>
 #include <vector>
 
@@ -51,7 +52,7 @@ class SdCardFont {
   // (e.g. shaped Arabic presentation forms the measurement path will look up).
   // Returns number of codepoints not found in font coverage.
   int buildAdvanceTable(const char* utf8Text, uint8_t styleMask = 0x0F, const char* extraText = nullptr);
-  int buildAdvanceTable(const std::vector<std::string>& words, bool includeHyphen, uint8_t styleMask = 0x0F,
+  int buildAdvanceTable(const std::deque<std::string>& words, bool includeHyphen, uint8_t styleMask = 0x0F,
                         const char* extraText = nullptr);
 
   // Look up advanceX for a codepoint from the advance table.

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -78,6 +78,12 @@ class Page {
   std::vector<FootnoteEntry> footnotes;
   static constexpr uint16_t MAX_FOOTNOTES_PER_PAGE = 16;
 
+  // Zero-based visible-codepoint offset where this page starts. Not part of the serialized page
+  // body (it lives in the section's visible-offset LUT); Section::loadPage* fills it in from the
+  // build LUT or the on-disk LUT while the page file is already open, so the reader can persist
+  // progress without a second section-file open per page turn.
+  uint32_t visibleTextOffset = 0;
+
   void addFootnote(const char* number, const char* href) {
     if (footnotes.size() >= MAX_FOOTNOTES_PER_PAGE) return;  // Cap per-page footnotes
     FootnoteEntry entry;

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -294,27 +294,25 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     effectiveNoSpaceBefore = true;
   }
 
+  // Bulk-reserve the per-token parallel arrays before a burst of pushes so they
+  // don't repeatedly double. Only the std::vector arrays are reserved: words and
+  // rubyTexts are std::deque (chunked growth, no reserve()/capacity() and no large
+  // contiguous reallocation to avoid). wordStyles' capacity gauges them all since
+  // pushToken() keeps every array in lockstep.
   const auto ensureTokenCapacity = [&](const size_t additionalTokens) {
     if (additionalTokens == 0) return;
     const size_t requiredSize = words.size() + additionalTokens;
-    if (words.capacity() >= requiredSize) return;
+    if (wordStyles.capacity() >= requiredSize) return;
 
-    size_t newCapacity = words.capacity();
-    if (newCapacity < 16) {
-      newCapacity = 16;
-    }
+    size_t newCapacity = wordStyles.capacity() < 16 ? 16 : wordStyles.capacity();
     while (newCapacity < requiredSize) {
       newCapacity *= 2;
     }
 
-    words.reserve(newCapacity);
     wordStyles.reserve(newCapacity);
     wordContinues.reserve(newCapacity);
     wordNoSpaceBefore.reserve(newCapacity);
     wordIsFocusSuffix.reserve(newCapacity);
-    if (!rubyTexts.empty()) {
-      rubyTexts.reserve(newCapacity);
-    }
   };
 
   if (auto breakOffsets = cjkCharacterBreakByteOffsets(word); !breakOffsets.empty()) {
@@ -488,9 +486,8 @@ void ParsedText::setRubyGroupAt(size_t startIndex, size_t count, const std::stri
 }
 
 void ParsedText::ensureRubyCapacity() {
-  if (rubyTexts.capacity() < words.capacity()) {
-    rubyTexts.reserve(words.capacity());
-  }
+  // No-op: rubyTexts is a std::deque (chunked growth, no capacity to pre-reserve
+  // and no large contiguous reallocation to avoid). Kept for call-site stability.
 }
 
 int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer& renderer, const int fontId) const {

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -136,6 +136,17 @@ bool containsCjkBreakableCodepoint(const std::string& text) {
   return false;
 }
 
+uint32_t countCodepoints(const std::string_view text) {
+  const auto* ptr = reinterpret_cast<const unsigned char*>(text.data());
+  const auto* const end = ptr + text.size();
+  uint32_t count = 0;
+  while (ptr < end) {
+    utf8NextCodepoint(&ptr);
+    count++;
+  }
+  return count;
+}
+
 bool hasCjkBreakOpportunityBetween(const uint32_t leftCp, const uint32_t rightCp) {
   if (!utf8IsCjkBreakable(leftCp) && !utf8IsCjkBreakable(rightCp)) return false;
   if (isNoBreakAfterCjkPunctuation(leftCp) || isNoBreakBeforeCjkPunctuation(rightCp)) return false;
@@ -251,8 +262,75 @@ bool isWordCharacter(uint32_t cp) {
 
 }  // namespace
 
+uint32_t ParsedText::visibleOffsetBaseAt(const size_t wordIndex) const {
+  uint32_t base = visibleOffsetBase;
+  for (const auto& rebase : visibleOffsetRebases) {
+    if (rebase.wordIndex > wordIndex) break;
+    base = rebase.base;
+  }
+  return base;
+}
+
+uint32_t ParsedText::visibleOffsetAt(const size_t wordIndex) const {
+  if (wordIndex >= wordVisibleOffsetDeltas.size()) return 0;
+  return visibleOffsetBaseAt(wordIndex) + wordVisibleOffsetDeltas[wordIndex];
+}
+
+void ParsedText::pushVisibleOffset(const uint32_t offset) {
+  uint32_t base = visibleOffsetBase;
+  if (wordVisibleOffsetDeltas.empty()) {
+    visibleOffsetBase = offset;
+    base = offset;
+  } else if (!visibleOffsetRebases.empty()) {
+    base = visibleOffsetRebases.back().base;
+  }
+
+  if (offset < base || offset - base > std::numeric_limits<uint16_t>::max()) {
+    visibleOffsetRebases.push_back({wordVisibleOffsetDeltas.size(), offset});
+    base = offset;
+  }
+  wordVisibleOffsetDeltas.push_back(static_cast<uint16_t>(offset - base));
+}
+
+void ParsedText::insertVisibleOffset(const size_t wordIndex, const uint32_t offset) {
+  const uint32_t base = wordIndex > 0 ? visibleOffsetBaseAt(wordIndex - 1) : visibleOffsetBase;
+  for (auto& rebase : visibleOffsetRebases) {
+    if (rebase.wordIndex >= wordIndex) rebase.wordIndex++;
+  }
+
+  uint32_t insertionBase = base;
+  if (offset < base || offset - base > std::numeric_limits<uint16_t>::max()) {
+    const auto rebaseIt = std::find_if(visibleOffsetRebases.begin(), visibleOffsetRebases.end(),
+                                       [wordIndex](const auto& rebase) { return rebase.wordIndex > wordIndex; });
+    visibleOffsetRebases.insert(rebaseIt, {wordIndex, offset});
+    insertionBase = offset;
+  }
+  wordVisibleOffsetDeltas.insert(wordVisibleOffsetDeltas.begin() + wordIndex,
+                                 static_cast<uint16_t>(offset - insertionBase));
+}
+
+void ParsedText::eraseVisibleOffsetPrefix(const size_t count) {
+  if (count >= wordVisibleOffsetDeltas.size()) {
+    wordVisibleOffsetDeltas.clear();
+    visibleOffsetRebases.clear();
+    visibleOffsetBase = 0;
+    return;
+  }
+
+  const uint32_t newBase = visibleOffsetBaseAt(count);
+  wordVisibleOffsetDeltas.erase(wordVisibleOffsetDeltas.begin(), wordVisibleOffsetDeltas.begin() + count);
+  size_t writeIndex = 0;
+  for (auto rebase : visibleOffsetRebases) {
+    if (rebase.wordIndex <= count) continue;
+    rebase.wordIndex -= count;
+    visibleOffsetRebases[writeIndex++] = rebase;
+  }
+  visibleOffsetRebases.resize(writeIndex);
+  visibleOffsetBase = newBase;
+}
+
 void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle, const bool underline,
-                         const bool attachToPrevious) {
+                         const bool attachToPrevious, const uint32_t visibleTextOffset) {
   if (word.empty()) return;
 
   // The device fonts carry no combining-mark positioning, so EPUB text stored in NFD
@@ -271,12 +349,13 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
                              BidiUtils::startsWithRtl(word.c_str(), RTL_PER_WORD_PROBE_DEPTH);
 
   const auto pushToken = [&](std::string token, const bool continues, const bool noSpaceBefore,
-                             const bool isFocusSuffix) {
+                             const bool isFocusSuffix, const uint32_t tokenOffset) {
     words.push_back(std::move(token));
     wordStyles.push_back(baseStyle);
     wordContinues.push_back(continues);
     wordNoSpaceBefore.push_back(noSpaceBefore);
     wordIsFocusSuffix.push_back(isFocusSuffix);
+    pushVisibleOffset(tokenOffset);
     if (!rubyTexts.empty()) {
       rubyTexts.push_back("");
     }
@@ -313,6 +392,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordContinues.reserve(newCapacity);
     wordNoSpaceBefore.reserve(newCapacity);
     wordIsFocusSuffix.reserve(newCapacity);
+    wordVisibleOffsetDeltas.reserve(newCapacity);
   };
 
   if (auto breakOffsets = cjkCharacterBreakByteOffsets(word); !breakOffsets.empty()) {
@@ -321,16 +401,19 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     ensureTokenCapacity(breakOffsets.size() + 1);
     bool firstToken = true;
     size_t tokenStart = 0;
+    uint32_t tokenVisibleOffset = visibleTextOffset;
     for (const size_t breakOffset : breakOffsets) {
       if (breakOffset <= tokenStart || breakOffset > word.size()) continue;
-      pushToken(word.substr(tokenStart, breakOffset - tokenStart), firstToken ? effectiveAttachToPrevious : false,
-                firstToken ? effectiveNoSpaceBefore : true, false);
+      const std::string_view token(word.data() + tokenStart, breakOffset - tokenStart);
+      pushToken(std::string(token), firstToken ? effectiveAttachToPrevious : false,
+                firstToken ? effectiveNoSpaceBefore : true, false, tokenVisibleOffset);
+      tokenVisibleOffset += countCodepoints(token);
       firstToken = false;
       tokenStart = breakOffset;
     }
     if (tokenStart < word.size()) {
       pushToken(word.substr(tokenStart), firstToken ? effectiveAttachToPrevious : false,
-                firstToken ? effectiveNoSpaceBefore : true, false);
+                firstToken ? effectiveNoSpaceBefore : true, false, tokenVisibleOffset);
     }
     if (wordStartsRtl) {
       hasRtlWord = true;
@@ -339,7 +422,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   }
 
   if (containsCjkBreakableCodepoint(word)) {
-    pushToken(std::move(word), effectiveAttachToPrevious, effectiveNoSpaceBefore, false);
+    pushToken(std::move(word), effectiveAttachToPrevious, effectiveNoSpaceBefore, false, visibleTextOffset);
     if (wordStartsRtl) {
       hasRtlWord = true;
     }
@@ -348,7 +431,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
 
   // Already-bold text should stay fully bold; focus splitting would make its suffix regular later.
   if (!this->focusReadingEnabled || (baseStyle & EpdFontFamily::BOLD) != 0) {
-    pushToken(std::move(word), effectiveAttachToPrevious, effectiveNoSpaceBefore, false);
+    pushToken(std::move(word), effectiveAttachToPrevious, effectiveNoSpaceBefore, false, visibleTextOffset);
     if (wordStartsRtl) {
       hasRtlWord = true;
     }
@@ -363,6 +446,14 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   // Lambda helper to process and push individual sub-segments of the string
   // Use std::string_view to avoid heap allocations when slicing
   auto processSegment = [&](std::string_view segment, bool isWord, bool attach, bool noSpaceBefore) {
+    const unsigned char* wordBegin = reinterpret_cast<const unsigned char*>(word.data());
+    const unsigned char* segmentBegin = reinterpret_cast<const unsigned char*>(segment.data());
+    uint32_t segmentOffset = visibleTextOffset;
+    const unsigned char* offsetPtr = wordBegin;
+    while (offsetPtr < segmentBegin) {
+      utf8NextCodepoint(&offsetPtr);
+      segmentOffset++;
+    }
     if (!isWord) {
       // Punctuation and Numbers stay regular
       words.emplace_back(segment);
@@ -370,6 +461,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
       wordContinues.push_back(attach);
       wordNoSpaceBefore.push_back(noSpaceBefore);
       wordIsFocusSuffix.push_back(false);
+      pushVisibleOffset(segmentOffset);
     } else {
       size_t charCount = 0;
       const unsigned char* countPtr = reinterpret_cast<const unsigned char*>(segment.data());
@@ -392,6 +484,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordIsFocusSuffix.push_back(false);
+        pushVisibleOffset(segmentOffset);
       } else {
         countPtr = reinterpret_cast<const unsigned char*>(segment.data());
         for (size_t i = 0; i < targetBoldChars; ++i) {
@@ -405,6 +498,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordIsFocusSuffix.push_back(false);
+        pushVisibleOffset(segmentOffset);
 
         // Regular suffix - marked so extractLine can merge it back into single TextBlock entry
         words.emplace_back(segment.substr(splitByteOffset));
@@ -412,6 +506,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(true);
         wordNoSpaceBefore.push_back(false);
         wordIsFocusSuffix.push_back(true);
+        pushVisibleOffset(segmentOffset + static_cast<uint32_t>(targetBoldChars));
       }
     }
   };
@@ -507,7 +602,7 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
 }
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                                       const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
     return;
@@ -573,6 +668,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
     wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + consumed);
     wordIsFocusSuffix.erase(wordIsFocusSuffix.begin(), wordIsFocusSuffix.begin() + consumed);
+    eraseVisibleOffsetPrefix(consumed);
     if (!rubyTexts.empty()) {
       const size_t rtConsumed = std::min(consumed, rubyTexts.size());
       rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + rtConsumed);
@@ -1002,6 +1098,14 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
     return false;
   }
 
+  uint32_t remainderOffset = visibleOffsetAt(wordIndex);
+  const unsigned char* offsetPtr = reinterpret_cast<const unsigned char*>(word.data());
+  const unsigned char* splitPtr = offsetPtr + chosenOffset;
+  while (offsetPtr < splitPtr) {
+    utf8NextCodepoint(&offsetPtr);
+    remainderOffset++;
+  }
+
   // Split the word at the selected breakpoint and append a hyphen if required.
   std::string remainder = word.substr(chosenOffset);
   words[wordIndex].resize(chosenOffset);
@@ -1012,6 +1116,7 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   // Insert the remainder word (with matching style and continuation flag) directly after the prefix.
   words.insert(words.begin() + wordIndex + 1, remainder);
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
+  insertVisibleOffset(wordIndex + 1, remainderOffset);
   // The hyphen remainder is not a focus suffix - it starts fresh on the next line.
   wordIsFocusSuffix.insert(wordIsFocusSuffix.begin() + wordIndex + 1, false);
   if (wordIndex + 1 <= rubyTexts.size()) {
@@ -1051,11 +1156,12 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                              const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
+  const uint32_t lineVisibleOffset = visibleOffsetAt(lastBreakAt);
 
   const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0, renderer, fontId);
 
@@ -1371,7 +1477,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
       return;
     }
-    processLine(std::move(block));
+    processLine(std::move(block), lineVisibleOffset);
     return;
   }
 
@@ -1425,5 +1531,5 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
     return;
   }
-  processLine(std::move(block));
+  processLine(std::move(block), lineVisibleOffset);
 }

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -479,16 +479,12 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
 
   // Lambda helper to process and push individual sub-segments of the string
   // Use std::string_view to avoid heap allocations when slicing
-  auto processSegment = [&](std::string_view segment, bool isWord, bool attach, bool noSpaceBefore) {
+  // segmentOffset: visible-codepoint offset of the segment's first character, tracked
+  // incrementally by the tokenization loop below (a per-segment prefix rescan would be
+  // O(n^2) on highly punctuated words -- Copilot review, PR #24).
+  auto processSegment = [&](std::string_view segment, bool isWord, bool attach, bool noSpaceBefore,
+                            const uint32_t segmentOffset) {
     const auto pushSegmentFont = pushTokenFont;
-    const unsigned char* wordBegin = reinterpret_cast<const unsigned char*>(word.data());
-    const unsigned char* segmentBegin = reinterpret_cast<const unsigned char*>(segment.data());
-    uint32_t segmentOffset = visibleTextOffset;
-    const unsigned char* offsetPtr = wordBegin;
-    while (offsetPtr < segmentBegin) {
-      utf8NextCodepoint(&offsetPtr);
-      segmentOffset++;
-    }
     if (!isWord) {
       // Punctuation and Numbers stay regular
       words.emplace_back(segment);
@@ -559,6 +555,8 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   bool inWordSegment = isWordCharacter(firstCp);
 
   bool isFirstSegment = true;
+  uint32_t cpIndex = 1;              // codepoints consumed from the word so far
+  uint32_t segmentStartCpIndex = 0;  // codepoint index where the current segment starts
 
   while (ptr < end) {
     const unsigned char* currentCpStart = ptr;
@@ -573,20 +571,22 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
       // Only the very first segment inherits the original attachToPrevious flag.
       // Every subsequent segment MUST attach=true so it glues seamlessly to the prefix.
       processSegment(segment, inWordSegment, isFirstSegment ? effectiveAttachToPrevious : true,
-                     isFirstSegment ? effectiveNoSpaceBefore : false);
+                     isFirstSegment ? effectiveNoSpaceBefore : false, visibleTextOffset + segmentStartCpIndex);
 
       // Setup for the next segment
       segmentStart = currentCpStart;
+      segmentStartCpIndex = cpIndex;
       inWordSegment = isWordChar;
       isFirstSegment = false;
     }
+    cpIndex++;
   }
 
   // Process the final remaining segment
   size_t segmentLen = end - segmentStart;
   std::string_view segment(reinterpret_cast<const char*>(segmentStart), segmentLen);
   processSegment(segment, inWordSegment, isFirstSegment ? effectiveAttachToPrevious : true,
-                 isFirstSegment ? effectiveNoSpaceBefore : false);
+                 isFirstSegment ? effectiveNoSpaceBefore : false, visibleTextOffset + segmentStartCpIndex);
   if (wordStartsRtl) {
     hasRtlWord = true;
   }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -2,6 +2,7 @@
 
 #include <EpdFontFamily.h>
 
+#include <deque>
 #include <functional>
 #include <memory>
 #include <string>
@@ -13,12 +14,21 @@
 class GfxRenderer;
 
 class ParsedText {
-  std::vector<std::string> words;
+  // words/rubyTexts are std::deque, not std::vector: a paragraph can hold thousands
+  // of tokens (CJK splits every character), and a vector grows by reallocating its
+  // whole element array into one contiguous block (32 B/std::string -> 64-128 KB at
+  // a few thousand tokens). On the ESP32-C3 that single large contiguous request
+  // fails under a fragmented, BLE-resident heap and the throwing operator new
+  // abort()s the firmware (fresh-open CJK crash). A deque grows in fixed ~512 B nodes
+  // (largest contiguous alloc stays ~2 KB regardless of token count), so it never
+  // triggers that. The per-token parallel arrays below stay vectors: 1 byte / 1 bit
+  // each, they never approach the contiguous-block ceiling.
+  std::deque<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
   std::vector<bool> wordContinues;      // true = word attaches to previous with no break
   std::vector<bool> wordNoSpaceBefore;  // true = may break before token, but no synthetic space when joined
   std::vector<bool> wordIsFocusSuffix;  // true = token is the regular tail of a focus bold-prefix split
-  std::vector<std::string> rubyTexts;
+  std::deque<std::string> rubyTexts;
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -28,6 +28,17 @@ class ParsedText {
   std::vector<bool> wordContinues;      // true = word attaches to previous with no break
   std::vector<bool> wordNoSpaceBefore;  // true = may break before token, but no synthetic space when joined
   std::vector<bool> wordIsFocusSuffix;  // true = token is the regular tail of a focus bold-prefix split
+  // Zero-based visible Unicode-codepoint offsets in the spine body, stored as
+  // uint16_t deltas from a shared base to keep this layout-only metadata small.
+  // Pathological spans wider than uint16_t use sparse rebases; rendered
+  // TextBlocks do not carry any of this metadata.
+  struct VisibleOffsetRebase {
+    size_t wordIndex;
+    uint32_t base;
+  };
+  std::vector<uint16_t> wordVisibleOffsetDeltas;
+  uint32_t visibleOffsetBase = 0;
+  std::vector<VisibleOffsetRebase> visibleOffsetRebases;
   std::deque<std::string> rubyTexts;
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
@@ -43,6 +54,11 @@ class ParsedText {
   std::vector<bool> reorderedFocusSuffixScratch;
   std::vector<uint16_t> visualOrderScratch;
 
+  uint32_t visibleOffsetBaseAt(size_t wordIndex) const;
+  uint32_t visibleOffsetAt(size_t wordIndex) const;
+  void pushVisibleOffset(uint32_t offset);
+  void insertVisibleOffset(size_t wordIndex, uint32_t offset);
+  void eraseVisibleOffsetPrefix(size_t count);
   int resolveFirstLineIndent(bool isFirstLine, const GfxRenderer& renderer, int fontId) const;
   std::vector<size_t> computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
                                         std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
@@ -55,8 +71,8 @@ class ParsedText {
   void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                    const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
-                   int fontId);
+                   const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
+                   const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
  public:
@@ -70,7 +86,8 @@ class ParsedText {
         hasRtlWord(false) {}
   ~ParsedText() = default;
 
-  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false);
+  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false,
+               uint32_t visibleTextOffset = 0);
   void setRubyForWordAt(size_t index, const std::string& ruby);
   void setRubyGroupAt(size_t startIndex, size_t count, const std::string& ruby);
   EpdFontFamily::Style getWordStyleAt(size_t index) const {
@@ -83,6 +100,6 @@ class ParsedText {
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -30,7 +30,8 @@ namespace {
 //      the scene-break gap, so cached pages laid out by older versions no longer
 //      match. Keeps <br>-per-paragraph books (common CJK formatting) from
 //      re-adding container spacing at every paragraph.
-constexpr uint8_t SECTION_FILE_VERSION = 34;
+// v35: Persist a uint32_t visible-text start offset for every page.
+constexpr uint8_t SECTION_FILE_VERSION = 35;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects
@@ -51,7 +52,7 @@ constexpr uint8_t SECTION_FILE_PARTIAL_VERSION = 0xFE - (SECTION_FILE_VERSION - 
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +
-                                 sizeof(uint32_t) + sizeof(uint32_t);
+                                 sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
 }  // namespace
 
 // Out-of-line so the unique_ptr<ChapterHtmlSlimParser> in BuildContext can be
@@ -99,7 +100,7 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
                                    sizeof(spec.viewportWidth) + sizeof(spec.viewportHeight) + sizeof(pageCount) +
                                    sizeof(spec.hyphenationEnabled) + sizeof(spec.embeddedStyle) +
                                    sizeof(spec.imageRendering) + sizeof(spec.focusReadingEnabled) + sizeof(uint32_t) +
-                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
+                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
                 "Header size mismatch");
   // Written as the incomplete sentinel; finalizeBuild() patches it to
   // SECTION_FILE_VERSION as the last step, committing the file.
@@ -119,6 +120,7 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for anchor map offset (patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for paragraph LUT offset (patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for li LUT offset (patched later)
+  serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for visible-offset LUT (patched later)
 }
 
 bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
@@ -176,13 +178,16 @@ bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
 
   if (filePartial) {
     // A partial's pageCount is the watermark of a suspended build. Read the watermark
-    // trailer (appended after the li LUT) so estimatedTotalPages can extrapolate.
+    // trailer (appended after the visible-offset LUT) so estimatedTotalPages can extrapolate.
     uint32_t liLutOffset = 0;
-    file.seek(HEADER_SIZE - sizeof(uint32_t));
+    file.seek(HEADER_SIZE - sizeof(uint32_t) * 2);
     serialization::readPod(file, liLutOffset);
-    const uint32_t trailerOffset = liLutOffset + static_cast<uint32_t>(pageCount) * sizeof(uint16_t);
-    const bool trailerValid =
-        pageCount > 0 && liLutOffset >= HEADER_SIZE && trailerOffset + 2 * sizeof(uint32_t) <= file.size();
+    uint32_t visibleLutOffset = 0;
+    file.seek(HEADER_SIZE - sizeof(uint32_t));
+    serialization::readPod(file, visibleLutOffset);
+    const uint32_t trailerOffset = visibleLutOffset + static_cast<uint32_t>(pageCount) * sizeof(uint32_t);
+    const bool trailerValid = pageCount > 0 && liLutOffset >= HEADER_SIZE && visibleLutOffset > liLutOffset &&
+                              trailerOffset + 2 * sizeof(uint32_t) <= file.size();
     if (!trailerValid) {
       file.close();
       LOG_ERR("SCT", "Deserialization failed: malformed partial section");
@@ -383,8 +388,10 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
       epub, ctxPtr->parsePath, renderer, spec.fontId, spec.lineCompression, spec.extraParagraphSpacing,
       spec.paragraphAlignment, spec.viewportWidth, spec.viewportHeight, spec.hyphenationEnabled,
       spec.focusReadingEnabled,
-      [this, ctxPtr](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex) {
-        ctxPtr->lut.push_back({this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex});
+      [this, ctxPtr](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
+                     const uint32_t visibleTextOffset) {
+        ctxPtr->lut.push_back(
+            {this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex, visibleTextOffset});
       },
       spec.embeddedStyle, ctxPtr->contentBase, ctxPtr->imageBasePath, spec.imageRendering, std::move(tocAnchors),
       popupFn, ctxPtr->cssParser);
@@ -551,19 +558,25 @@ bool Section::commitBuildFile(const uint8_t version, const uint32_t bytesConsume
     serialization::writePod(file, entry.listItemIndex);
   }
 
+  const uint32_t visibleLutFileOffset = static_cast<uint32_t>(file.position());
+  for (const auto& entry : build_->lut) {
+    serialization::writePod(file, entry.visibleTextOffset);
+  }
+
   if (asPartial) {
-    // Watermark trailer, located on load as liLutOffset + pageCount * sizeof(uint16_t).
+    // Watermark trailer, located on load immediately after the visible-offset LUT.
     serialization::writePod(file, bytesConsumed);
     serialization::writePod(file, totalBytes);
   }
 
   // Patch header with the built page count and section offsets...
-  file.seek(HEADER_SIZE - sizeof(uint32_t) * 4 - sizeof(builtPageCount_));
+  file.seek(HEADER_SIZE - sizeof(uint32_t) * 5 - sizeof(builtPageCount_));
   serialization::writePod(file, builtPageCount_);
   serialization::writePod(file, lutOffset);
   serialization::writePod(file, anchorMapOffset);
   serialization::writePod(file, paragraphLutOffset);
   serialization::writePod(file, liLutFileOffset);
+  serialization::writePod(file, visibleLutFileOffset);
   // ...then commit by overwriting the sentinel version with the real one. Writing the
   // version last makes it the commit point: a crash before here leaves version 0.
   file.seek(0);
@@ -705,7 +718,7 @@ std::unique_ptr<Page> Section::loadPageAt(const int page) const {
     return nullptr;
   }
 
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 4);
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 5);
   uint32_t lutOffset;
   serialization::readPod(f, lutOffset);
   f.seek(lutOffset + sizeof(uint32_t) * page);
@@ -773,7 +786,7 @@ std::optional<uint16_t> Section::getCachedPageCount() const {
     return std::nullopt;
   }
 
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 4 - sizeof(uint16_t));
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 5 - sizeof(uint16_t));
   uint16_t count;
   serialization::readPod(f, count);
   return count;
@@ -786,7 +799,7 @@ std::optional<uint16_t> Section::getPageForAnchor(const std::string& anchor) con
   }
 
   const uint32_t fileSize = f.size();
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 3);
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 4);
   uint32_t anchorMapOffset;
   serialization::readPod(f, anchorMapOffset);
   if (anchorMapOffset == 0 || anchorMapOffset >= fileSize) {
@@ -816,7 +829,7 @@ std::optional<uint16_t> Section::getPageForParagraphIndex(const uint16_t pIndex)
   }
 
   const uint32_t fileSize = f.size();
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 2);
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 3);
   uint32_t paragraphLutOffset;
   serialization::readPod(f, paragraphLutOffset);
   if (paragraphLutOffset == 0 || paragraphLutOffset >= fileSize) {
@@ -855,7 +868,7 @@ std::optional<uint16_t> Section::getParagraphIndexForPage(const uint16_t page) c
   }
 
   const uint32_t fileSize = f.size();
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 2);
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 3);
   uint32_t paragraphLutOffset;
   serialization::readPod(f, paragraphLutOffset);
   if (paragraphLutOffset == 0 || paragraphLutOffset >= fileSize) {
@@ -887,7 +900,7 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
   }
 
   const uint32_t fileSize = f.size();
-  f.seek(HEADER_SIZE - sizeof(uint32_t));
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 2);
   uint32_t liLutOffset;
   serialization::readPod(f, liLutOffset);
   if (liLutOffset == 0 || liLutOffset >= fileSize) {
@@ -895,7 +908,7 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
   }
 
   // The li LUT shares count with the paragraph LUT; read count from paragraphLutOffset
-  f.seek(HEADER_SIZE - sizeof(uint32_t) * 2);
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 3);
   uint32_t paragraphLutOffset;
   serialization::readPod(f, paragraphLutOffset);
   if (paragraphLutOffset == 0 || paragraphLutOffset >= fileSize) {
@@ -926,4 +939,110 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
   }
 
   return resultPage;
+}
+
+std::optional<uint32_t> Section::getVisibleTextOffsetForPage(const uint16_t page) const {
+  if (build_ && page < build_->lut.size()) {
+    return build_->lut[page].visibleTextOffset;
+  }
+
+  HalFile f;
+  if (!Storage.openFileForRead("SCT", filePath, f) || f.size() < HEADER_SIZE) {
+    return std::nullopt;
+  }
+
+  uint8_t version;
+  serialization::readPod(f, version);
+  if (version != SECTION_FILE_VERSION && version != SECTION_FILE_PARTIAL_VERSION) {
+    return std::nullopt;
+  }
+
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 5 - sizeof(uint16_t));
+  uint16_t count;
+  serialization::readPod(f, count);
+  if (page >= count) {
+    return std::nullopt;
+  }
+
+  f.seek(HEADER_SIZE - sizeof(uint32_t));
+  uint32_t visibleLutOffset;
+  serialization::readPod(f, visibleLutOffset);
+  const uint32_t entryOffset = visibleLutOffset + static_cast<uint32_t>(page) * sizeof(uint32_t);
+  if (visibleLutOffset < HEADER_SIZE || entryOffset + sizeof(uint32_t) > f.size()) {
+    return std::nullopt;
+  }
+
+  f.seek(entryOffset);
+  uint32_t result;
+  serialization::readPod(f, result);
+  return result;
+}
+
+std::optional<uint16_t> Section::getPageForVisibleTextOffset(const uint32_t offset,
+                                                             const bool preferFirstAtOffset) const {
+  const auto findInEntries = [offset, preferFirstAtOffset](const auto& entries) -> std::optional<uint16_t> {
+    if (entries.empty()) return std::nullopt;
+    uint16_t result = 0;
+    for (size_t i = 0; i < entries.size(); i++) {
+      const uint32_t pageStart = entries[i].visibleTextOffset;
+      if (preferFirstAtOffset && pageStart == offset) {
+        return static_cast<uint16_t>(i);
+      }
+      if (pageStart > offset) break;
+      result = static_cast<uint16_t>(i);
+    }
+    return result;
+  };
+
+  if (build_ && !build_->lut.empty()) {
+    // Resolve within the active build's known range. Later offsets may still be
+    // covered by an on-disk partial that the resumed build has not reached yet.
+    if (offset <= build_->lut.back().visibleTextOffset) {
+      return findInEntries(build_->lut);
+    }
+  }
+
+  HalFile f;
+  if (!Storage.openFileForRead("SCT", filePath, f) || f.size() < HEADER_SIZE) {
+    return std::nullopt;
+  }
+
+  uint8_t version;
+  serialization::readPod(f, version);
+  if (version != SECTION_FILE_VERSION && version != SECTION_FILE_PARTIAL_VERSION) {
+    return std::nullopt;
+  }
+  const bool partial = version == SECTION_FILE_PARTIAL_VERSION;
+
+  f.seek(HEADER_SIZE - sizeof(uint32_t) * 5 - sizeof(uint16_t));
+  uint16_t count;
+  serialization::readPod(f, count);
+  if (count == 0) {
+    return std::nullopt;
+  }
+
+  f.seek(HEADER_SIZE - sizeof(uint32_t));
+  uint32_t visibleLutOffset;
+  serialization::readPod(f, visibleLutOffset);
+  if (visibleLutOffset < HEADER_SIZE || visibleLutOffset + static_cast<uint32_t>(count) * sizeof(uint32_t) > f.size()) {
+    return std::nullopt;
+  }
+
+  f.seek(visibleLutOffset);
+  uint16_t result = 0;
+  uint32_t lastPageStart = 0;
+  for (uint16_t page = 0; page < count; page++) {
+    uint32_t pageStart;
+    serialization::readPod(f, pageStart);
+    lastPageStart = pageStart;
+    if (preferFirstAtOffset && pageStart == offset) {
+      return page;
+    }
+    if (pageStart > offset) break;
+    result = page;
+  }
+  if (partial && offset > lastPageStart) {
+    return std::nullopt;
+  }
+  return result;
 }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -706,6 +706,9 @@ std::unique_ptr<Page> Section::loadPageDuringBuild(const int page) {
   file.seek(pos);
   auto p = Page::deserialize(file);
   file.seek(writePos);
+  if (p) {
+    p->visibleTextOffset = build_->lut[page].visibleTextOffset;
+  }
   return p;
 }
 
@@ -724,9 +727,26 @@ std::unique_ptr<Page> Section::loadPageAt(const int page) const {
   f.seek(lutOffset + sizeof(uint32_t) * page);
   uint32_t pagePos;
   serialization::readPod(f, pagePos);
-  f.seek(pagePos);
 
-  return Page::deserialize(f);
+  // Read this page's visible-codepoint start offset from the visible-offset LUT (last header slot)
+  // in the same open handle, so the reader can persist progress without reopening the section file
+  // on every page turn (see Page::visibleTextOffset). A malformed/old file leaves it at 0.
+  f.seek(HEADER_SIZE - sizeof(uint32_t));
+  uint32_t visibleLutOffset;
+  serialization::readPod(f, visibleLutOffset);
+  uint32_t visibleTextOffset = 0;
+  const uint32_t visibleEntry = visibleLutOffset + sizeof(uint32_t) * page;
+  if (visibleLutOffset >= HEADER_SIZE && visibleEntry + sizeof(uint32_t) <= f.size()) {
+    f.seek(visibleEntry);
+    serialization::readPod(f, visibleTextOffset);
+  }
+
+  f.seek(pagePos);
+  auto p = Page::deserialize(f);
+  if (p) {
+    p->visibleTextOffset = visibleTextOffset;
+  }
+  return p;
   // No f.close() needed -- DESTRUCTOR_CLOSES_FILE=1 handles it at scope exit
 }
 

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -156,4 +156,14 @@ class Section {
   // preferFirstAtOffset is true, ties caused by zero-width content such as an
   // image-only page select the first page at that offset.
   std::optional<uint16_t> getPageForVisibleTextOffset(uint32_t offset, bool preferFirstAtOffset = false) const;
+
+  // True once the active build has laid out a page starting at or past `offset`, i.e.
+  // getPageForVisibleTextOffset() can resolve it from the build without laying out more.
+  // Lets a caller build to a content target instead of a page number, which is what a
+  // re-pagination needs: the old page index no longer names the same content.
+  // False with no build running -- there is nothing left to wait for, so the on-disk
+  // cache answers directly.
+  bool buildReachedVisibleTextOffset(uint32_t offset) const {
+    return build_ && !build_->lut.empty() && offset <= build_->lut.back().visibleTextOffset;
+  }
 };

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -29,6 +29,7 @@ class Section {
     uint32_t fileOffset;
     uint16_t paragraphIndex;
     uint16_t listItemIndex;
+    uint32_t visibleTextOffset;
   };
   // Held only while an incremental build is in progress (see startBuild). Carries the
   // live parser plus the strings it references (the parser stores them by reference)
@@ -146,4 +147,13 @@ class Section {
 
   // Look up the synthetic paragraph index for the given rendered page.
   std::optional<uint16_t> getParagraphIndexForPage(uint16_t page) const;
+
+  // Exact zero-based visible Unicode-codepoint offset where a rendered page
+  // starts. Available from both an active build and finalized/partial caches.
+  std::optional<uint32_t> getVisibleTextOffsetForPage(uint16_t page) const;
+
+  // Derive the local page containing an exact visible-text offset. When
+  // preferFirstAtOffset is true, ties caused by zero-width content such as an
+  // image-only page select the first page at that offset.
+  std::optional<uint16_t> getPageForVisibleTextOffset(uint32_t offset, bool preferFirstAtOffset = false) const;
 };

--- a/lib/Epub/Epub/VisibleTextUtils.h
+++ b/lib/Epub/Epub/VisibleTextUtils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+
+namespace VisibleTextUtils {
+
+inline bool equalsTag(const std::string_view name, const std::string_view tag) {
+  if (name.size() != tag.size()) return false;
+  for (std::size_t i = 0; i < name.size(); i++) {
+    const char c = name[i] >= 'A' && name[i] <= 'Z' ? static_cast<char>(name[i] + ('a' - 'A')) : name[i];
+    if (c != tag[i]) return false;
+  }
+  return true;
+}
+
+inline bool isNonVisibleElement(const std::string_view name) {
+  return equalsTag(name, "head") || equalsTag(name, "style") || equalsTag(name, "script") || equalsTag(name, "title") ||
+         equalsTag(name, "rp");
+}
+
+}  // namespace VisibleTextUtils

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -15,6 +15,7 @@
 #include "../../../../src/fontIds.h"
 #include "Epub.h"
 #include "Epub/Page.h"
+#include "Epub/VisibleTextUtils.h"
 #include "Epub/converters/ImageDecoderFactory.h"
 #include "Epub/converters/ImageDimsProbe.h"
 #include "Epub/converters/ImageToFramebufferDecoder.h"
@@ -49,8 +50,6 @@ constexpr const char* ITALIC_TAGS[] = {"i", "em"};
 constexpr const char* UNDERLINE_TAGS[] = {"u", "ins"};
 constexpr const char* LINETHROUGH_TAGS[] = {"del", "s", "strike"};
 constexpr const char* IMAGE_TAGS[] = {"img", "image"};
-constexpr const char* SKIP_TAGS[] = {"head", "rp"};
-
 bool isWhitespace(const char c) { return c == ' ' || c == '\r' || c == '\n' || c == '\t'; }
 
 std::string trimAndNormalize(const std::string& str) {
@@ -89,6 +88,8 @@ bool matches(const char* tag_name, const char* const* possible_tags, size_t coun
   }
   return false;
 }
+
+bool isNonVisibleTextTag(const char* name) { return VisibleTextUtils::isNonVisibleElement(name); }
 
 const char* getAttribute(const XML_Char** atts, const char* attrName) {
   if (!atts) return nullptr;
@@ -228,16 +229,25 @@ void ChapterHtmlSlimParser::flushPendingAnchor() {
   // block is flushed so the chapter starts on a fresh page.
   if (std::find(tocAnchors.begin(), tocAnchors.end(), pendingAnchorId) != tocAnchors.end()) {
     if (currentPage && !currentPage->elements.empty()) {
-      completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+      completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
       completedPageCount++;
       currentPage.reset(new Page());
       currentPageNextY = 0;
+      currentPageVisibleOffsetSet = false;
     }
   }
 
   // Record deferred anchor after previous block is flushed (and any TOC page break)
   anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
   pendingAnchorId.clear();
+}
+
+void ChapterHtmlSlimParser::setCurrentPageVisibleOffset(const uint32_t offset) {
+  if (currentPageVisibleOffsetSet) return;
+  // The first page always begins at the start of the body, even when the XHTML
+  // contains leading formatting whitespace before its first rendered word.
+  currentPageVisibleOffset = completedPageCount == 0 ? 0 : offset;
+  currentPageVisibleOffsetSet = true;
 }
 
 // flush the contents of partWordBuffer to currentTextBlock
@@ -263,7 +273,7 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 
   // flush the buffer
   partWordBuffer[partWordBufferIndex] = '\0';
-  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
+  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, partWordVisibleOffset);
   partWordBufferIndex = 0;
   nextWordContinues = false;
   listItemBulletOnly = false;
@@ -352,7 +362,8 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   const int16_t totalHeight = static_cast<int16_t>(topSpacing + ruleThickness + bottomSpacing);
 
   if (!currentPage->elements.empty() && currentPageNextY + totalHeight > viewportHeight) {
-    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    setCurrentPageVisibleOffset(visibleTextOffset);
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
     completedPageCount++;
     currentPage.reset(new (std::nothrow) Page());
     if (!currentPage) {
@@ -360,6 +371,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
       return;
     }
     currentPageNextY = 0;
+    currentPageVisibleOffsetSet = false;
   }
 
   currentPageNextY += topSpacing;
@@ -371,6 +383,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
     return;
   }
   currentPage->elements.push_back(pageRule);
+  setCurrentPageVisibleOffset(visibleTextOffset);
   currentPageNextY = static_cast<int16_t>(currentPageNextY + ruleThickness + bottomSpacing);
 
   if (!pendingAnchorId.empty()) {
@@ -381,6 +394,12 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (strcmp(name, "body") == 0) {
+    self->insideBody = true;
+  }
+  if (self->insideBody && (self->nonVisibleTextDepth > 0 || isNonVisibleTextTag(name))) {
+    self->nonVisibleTextDepth++;
+  }
 
   // Middle of skip
   if (self->skipUntilDepth < self->depth) {
@@ -524,7 +543,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->updateEffectiveInlineStyle();
     const CssTextDecoration savedTextDecoration = self->effectiveTextDecoration;
     self->effectiveTextDecoration = CssTextDecoration::None;
+    self->syntheticCharacterData = true;
     self->characterData(userData, headerText.c_str(), static_cast<int>(headerText.length()));
+    self->syntheticCharacterData = false;
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
     }
@@ -750,7 +771,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                     (self->currentPageNextY + imageMarginTop + displayHeight + imageMarginBottom >
                      self->viewportHeight)) {
                   self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex,
-                                       self->xpathListItemIndex);
+                                       self->xpathListItemIndex, self->currentPageVisibleOffset);
                   self->completedPageCount++;
                   self->currentPage.reset(new Page());
                   if (!self->currentPage) {
@@ -758,6 +779,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                     return;
                   }
                   self->currentPageNextY = 0;
+                  self->currentPageVisibleOffsetSet = false;
                 } else if (!self->currentPage) {
                   self->currentPage.reset(new Page());
                   if (!self->currentPage) {
@@ -765,6 +787,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                     return;
                   }
                   self->currentPageNextY = 0;
+                  self->currentPageVisibleOffsetSet = false;
                 }
 
                 // Apply top margin from container block
@@ -788,6 +811,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   return;
                 }
                 self->currentPage->elements.push_back(pageImage);
+                self->setCurrentPageVisibleOffset(self->visibleTextOffset);
                 self->currentPageNextY += displayHeight + imageMarginBottom;
 
                 // The image consumed the empty block's accumulated vertical spacing.
@@ -820,7 +844,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                                     .withoutBottom());
         self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
         self->depth += 1;
+        self->syntheticCharacterData = true;
         self->characterData(userData, alt.c_str(), alt.length());
+        self->syntheticCharacterData = false;
         // Skip any child content (skip until parent as we pre-advanced depth above)
         self->skipUntilDepth = self->depth - 1;
         return;
@@ -859,7 +885,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     return;
   }
 
-  if (matches(name, SKIP_TAGS, std::size(SKIP_TAGS))) {
+  if (VisibleTextUtils::isNonVisibleElement(name)) {
     // start skip
     self->skipUntilDepth = self->depth;
     self->depth += 1;
@@ -991,7 +1017,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR, false, false, self->visibleTextOffset);
         self->listItemBulletOnly = true;
       }
     }
@@ -1106,6 +1132,16 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
 void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char* s, const int len) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  const bool countVisibleOffsets = self->insideBody && self->nonVisibleTextDepth == 0 && !self->syntheticCharacterData;
+  const uint32_t callbackVisibleOffset = self->visibleTextOffset;
+  if (countVisibleOffsets) {
+    const unsigned char* ptr = reinterpret_cast<const unsigned char*>(s);
+    const unsigned char* end = ptr + len;
+    while (ptr < end) {
+      utf8NextCodepoint(&ptr);
+      self->visibleTextOffset++;
+    }
+  }
 
   // Skip content of nested table
   if (self->tableDepth > 1) {
@@ -1151,7 +1187,13 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     self->currentFootnote.number[self->currentFootnoteLinkTextLen] = '\0';
   }
 
+  uint32_t nextCodepointOffset = callbackVisibleOffset;
   for (int i = 0; i < len; i++) {
+    const uint32_t codepointOffset = nextCodepointOffset;
+    if (countVisibleOffsets && (static_cast<uint8_t>(s[i]) & 0xC0) != 0x80) {
+      nextCodepointOffset++;
+    }
+
     if (isWhitespace(s[i])) {
       // Currently looking at whitespace, if there's anything in the partWordBuffer, flush it
       if (self->partWordBufferIndex > 0) {
@@ -1189,6 +1231,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordBuffer[0] = ' ';
       self->partWordBuffer[1] = '\0';
       self->partWordBufferIndex = 1;
+      self->partWordVisibleOffset = codepointOffset;
       self->nextWordContinues = true;  // Attach space to previous word (no break).
       self->flushPartWordBuffer();
 
@@ -1208,6 +1251,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordBuffer[0] = ' ';
       self->partWordBuffer[1] = '\0';
       self->partWordBufferIndex = 1;
+      self->partWordVisibleOffset = codepointOffset;
       self->nextWordContinues = true;
       self->flushPartWordBuffer();
 
@@ -1242,6 +1286,13 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       if (safeLen < self->partWordBufferIndex && safeLen > 0) {
         // Incomplete UTF-8 sequence at the end — save it before flushing
         int overflow = self->partWordBufferIndex - safeLen;
+        uint32_t overflowVisibleOffset = self->partWordVisibleOffset;
+        const unsigned char* offsetPtr = reinterpret_cast<const unsigned char*>(self->partWordBuffer);
+        const unsigned char* const safeEnd = offsetPtr + safeLen;
+        while (offsetPtr < safeEnd) {
+          utf8NextCodepoint(&offsetPtr);
+          overflowVisibleOffset++;
+        }
         char saved[4];
         for (int j = 0; j < overflow; j++) {
           saved[j] = self->partWordBuffer[safeLen + j];
@@ -1253,12 +1304,16 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
           self->partWordBuffer[j] = saved[j];
         }
         self->partWordBufferIndex = overflow;
+        self->partWordVisibleOffset = overflowVisibleOffset;
       } else {
         self->flushPartWordBuffer();
         self->nextWordContinues = true;
       }
     }
 
+    if (self->partWordBufferIndex == 0) {
+      self->partWordVisibleOffset = codepointOffset;
+    }
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
 
@@ -1276,7 +1331,10 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
                                         : self->viewportWidth;
     self->currentTextBlock->layoutAndExtractLines(
         self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+        [self](const std::shared_ptr<TextBlock>& textBlock, const uint32_t offset) {
+          self->addLineToPage(textBlock, offset);
+        },
+        false);
   }
 }
 
@@ -1298,6 +1356,9 @@ void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const X
 
 void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* name) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (self->nonVisibleTextDepth > 0) {
+    self->nonVisibleTextDepth--;
+  }
 
   // Ruby text: </rt> distributes ruby to base words, </ruby> resets ruby state
   if (strcmp(name, "rt") == 0) {
@@ -1464,6 +1525,9 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       self->listItemBulletOnly = false;
     }
   }
+  if (strcmp(name, "body") == 0) {
+    self->insideBody = false;
+  }
 }
 
 ChapterHtmlSlimParser::~ChapterHtmlSlimParser() { abortParse(); }
@@ -1566,7 +1630,8 @@ bool ChapterHtmlSlimParser::finishParse() {
       anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
       pendingAnchorId.clear();
     }
-    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    setCurrentPageVisibleOffset(visibleTextOffset);
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
     completedPageCount++;
     currentPage.reset();
     currentTextBlock.reset();
@@ -1592,21 +1657,25 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   return finishParse();
 }
 
-void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
+void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const uint32_t visibleOffset) {
   const int lineHeight =
       renderer.getLineHeight(fontId, lineCompression) + line->getRubyShift(renderer.getFontAscenderSize(fontId));
 
   if (!currentPage) {
     currentPage.reset(new Page());
     currentPageNextY = 0;
+    currentPageVisibleOffsetSet = false;
   }
 
   if (currentPageNextY + lineHeight > viewportHeight) {
-    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    setCurrentPageVisibleOffset(visibleOffset);
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
     completedPageCount++;
     currentPage.reset(new Page());
     currentPageNextY = 0;
+    currentPageVisibleOffsetSet = false;
   }
+  setCurrentPageVisibleOffset(visibleOffset);
 
   // Track cumulative words to assign footnotes to the page containing their anchor
   wordsExtractedInBlock += line->wordCount();
@@ -1632,6 +1701,7 @@ void ChapterHtmlSlimParser::makePages() {
   if (!currentPage) {
     currentPage.reset(new Page());
     currentPageNextY = 0;
+    currentPageVisibleOffsetSet = false;
   }
 
   const int lineHeight = renderer.getLineHeight(fontId, lineCompression);
@@ -1652,7 +1722,7 @@ void ChapterHtmlSlimParser::makePages() {
 
   currentTextBlock->layoutAndExtractLines(
       renderer, fontId, effectiveWidth,
-      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
+      [this](const std::shared_ptr<TextBlock>& textBlock, const uint32_t offset) { addLineToPage(textBlock, offset); });
 
   // Fallback: transfer any remaining pending footnotes to current page.
   // Normally addLineToPage handles this via word-index tracking, but this catches

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -394,7 +394,10 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
-  if (strcmp(name, "body") == 0) {
+  if (strcasecmp(name, "body") == 0) {
+    // Case-insensitive to match ParagraphStreamer's tag matching (ProgressMapper). A case
+    // mismatch here would leave visibleTextOffset at 0 for the whole section, so every page
+    // would record offset 0 while the sync resolver still counts a non-zero offset.
     self->insideBody = true;
   }
   if (self->insideBody && (self->nonVisibleTextDepth > 0 || isNonVisibleTextTag(name))) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -26,7 +26,7 @@ class ChapterHtmlSlimParser {
   std::shared_ptr<Epub> epub;
   const std::string& filepath;
   GfxRenderer& renderer;
-  std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn;
+  std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)> completePageFn;
   std::function<void()> popupFn;  // Popup callback
   bool imagePopupFired = false;   // popupFn fired for the first image probe (single-shot)
   int depth = 0;
@@ -95,6 +95,16 @@ class ChapterHtmlSlimParser {
   std::vector<std::string> tocAnchors;  // the list of anchors that are TOC chapter boundaries
   uint16_t xpathParagraphIndex = 0;
   uint16_t xpathListItemIndex = 0;
+  // Canonical reading-position counter: zero-based Unicode codepoints in visible
+  // <body> text. Token offsets flow through line breaking so every completed page
+  // records the first source character it renders.
+  uint32_t visibleTextOffset = 0;
+  uint32_t partWordVisibleOffset = 0;
+  uint32_t currentPageVisibleOffset = 0;
+  bool currentPageVisibleOffsetSet = false;
+  bool insideBody = false;
+  bool syntheticCharacterData = false;
+  uint16_t nonVisibleTextDepth = 0;
 
   // Footnote link tracking
   bool insideFootnoteLink = false;
@@ -118,6 +128,7 @@ class ChapterHtmlSlimParser {
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPendingAnchor();
   void flushPartWordBuffer();
+  void setCurrentPageVisibleOffset(uint32_t offset);
   void makePages();
   static EpdFontFamily::Style fontStyleForTextDecoration(CssTextDecoration decoration);
   static void applyDirectionToEntry(StyleStackEntry& entry, const CssStyle& css);
@@ -131,16 +142,15 @@ class ChapterHtmlSlimParser {
   static void XMLCALL endElement(void* userData, const XML_Char* name);
 
  public:
-  explicit ChapterHtmlSlimParser(std::shared_ptr<Epub> epub, const std::string& filepath, GfxRenderer& renderer,
-                                 const int fontId, const float lineCompression, const bool extraParagraphSpacing,
-                                 const uint8_t paragraphAlignment, const uint16_t viewportWidth,
-                                 const uint16_t viewportHeight, const bool hyphenationEnabled,
-                                 const bool focusReadingEnabled,
-                                 const std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)>& completePageFn,
-                                 const bool embeddedStyle, const std::string& contentBase,
-                                 const std::string& imageBasePath, const uint8_t imageRendering = 0,
-                                 std::vector<std::string> tocAnchors = {},
-                                 const std::function<void()>& popupFn = nullptr, const CssParser* cssParser = nullptr)
+  explicit ChapterHtmlSlimParser(
+      std::shared_ptr<Epub> epub, const std::string& filepath, GfxRenderer& renderer, const int fontId,
+      const float lineCompression, const bool extraParagraphSpacing, const uint8_t paragraphAlignment,
+      const uint16_t viewportWidth, const uint16_t viewportHeight, const bool hyphenationEnabled,
+      const bool focusReadingEnabled,
+      const std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>& completePageFn,
+      const bool embeddedStyle, const std::string& contentBase, const std::string& imageBasePath,
+      const uint8_t imageRendering = 0, std::vector<std::string> tocAnchors = {},
+      const std::function<void()>& popupFn = nullptr, const CssParser* cssParser = nullptr)
 
       : epub(epub),
         filepath(filepath),
@@ -178,7 +188,7 @@ class ChapterHtmlSlimParser {
   bool finishParse();  // flush the trailing page and tear down; returns true
   void abortParse();   // tear down without flushing (error / abandon)
 
-  void addLineToPage(std::shared_ptr<TextBlock> line);
+  void addLineToPage(std::shared_ptr<TextBlock> line, uint32_t visibleOffset);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 
   // Byte progress of the in-flight parse, used to estimate a still-building section's total page

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -97,7 +97,7 @@ void GfxRenderer::ensureSdCardFontReady(int fontId, const char* utf8Text, uint8_
   }
 }
 
-void GfxRenderer::ensureSdCardFontReady(int fontId, const std::vector<std::string>& words, bool includeHyphen,
+void GfxRenderer::ensureSdCardFontReady(int fontId, const std::deque<std::string>& words, bool includeHyphen,
                                         uint8_t styleMask) const {
   auto it = sdCardFonts_.find(fontId);
   if (it != sdCardFonts_.end()) {

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -15,6 +15,7 @@ class FontCacheManager;
 class SdCardFont;
 
 #include <cstring>
+#include <deque>
 #include <map>
 #include <string>
 #include <vector>
@@ -150,7 +151,7 @@ class GfxRenderer {
   // (which holds a const GfxRenderer&) before measuring word widths. Safe to call on non-SD fonts (no-op).
   // styleMask: bitmask of styles to prepare (bit 0=regular, 1=bold, 2=italic, 3=bold-italic).
   void ensureSdCardFontReady(int fontId, const char* utf8Text, uint8_t styleMask = 0x0F) const;
-  void ensureSdCardFontReady(int fontId, const std::vector<std::string>& words, bool includeHyphen,
+  void ensureSdCardFontReady(int fontId, const std::deque<std::string>& words, bool includeHyphen,
                              uint8_t styleMask = 0x0F) const;
 
   // Orientation control (affects logical width/height and coordinate transforms)

--- a/lib/InflateReader/InflateReader.cpp
+++ b/lib/InflateReader/InflateReader.cpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 namespace {
-constexpr size_t INFLATE_DICT_SIZE = 32768;
+constexpr size_t INFLATE_DICT_SIZE = InflateReader::RING_BYTES;
 }
 
 // Guarantee the cast pattern in the header comment is valid.
@@ -19,6 +19,7 @@ bool InflateReader::init(const bool streaming) {
   if (streaming) {
     ringBuffer = static_cast<uint8_t*>(malloc(INFLATE_DICT_SIZE));
     if (!ringBuffer) return false;
+    ownsRing = true;
     memset(ringBuffer, 0, INFLATE_DICT_SIZE);
   }
 
@@ -26,11 +27,20 @@ bool InflateReader::init(const bool streaming) {
   return true;
 }
 
+bool InflateReader::initWithRing(uint8_t* ring) {
+  deinit();  // free any owned ring buffer and reset state
+  if (!ring) return false;
+  ringBuffer = ring;
+  ownsRing = false;  // caller's buffer: never freed here
+  memset(ringBuffer, 0, INFLATE_DICT_SIZE);
+  uzlib_uncompress_init(&decomp, ringBuffer, INFLATE_DICT_SIZE);
+  return true;
+}
+
 void InflateReader::deinit() {
-  if (ringBuffer) {
-    free(ringBuffer);
-    ringBuffer = nullptr;
-  }
+  if (ringBuffer && ownsRing) free(ringBuffer);
+  ringBuffer = nullptr;
+  ownsRing = false;
   memset(&decomp, 0, sizeof(decomp));
 }
 

--- a/lib/InflateReader/InflateReader.h
+++ b/lib/InflateReader/InflateReader.h
@@ -49,12 +49,29 @@ class InflateReader {
   InflateReader(const InflateReader&) = delete;
   InflateReader& operator=(const InflateReader&) = delete;
 
+  // Size of the streaming ring buffer, exposed so callers using initWithRing()
+  // can allocate it themselves.
+  static constexpr size_t RING_BYTES = 32768;
+
   // Initialise decompressor. streaming=true allocates a 32KB ring buffer needed
   // when read() or readAtMost() will be called multiple times.
   // Returns false only in streaming mode if the ring buffer allocation fails.
   bool init(bool streaming = false);
 
-  // Release the ring buffer and reset internal state.
+  // Initialise streaming mode over a caller-owned ring buffer of RING_BYTES.
+  //
+  // Exists for allocation ordering. The ring is by far the largest block a
+  // streaming decode needs, and on a heap where every allocation is carved from
+  // one big free run, taking any smaller buffer first can leave the largest
+  // block just short of 32KB — measured on device at 32756 bytes against a
+  // 32768 requirement. A caller that allocates the ring FIRST, then its own
+  // state, never hits that. The buffer must outlive the reader; deinit() does
+  // not free it.
+  // Returns false if ring is null (e.g. a forwarded failed allocation), leaving
+  // the reader deinitialised.
+  bool initWithRing(uint8_t* ring);
+
+  // Release the ring buffer (only if this reader owns it) and reset state.
   void deinit();
 
   // Set the entire compressed input as a contiguous memory buffer.
@@ -87,4 +104,5 @@ class InflateReader {
  private:
   uzlib_uncomp decomp = {};
   uint8_t* ringBuffer = nullptr;
+  bool ownsRing = false;
 };

--- a/lib/KOReaderSync/KOReaderSyncClient.h
+++ b/lib/KOReaderSync/KOReaderSyncClient.h
@@ -17,11 +17,11 @@ struct KOReaderMetadata {
 /**
  * Rich CrossPoint position sent alongside progress uploads. Maps 1:1 onto the
  * crosspoint-sync extended `position` object (see crosspoint-sync docs/API.md).
- * It is only transmitted to sync.crosspointreader.com, where it makes
- * CrossPoint<->CrossPoint sync lossless instead of xpath-approximated.
+ * It is only transmitted to sync.crosspointreader.com. These fields remain
+ * layout-dependent compatibility hints; the standard XPath is the content anchor.
  */
 struct KOReaderRichPosition {
-  uint32_t pctQ = 0;                       // Percentage quantized 0..1,000,000 (authoritative)
+  uint32_t pctQ = 0;                       // Percentage quantized 0..1,000,000 (metadata/fallback)
   uint16_t spineIndex = 0;                 // Spine (chapter) index
   uint16_t pageNumber = 0;                 // Page within spine (layout-dependent hint)
   uint16_t totalPages = 1;                 // Spine page count (layout-dependent hint)

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -9,6 +9,7 @@
 
 #include "ChapterXPathResolver.h"
 #include "Epub/Section.h"
+#include "Epub/VisibleTextUtils.h"
 #include "Epub/htmlEntities.h"
 #include "Utf8.h"
 
@@ -116,13 +117,25 @@ bool isChapterStartXPath(const std::string& xpath) {
   for (size_t i = dotPos + 1; i < xpath.size(); i++) {
     if (xpath[i] != '0') return false;
   }
-  return true;
+  return parseTextNodeIndex(xpath) <= 1;
+}
+
+bool isBodyTextXPath(const std::string& xpath) {
+  static constexpr char kBodyFrag[] = "/body/DocFragment[";
+  const size_t fragPos = xpath.find(kBodyFrag);
+  if (fragPos == std::string::npos) return false;
+  const size_t afterBracket = xpath.find(']', fragPos + strlen(kBodyFrag));
+  if (afterBracket == std::string::npos) return false;
+  static constexpr char kBody[] = "/body/";
+  if (xpath.compare(afterBracket + 1, strlen(kBody), kBody) != 0) return false;
+  const size_t contentPos = afterBracket + 1 + strlen(kBody);
+  return xpath.compare(contentPos, strlen("text()"), "text()") == 0;
 }
 
 // Parsed representation of one step in the XPath ancestry.
 struct XPathStep {
   char tag[12];      // element name, null-terminated
-  int siblingIndex;  // 1-based sibling index, or 0 if unspecified (treat as 1)
+  int siblingIndex;  // 1-based sibling index, or 0 if unspecified (match any)
 };
 
 static constexpr int MAX_XPATH_DEPTH = 16;
@@ -174,7 +187,7 @@ int parseXPathSteps(const std::string& xpath, XPathStep steps[MAX_XPATH_DEPTH]) 
       }
       step.siblingIndex = idx;
     } else {
-      step.siblingIndex = 1;
+      step.siblingIndex = 0;
     }
 
     count++;
@@ -220,7 +233,9 @@ class ParagraphStreamer final : public Print {
   int siblingCounters[MAX_XPATH_DEPTH] = {};
   bool insideStep[MAX_XPATH_DEPTH] = {};
   int htmlDepth = 0;
+  int bodyHtmlDepth = -1;
   int stepEnteredAtDepth[MAX_XPATH_DEPTH] = {};
+  bool relaxFirstStepDepth = false;
 
   // Tag name accumulation
   enum TagParseState { TAG_IDLE, TAG_IN_NAME, TAG_ATTRS } tagState = TAG_IDLE;
@@ -249,11 +264,10 @@ class ParagraphStreamer final : public Print {
       false;  // true while inside a quoted attribute value (prevents '/' from being treated as self-close)
   char attrQuoteChar = 0;
   uint8_t nonVisibleDepth = 0;
+  bool insideBody = false;
+  bool targetBodyText = false;
 
-  bool isNonVisibleTag() const {
-    return strcasecmp(tagName, "head") == 0 || strcasecmp(tagName, "style") == 0 ||
-           strcasecmp(tagName, "script") == 0 || strcasecmp(tagName, "title") == 0;
-  }
+  bool isNonVisibleTag() const { return VisibleTextUtils::isNonVisibleElement(tagName); }
 
   static bool isAttrWhitespace(uint8_t c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r'; }
 
@@ -383,8 +397,11 @@ class ParagraphStreamer final : public Print {
     if (revPFound && !revDone) {
       // Ancestry mode: count only while inside the fully-matched element and in the target text node.
       // Legacy mode: count only while still inside the matched paragraph and in the target text node.
-      const bool inTargetNode = (stepCount > 0) ? (matchedDepth == stepCount && currentTextNode == targetTextNode)
-                                                : (paragraphHtmlDepth >= 0 && currentTextNode == targetTextNode);
+      const bool inTargetNode =
+          (stepCount > 0)
+              ? (matchedDepth == stepCount && htmlDepth == stepEnteredAtDepth[stepCount - 1] &&
+                 currentTextNode == targetTextNode)
+              : (paragraphHtmlDepth >= 0 && htmlDepth == paragraphHtmlDepth && currentTextNode == targetTextNode);
       if (inTargetNode) {
         revVisChars++;
         if (revVisChars >= revChar) {
@@ -436,6 +453,22 @@ class ParagraphStreamer final : public Print {
   void onOpenTag() {
     htmlDepth++;
 
+    if (strcasecmp(tagName, "body") == 0) {
+      insideBody = true;
+      bodyHtmlDepth = htmlDepth;
+      if (targetBodyText) {
+        revPFound = true;
+        paragraphHtmlDepth = htmlDepth;
+        currentTextNode = 1;
+        if (revChar <= 0 && targetTextNode <= 1) {
+          targetVisChars = totalVisChars;
+          revDone = true;
+        }
+      }
+      return;
+    }
+    if (!insideBody) return;
+
     if (nonVisibleDepth > 0 || isNonVisibleTag()) {
       nonVisibleDepth++;
       return;
@@ -461,10 +494,11 @@ class ParagraphStreamer final : public Print {
       if (strcasecmp(tagName, target.tag) == 0) {
         // Count only direct children of the previously matched ancestor step.
         // For step 0 any depth is valid; subsequent steps must be exactly one level deeper.
-        const bool atCorrectDepth = (matchedDepth == 0) || (htmlDepth == stepEnteredAtDepth[matchedDepth - 1] + 1);
+        const bool atCorrectDepth = (matchedDepth == 0) ? (relaxFirstStepDepth || htmlDepth == bodyHtmlDepth + 1)
+                                                        : (htmlDepth == stepEnteredAtDepth[matchedDepth - 1] + 1);
         if (!atCorrectDepth) return;
         siblingCounters[matchedDepth]++;
-        if (siblingCounters[matchedDepth] == target.siblingIndex) {
+        if (target.siblingIndex == 0 || siblingCounters[matchedDepth] == target.siblingIndex) {
           insideStep[matchedDepth] = true;
           stepEnteredAtDepth[matchedDepth] = htmlDepth;
           matchedDepth++;
@@ -487,6 +521,16 @@ class ParagraphStreamer final : public Print {
   }
 
   void onCloseTag() {
+    if (strcasecmp(tagName, "body") == 0) {
+      insideBody = false;
+      if (htmlDepth > 0) htmlDepth--;
+      return;
+    }
+    if (!insideBody) {
+      if (htmlDepth > 0) htmlDepth--;
+      return;
+    }
+
     if (nonVisibleDepth > 0) {
       nonVisibleDepth--;
       if (htmlDepth > 0) htmlDepth--;
@@ -601,12 +645,19 @@ class ParagraphStreamer final : public Print {
     memset(stepEnteredAtDepth, -1, sizeof(stepEnteredAtDepth));
   }
 
-  ParagraphStreamer(const XPathStep* xpathSteps, int xpathStepCount, int charOff, int textNodeIdx = 1)
+  ParagraphStreamer(const XPathStep* xpathSteps, int xpathStepCount, int charOff, int textNodeIdx = 1,
+                    bool relaxFirstStep = false)
       : fwdTarget(SIZE_MAX),
         revChar(charOff),
         steps(xpathSteps),
         stepCount(xpathStepCount),
-        targetTextNode(textNodeIdx) {
+        targetTextNode(textNodeIdx),
+        relaxFirstStepDepth(relaxFirstStep) {
+    memset(stepEnteredAtDepth, -1, sizeof(stepEnteredAtDepth));
+  }
+
+  ParagraphStreamer(bool resolveBodyText, int charOff, int textNodeIdx)
+      : fwdTarget(SIZE_MAX), revChar(charOff), targetTextNode(textNodeIdx), targetBodyText(resolveBodyText) {
     memset(stepEnteredAtDepth, -1, sizeof(stepEnteredAtDepth));
   }
 
@@ -663,7 +714,7 @@ class ParagraphStreamer final : public Print {
       tagState = TAG_IDLE;
     } else if (globalInTag) {
       processByteInTag(c);
-    } else if (nonVisibleDepth > 0) {
+    } else if (!insideBody || nonVisibleDepth > 0) {
       // Ignore head/style/script/title text. KOReader XPaths are body-relative, and CSS text
       // should not contribute to intra-spine progress.
     } else {
@@ -689,7 +740,7 @@ class ParagraphStreamer final : public Print {
   int getListItemAtMatch() const { return liCountAtMatch; }
   const char* getCapturedAnchorId() const { return capturedAnchorIdLen > 0 ? capturedAnchorId : nullptr; }
   size_t totalBytes() const { return bytesWritten; }
-  bool found() const { return revDone || revPFound; }
+  bool found() const { return revDone; }
   size_t getTotalVisChars() const { return totalVisChars; }
   size_t getTargetVisChars() const { return targetVisChars; }
   float progress() const {
@@ -720,7 +771,7 @@ SavedProgressPosition ProgressMapper::toSavedProgress(const std::shared_ptr<Epub
     result.xpath = generateXPath(epub, pos.spineIndex, intra);
   }
   LOG_DBG("PM", "-> Progress: spine=%d page=%d/%d %.2f%% %s", pos.spineIndex, pos.pageNumber, pos.totalPages,
-          result.percentage * 100, result.xpath.c_str());
+          static_cast<double>(result.percentage * 100), result.xpath.c_str());
   return result;
 }
 
@@ -735,6 +786,17 @@ std::optional<CrossPointPosition> ProgressMapper::fromRichPosition(const std::sh
 
   CrossPointPosition result{};
   result.spineIndex = rich.spineIndex;
+
+  // The existing rich extension carries the same KOReader XPath as the standard
+  // progress field. Resolve that content anchor first; remote page counts are
+  // layout-dependent hints only.
+  if (!rich.xpath.empty()) {
+    SavedProgressPosition saved{rich.xpath, static_cast<float>(rich.pctQ) / 1000000.0f};
+    auto contentMapped = toCrossPoint(epub, saved, renderer);
+    if (contentMapped.hasVisibleTextOffset) {
+      return contentMapped;
+    }
+  }
 
   Section tempSection(epub, result.spineIndex, renderer);
   const auto cachedCount = tempSection.getCachedPageCount();
@@ -798,6 +860,7 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
   const int xpathStepCount = parseXPathSteps(koPos.xpath, xpathSteps);
   // Use ancestry mode whenever the XPath has a structured path (always more accurate than global counting).
   const bool useAncestry = xpathStepCount > 0;
+  const bool useBodyText = !useAncestry && isBodyTextXPath(koPos.xpath);
 
   if (xpathSpine >= 0 && xpathSpine < spineCount) {
     result.spineIndex = xpathSpine;
@@ -835,12 +898,11 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
   }
 
   float intra = 0.0f;
-  bool resolvedIntra = false;
   if (useAncestry) {
-    ParagraphStreamer s(xpathSteps, xpathStepCount, xpathChar, xpathTextNode);
-    if (streamSpine(epub, result.spineIndex, s) && s.found()) {
-      intra = s.progress();
-      resolvedIntra = true;
+    const auto applyResolvedXPath = [&](const ParagraphStreamer& s) {
+      result.visibleTextOffset =
+          static_cast<uint32_t>(std::min<size_t>(s.getTargetVisChars(), static_cast<size_t>(UINT32_MAX)));
+      result.hasVisibleTextOffset = true;
       const int pAtMatch = s.getParagraphAtMatch();
       if (pAtMatch > 0) {
         result.paragraphIndex = static_cast<uint16_t>(pAtMatch);
@@ -859,27 +921,65 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
       }
       LOG_DBG("PM", "XPath ancestry(%s[%d])/text()[%d]+%d -> %.1f%% (target=%zu total=%zu p~%d li~%d anchor=%s)",
               xpathSteps[xpathStepCount - 1].tag, xpathSteps[xpathStepCount - 1].siblingIndex, xpathTextNode, xpathChar,
-              intra * 100, s.getTargetVisChars(), s.getTotalVisChars(), pAtMatch,
+              s.progress() * 100, s.getTargetVisChars(), s.getTotalVisChars(), pAtMatch,
               result.hasLiIndex ? static_cast<int>(result.liIndex) : 0, anchorId ? anchorId : "none");
+    };
+
+    ParagraphStreamer strict(xpathSteps, xpathStepCount, xpathChar, xpathTextNode);
+    if (streamSpine(epub, result.spineIndex, strict) && strict.found()) {
+      applyResolvedXPath(strict);
+    } else {
+      // Some KOReader producers omit an unindexed wrapper from the ancestry
+      // (the compatibility case covered by PR #2777). Retry only after the
+      // structurally exact path fails, allowing the first step at any body depth.
+      ParagraphStreamer relaxed(xpathSteps, xpathStepCount, xpathChar, xpathTextNode, true);
+      if (streamSpine(epub, result.spineIndex, relaxed) && relaxed.found()) {
+        applyResolvedXPath(relaxed);
+      }
+    }
+  } else if (useBodyText) {
+    ParagraphStreamer s(true, xpathChar, xpathTextNode);
+    if (streamSpine(epub, result.spineIndex, s) && s.found()) {
+      result.visibleTextOffset =
+          static_cast<uint32_t>(std::min<size_t>(s.getTargetVisChars(), static_cast<size_t>(UINT32_MAX)));
+      result.hasVisibleTextOffset = true;
+      LOG_DBG("PM", "XPath body/text()[%d]+%d -> offset=%u", xpathTextNode, xpathChar, result.visibleTextOffset);
     }
   } else if (xpathP > 0) {
     ParagraphStreamer s(xpathP, xpathChar, xpathTextNode);
     if (streamSpine(epub, result.spineIndex, s) && s.found()) {
-      intra = s.progress();
-      resolvedIntra = true;
+      result.visibleTextOffset =
+          static_cast<uint32_t>(std::min<size_t>(s.getTargetVisChars(), static_cast<size_t>(UINT32_MAX)));
+      result.hasVisibleTextOffset = true;
       LOG_DBG("PM", "XPath p[%d]/text()[%d]+%d -> %.1f%% (target=%zu total=%zu)", xpathP, xpathTextNode, xpathChar,
-              intra * 100, s.getTargetVisChars(), s.getTotalVisChars());
+              s.progress() * 100, s.getTargetVisChars(), s.getTotalVisChars());
     }
   }
-  if (!resolvedIntra && xpathSpine >= 0 && xpathSpine < spineCount && isChapterStartXPath(koPos.xpath)) {
-    intra = 0.0f;
-    resolvedIntra = true;
+  if (xpathSpine >= 0 && xpathSpine < spineCount && isChapterStartXPath(koPos.xpath)) {
+    result.visibleTextOffset = 0;
+    result.hasVisibleTextOffset = true;
     LOG_DBG("PM", "Chapter-start XPath %s -> spine=%d page start", koPos.xpath.c_str(), result.spineIndex);
   }
-  if (!resolvedIntra) {
-    const size_t bytesIn = (targetBytes > prevCum) ? (targetBytes - prevCum) : 0;
-    intra = std::max(0.0f, std::min(1.0f, static_cast<float>(bytesIn) / static_cast<float>(spineSize)));
+  if (result.hasVisibleTextOffset) {
+    Section tempSection(epub, result.spineIndex, renderer);
+    const bool imageAnchor = useAncestry && (strcasecmp(xpathSteps[xpathStepCount - 1].tag, "img") == 0 ||
+                                             strcasecmp(xpathSteps[xpathStepCount - 1].tag, "image") == 0);
+    if (const auto offsetPage = tempSection.getPageForVisibleTextOffset(result.visibleTextOffset, imageAnchor)) {
+      result.pageNumber = *offsetPage;
+      result.totalPages = std::max(result.totalPages, result.pageNumber + 1);
+      LOG_DBG("PM", "XPath content offset %u -> spine=%d page=%d/%d", result.visibleTextOffset, result.spineIndex,
+              result.pageNumber, result.totalPages);
+      return result;
+    }
+    // A valid content anchor without a local pagination LUT cannot yet be turned
+    // into a page. Retain it on the result, but use protocol percentage for the
+    // immediate page fallback.
+    LOG_DBG("PM", "No page-offset LUT for spine=%d offset=%u; using percentage fallback", result.spineIndex,
+            result.visibleTextOffset);
   }
+  const size_t bytesIn = (targetBytes > prevCum) ? (targetBytes - prevCum) : 0;
+  intra = spineSize > 0 ? std::max(0.0f, std::min(1.0f, static_cast<float>(bytesIn) / static_cast<float>(spineSize)))
+                        : 0.0f;
 
   result.pageNumber = std::max(
       0, std::min(static_cast<int>(intra * static_cast<float>(result.totalPages - 1) + 0.5f), result.totalPages - 1));

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -203,6 +203,7 @@ class ParagraphStreamer final : public Print {
   static constexpr size_t MAX_ENTITY_SIZE = 16;
   char entityBuffer[MAX_ENTITY_SIZE] = {};
   size_t entityLen = 0;
+  bool prevCR = false;  // last counted visible byte was a CR (XML line-ending normalization)
 
   // Forward mode: count <p> paragraphs at a byte offset (legacy, used by generateXPath)
   size_t fwdTarget;
@@ -430,6 +431,10 @@ class ParagraphStreamer final : public Print {
     const char* resolved = lookupHtmlEntity(entityBuffer, entityLen);
     if (resolved)
       onVisibleText(resolved);
+    else if (entityLen >= 3 && entityBuffer[1] == '#')
+      // Numeric character reference (&#NNN; / &#xHH;): expat -- which builds the page LUT --
+      // decodes it to a single codepoint. Count one here too, not the raw "&#NNN" characters.
+      onVisibleCodepoint();
     else
       flushEntityAsLiteral();
     globalInEntity = false;
@@ -688,6 +693,13 @@ class ParagraphStreamer final : public Print {
       return 1;
     }
 
+    // XML 1.0 §2.11 line-ending normalization: expat (which builds the page LUT) collapses a
+    // "\r\n" pair and a lone "\r" to a single "\n". Mirror that so this byte counter -- which the
+    // resolved offset is measured against -- stays codepoint-for-codepoint identical. prevCR is
+    // set only by the visible-text branch below, so any non-text byte clears it here.
+    const bool afterCR = prevCR;
+    prevCR = false;
+
     if (c == '<') {
       globalInTag = true;
       tagState = TAG_IDLE;
@@ -722,9 +734,12 @@ class ParagraphStreamer final : public Print {
         globalInEntity = true;
         entityBuffer[0] = '&';
         entityLen = 1;
+      } else if (c == '\n' && afterCR) {
+        // Second half of a CRLF: the newline was already counted on the preceding CR.
       } else {
         const bool startsCodepoint = (c & 0xC0) != 0x80;
         if (startsCodepoint) onVisibleCodepoint();
+        prevCR = (c == '\r');  // a lone/leading CR is the newline; swallow any '\n' that follows
       }
     }
     return 1;
@@ -777,7 +792,7 @@ SavedProgressPosition ProgressMapper::toSavedProgress(const std::shared_ptr<Epub
 
 std::optional<CrossPointPosition> ProgressMapper::fromRichPosition(const std::shared_ptr<Epub>& epub,
                                                                    const KOReaderRichPosition& rich,
-                                                                   GfxRenderer& renderer) {
+                                                                   GfxRenderer& renderer, bool xpathAlreadyTried) {
   const int spineCount = epub->getSpineItemsCount();
   if (static_cast<int>(rich.spineIndex) >= spineCount) {
     LOG_DBG("PM", "Rich position spine %u out of range (%d spine items)", rich.spineIndex, spineCount);
@@ -789,8 +804,9 @@ std::optional<CrossPointPosition> ProgressMapper::fromRichPosition(const std::sh
 
   // The existing rich extension carries the same KOReader XPath as the standard
   // progress field. Resolve that content anchor first; remote page counts are
-  // layout-dependent hints only.
-  if (!rich.xpath.empty()) {
+  // layout-dependent hints only. Skip it when the caller already resolved this exact
+  // XPath -- re-streaming the same chapter for the same failure is pure waste.
+  if (!xpathAlreadyTried && !rich.xpath.empty()) {
     SavedProgressPosition saved{rich.xpath, static_cast<float>(rich.pctQ) / 1000000.0f};
     auto contentMapped = toCrossPoint(epub, saved, renderer);
     if (contentMapped.hasVisibleTextOffset) {
@@ -955,7 +971,9 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
               s.progress() * 100, s.getTargetVisChars(), s.getTotalVisChars());
     }
   }
-  if (xpathSpine >= 0 && xpathSpine < spineCount && isChapterStartXPath(koPos.xpath)) {
+  if (!result.hasVisibleTextOffset && xpathSpine >= 0 && xpathSpine < spineCount && isChapterStartXPath(koPos.xpath)) {
+    // Only fall back to "chapter start" when no intra-chapter offset was resolved above --
+    // otherwise a resolved deep position (e.g. body/div[3]/text().0) would be clobbered to page 0.
     result.visibleTextOffset = 0;
     result.hasVisibleTextOffset = true;
     LOG_DBG("PM", "Chapter-start XPath %s -> spine=%d page start", koPos.xpath.c_str(), result.spineIndex);

--- a/lib/KOReaderSync/ProgressMapper.h
+++ b/lib/KOReaderSync/ProgressMapper.h
@@ -15,6 +15,8 @@ struct CrossPointPosition {
   int spineIndex;                  // Current spine item (chapter) index
   int pageNumber;                  // Current page within the spine item
   int totalPages;                  // Total pages in the current spine item
+  uint32_t visibleTextOffset = 0;  // Authoritative zero-based visible codepoint offset
+  bool hasVisibleTextOffset = false;
   uint16_t paragraphIndex = 0;     // 1-based synthetic paragraph index from XPath p[N]
   bool hasParagraphIndex = false;  // True when paragraphIndex was resolved from XPath
   uint16_t liIndex = 0;            // Running <li> count at the matched XPath element
@@ -33,12 +35,13 @@ struct SavedProgressPosition {
 /**
  * Maps between CrossPoint and SavedProgress position formats, such as those used by KOReader.
  *
- * CrossPoint tracks position as (spineIndex, pageNumber).
+ * CrossPoint tracks position as (spineIndex, visibleTextOffset). Page number is
+ * derived from the current section layout.
  * SavedProgress uses XPath-like strings + percentage.
  *
- * Since CrossPoint discards HTML structure during parsing, we generate
- * synthetic XPath strings based on spine index, using percentage as the
- * primary sync mechanism.
+ * The section cache records page-start visible offsets during pagination. The
+ * same body-text counting rules are used to generate and resolve KOReader
+ * XPaths. Percentage remains metadata and a fallback only.
  */
 class ProgressMapper {
  public:
@@ -70,10 +73,9 @@ class ProgressMapper {
 
   /**
    * Convert a rich CrossPoint position (downloaded from a crosspoint-sync
-   * server) directly to a CrossPoint position, without XPath approximation.
-   * When the local layout matches the uploader's (same spine page count) the
-   * page transfers losslessly; otherwise the paragraph LUT or the intra-spine
-   * page fraction is used.
+   * server) directly to a CrossPoint position. Its standard KOReader XPath is
+   * resolved to a content offset first; legacy spine/page/paragraph hints are
+   * used only when that content anchor cannot be applied.
    *
    * @return The position, or std::nullopt when the rich position cannot be
    *         applied (spine out of range, no section cache) and the caller

--- a/lib/KOReaderSync/ProgressMapper.h
+++ b/lib/KOReaderSync/ProgressMapper.h
@@ -77,12 +77,16 @@ class ProgressMapper {
    * resolved to a content offset first; legacy spine/page/paragraph hints are
    * used only when that content anchor cannot be applied.
    *
+   * @param xpathAlreadyTried when true, skip re-resolving rich.xpath and go straight to the
+   *        legacy page hints. The caller sets this when it just resolved the identical XPath via
+   *        toCrossPoint(), so retrying it here would decompress the chapter twice for nothing.
    * @return The position, or std::nullopt when the rich position cannot be
    *         applied (spine out of range, no section cache) and the caller
    *         should fall back to toCrossPoint().
    */
   static std::optional<CrossPointPosition> fromRichPosition(const std::shared_ptr<Epub>& epub,
-                                                            const KOReaderRichPosition& rich, GfxRenderer& renderer);
+                                                            const KOReaderRichPosition& rich, GfxRenderer& renderer,
+                                                            bool xpathAlreadyTried = false);
 
  private:
   /**

--- a/lib/MiniBidi/BidiUtils.cpp
+++ b/lib/MiniBidi/BidiUtils.cpp
@@ -34,6 +34,12 @@ bool isNaturalDirectionClass(const uchar cls) {
   }
 }
 
+// Visual-reorder scratch shared by applyBidiVisual() and
+// computeVisualWordOrder(). Neither function calls the other, and bidiMutex
+// already serialises both, so a single buffer serves both instead of a
+// per-function static — saving ~1.5 KB of always-resident RAM.
+bidi_char sharedBidiLine[BIDI_MAX_LINE];
+
 }  // namespace
 
 namespace BidiUtils {
@@ -89,7 +95,7 @@ bool applyBidiVisual(const char* utf8, std::string& out, int paragraphLevel) {
   if (!utf8 || !*utf8) return false;
   const std::lock_guard<std::mutex> lock(bidiMutex);
 
-  static bidi_char line[BIDI_MAX_LINE];
+  bidi_char* const line = sharedBidiLine;
   static bidi_char shaped[BIDI_MAX_LINE];
   int count = 0;
   int lastBase = -1;           // last non-formatter character (mintty's ibase)
@@ -176,7 +182,7 @@ bool computeVisualWordOrder(const std::vector<std::string>& words, bool paragrap
   if (nWords <= 1 || nWords > BIDI_MAX_LINE) return false;
   const std::lock_guard<std::mutex> lock(bidiMutex);
 
-  static bidi_char line[BIDI_MAX_LINE];
+  bidi_char* const line = sharedBidiLine;
   int count = 0;
   bool truncated = false;
 

--- a/src/BookmarkEntry.h
+++ b/src/BookmarkEntry.h
@@ -11,4 +11,10 @@ struct BookmarkEntry {
   uint16_t computedSpineIndex = 0;        // Spine index at the time of bookmarking
   uint16_t computedChapterPageCount = 0;  // Total page count of the chapter at the time of bookmarking
   uint16_t computedChapterProgress = 0;   // Number of pages into the chapter at the time of bookmarking
+
+  // Exact visible-codepoint offset of the bookmarked page within its spine. Unlike the page
+  // number above it is immune to re-pagination, so it lands on the right page under any
+  // font/margin/orientation. Absent (hasVisibleTextOffset == false) for pre-offset bookmarks.
+  bool hasVisibleTextOffset = false;
+  uint32_t visibleTextOffset = 0;
 };

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -17,6 +17,38 @@ bool MappedInputManager::isNavDirectionSwapped() const {
          (orientation == GfxRenderer::PortraitInverted || orientation == GfxRenderer::LandscapeCounterClockwise);
 }
 
+MappedInputManager::Button MappedInputManager::mapScreenDirection(const Button button) const {
+  // Rows follow GfxRenderer::Orientation's declared order.
+  static constexpr Button directions[][4] = {
+      {Button::Left, Button::Right, Button::Up, Button::Down},
+      {Button::Down, Button::Up, Button::Left, Button::Right},
+      {Button::Right, Button::Left, Button::Down, Button::Up},
+      {Button::Up, Button::Down, Button::Right, Button::Left},
+  };
+
+  uint8_t direction = 0;
+  switch (button) {
+    case Button::ScreenLeft:
+      direction = 0;
+      break;
+    case Button::ScreenRight:
+      direction = 1;
+      break;
+    case Button::ScreenUp:
+      direction = 2;
+      break;
+    case Button::ScreenDown:
+      direction = 3;
+      break;
+    default:
+      return button;
+  }
+
+  const uint8_t orientation =
+      SETTINGS.frontButtonFollowOrientation ? static_cast<uint8_t>(renderer.getOrientation()) : 0;
+  return directions[orientation][direction];
+}
+
 bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {
   const auto sideLayout = SETTINGS.sideButtonLayout;
 
@@ -73,6 +105,11 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       // Logical "previous item" navigation: side Up + front Left, axis-flipped in the same orientations.
       return isNavDirectionSwapped() ? (mapButton(Button::Down, fn) || mapButton(Button::Right, fn))
                                      : (mapButton(Button::Up, fn) || mapButton(Button::Left, fn));
+    case Button::ScreenLeft:
+    case Button::ScreenRight:
+    case Button::ScreenUp:
+    case Button::ScreenDown:
+      return mapButton(mapScreenDirection(button), fn);
   }
 
   return false;
@@ -304,6 +341,24 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
   const char* leftLabel = swapLabels ? next : previous;
   const char* rightLabel = swapLabels ? previous : next;
 
+  return mapFrontLabels(back, confirm, leftLabel, rightLabel);
+}
+
+MappedInputManager::Labels MappedInputManager::mapDirectionalLabels(const char* back, const char* confirm,
+                                                                    const char* left, const char* right, const char* up,
+                                                                    const char* down) const {
+  const auto labelForButton = [&](const Button rawButton) {
+    if (mapScreenDirection(Button::ScreenLeft) == rawButton) return left;
+    if (mapScreenDirection(Button::ScreenRight) == rawButton) return right;
+    if (mapScreenDirection(Button::ScreenUp) == rawButton) return up;
+    if (mapScreenDirection(Button::ScreenDown) == rawButton) return down;
+    return "";
+  };
+  return mapFrontLabels(back, confirm, labelForButton(Button::Left), labelForButton(Button::Right));
+}
+
+MappedInputManager::Labels MappedInputManager::mapFrontLabels(const char* back, const char* confirm, const char* left,
+                                                              const char* right) const {
   // Build the label order based on the configured hardware mapping.
   auto labelForHardware = [&](uint8_t hw) -> const char* {
     // Compare against configured logical roles and return the matching label.
@@ -314,10 +369,10 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
       return confirm;
     }
     if (hw == SETTINGS.frontButtonLeft) {
-      return leftLabel;
+      return left;
     }
     if (hw == SETTINGS.frontButtonRight) {
-      return rightLabel;
+      return right;
     }
     return "";
   };

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -6,7 +6,23 @@ class GfxRenderer;
 
 class MappedInputManager {
  public:
-  enum class Button { Back, Confirm, Left, Right, Up, Down, Power, PageBack, PageForward, NavNext, NavPrevious };
+  enum class Button {
+    Back,
+    Confirm,
+    Left,
+    Right,
+    Up,
+    Down,
+    Power,
+    PageBack,
+    PageForward,
+    NavNext,
+    NavPrevious,
+    ScreenLeft,
+    ScreenRight,
+    ScreenUp,
+    ScreenDown
+  };
   enum class SwipeDir { None, Left, Right, Up, Down };
 
   struct Labels {
@@ -52,6 +68,10 @@ class MappedInputManager {
   unsigned long getHeldTime() const;
   const GfxRenderer& getRenderer() const { return renderer; }
   Labels mapLabels(const char* back, const char* confirm, const char* previous, const char* next) const;
+  // Maps four screen-direction labels onto the two physical front-button roles
+  // using the same live-orientation transform as ScreenLeft/Right/Up/Down.
+  Labels mapDirectionalLabels(const char* back, const char* confirm, const char* left, const char* right,
+                              const char* up, const char* down) const;
   // Returns the raw front button index that was pressed this frame (or -1 if none).
   int getPressedFrontButton() const;
 
@@ -70,6 +90,8 @@ class MappedInputManager {
   // preference and stays "rotated" even while portrait UI like home/settings is on screen.
   const GfxRenderer& renderer;
 
+  Button mapScreenDirection(Button button) const;
+  Labels mapFrontLabels(const char* back, const char* confirm, const char* left, const char* right) const;
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;
   bool wasBackGesture() const;
   // Fetch the pending swipe (if any) and map both endpoints to logical screen coords

--- a/src/activities/ActivityResult.h
+++ b/src/activities/ActivityResult.h
@@ -47,6 +47,10 @@ struct ProgressChangeResult {
   std::string xpath;
   float percentage = 0.0f;
   bool hasSavedProgress = false;
+  // Exact visible-codepoint offset within spineIndex, when the source (a bookmark) has one.
+  // Preferred over xpath/percentage on resolution: it is immune to re-pagination.
+  bool hasVisibleTextOffset = false;
+  uint32_t visibleTextOffset = 0;
 };
 
 enum class NetworkMode;

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -263,16 +263,16 @@ void DictionaryWordSelectActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Left) && selected > 0) {
+  const bool hasNextWord = selected + 1 < static_cast<int>(words.size());
+  if (mappedInput.wasPressed(MappedInputManager::Button::ScreenLeft) && selected > 0) {
     selected--;
     requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Right) &&
-             selected + 1 < static_cast<int>(words.size())) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenRight) && hasNextWord) {
     selected++;
     requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenUp)) {
     moveVertical(-1);
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenDown)) {
     moveVertical(1);
   }
 }
@@ -315,11 +315,10 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
 // Front-button bar (Back/Confirm/Left/Right). Drawn last on every repaint
 // path, including the differential highlight-only path, so it always ends
 // up as the top layer even when a highlighted word's box falls under a
-// hint's screen area. No side-button hints: Up/Down row jump has no spare
-// screen area on this page (it reuses the reader's full-bleed layout), and
-// a hint box there would hide text instead of sitting in a reserved gutter.
+// hint's screen area. No side-button hints: the full-bleed reader page has no
+// spare gutter for them, so a hint box there would hide text.
 void DictionaryWordSelectActivity::drawHints() const {
-  // No selectable word on this page: Confirm/Left/Right are all no-ops
+  // No selectable word on this page: Confirm and navigation are all no-ops
   // (guarded by words.empty() in loop()/performLookup), so only Back does
   // anything and only Back is hinted.
   if (words.empty()) {
@@ -327,7 +326,8 @@ void DictionaryWordSelectActivity::drawHints() const {
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     return;
   }
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_LOOKUP), tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT));
+  const auto labels = mappedInput.mapDirectionalLabels(tr(STR_BACK), tr(STR_LOOKUP), tr(STR_DIR_LEFT),
+                                                       tr(STR_DIR_RIGHT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 }
 

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -155,14 +155,20 @@ void DictionaryWordSelectActivity::performLookup() {
   if (!dictOpenAttempted) {
     dictOpenAttempted = true;
     dictOpenOk = dict.open(SETTINGS.dictionaryName);
+    // needsIndex() opens and validates the .qidx sidecar, so ask it once per
+    // open rather than once per word: the answer only changes when we build
+    // the sidecar ourselves, which is handled below.
+    dictNeedsIndex = dictOpenOk && dict.needsIndex();
   }
-  const bool indexing = dictOpenOk && dict.needsIndex();
-  popupMsg = indexing ? StrId::STR_DICT_INDEXING : StrId::STR_DICT_LOOKING_UP;
+  popupMsg = dictNeedsIndex ? StrId::STR_DICT_INDEXING : StrId::STR_DICT_LOOKING_UP;
   requestUpdateAndWait();  // paint the page + busy popup before blocking on SD
 
   bool ok = dictOpenOk;
   Dictionary::IndexResult indexResult = Dictionary::IndexResult::Ok;
-  if (ok && indexing) ok = dict.buildIndex(&indexBuildYield, nullptr, &indexResult);
+  if (ok && dictNeedsIndex) {
+    ok = dict.buildIndex(&indexBuildYield, nullptr, &indexResult);
+    dictNeedsIndex = !ok;  // a successful build leaves the sidecar fresh; a failed one retries
+  }
 
   std::string definition;
   std::string headword;

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -61,6 +61,7 @@ class DictionaryWordSelectActivity final : public Activity {
   Dictionary dict;
   bool dictOpenAttempted = false;
   bool dictOpenOk = false;
+  bool dictNeedsIndex = false;
 
   Popup popup = Popup::None;
   StrId popupMsg = StrId::STR_DICT_NOT_FOUND;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -173,9 +173,9 @@ void EpubReaderActivity::onEnter() {
 
   HalFile f;
   if (Storage.openFileForRead("ERS", epub->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[6];
-    int dataSize = f.read(data, 6);
-    if (dataSize == 4 || dataSize == 6) {
+    uint8_t data[10];
+    int dataSize = f.read(data, sizeof(data));
+    if (dataSize == 4 || dataSize == 6 || dataSize == 10) {
       currentSpineIndex = data[0] + (data[1] << 8);
       nextPageNumber = data[2] + (data[3] << 8);
       if (nextPageNumber == UINT16_MAX) {
@@ -190,6 +190,10 @@ void EpubReaderActivity::onEnter() {
     }
     if (dataSize == 6) {
       cachedChapterTotalPageCount = data[4] + (data[5] << 8);
+    } else if (dataSize == 10) {
+      cachedChapterTotalPageCount = data[4] + (data[5] << 8);
+      cachedVisibleTextOffset = static_cast<uint32_t>(data[6]) | (static_cast<uint32_t>(data[7]) << 8) |
+                                (static_cast<uint32_t>(data[8]) << 16) | (static_cast<uint32_t>(data[9]) << 24);
     }
   }
   // We may want a better condition to detect if we are opening for the first time.
@@ -198,6 +202,7 @@ void EpubReaderActivity::onEnter() {
     int textSpineIndex = epub->getSpineIndexForTextReference();
     if (textSpineIndex != 0) {
       currentSpineIndex = textSpineIndex;
+      cachedVisibleTextOffset.reset();
       LOG_DBG("ERS", "Opened for first time, navigating to text reference at index %d", textSpineIndex);
     }
   }
@@ -817,6 +822,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
                                // applyOrientation()'s reflow.
                                RenderLock lock(*this);
                                if (section) {
+                                 rememberCurrentContentOffset();
                                  cachedSpineIndex = currentSpineIndex;
                                  cachedChapterTotalPageCount = section->pageCount;
                                  nextPageNumber = section->currentPage;
@@ -967,6 +973,7 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
   {
     RenderLock lock(*this);
     if (section) {
+      rememberCurrentContentOffset();
       cachedSpineIndex = currentSpineIndex;
       cachedChapterTotalPageCount = section->pageCount;
       nextPageNumber = section->currentPage;
@@ -1001,6 +1008,7 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
     // Preserve current reading position so we can restore after reflow.
     RenderLock lock(*this);
     if (section) {
+      rememberCurrentContentOffset();
       cachedSpineIndex = currentSpineIndex;
       cachedChapterTotalPageCount = section->pageCount;
       nextPageNumber = section->currentPage;
@@ -1135,6 +1143,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       // saved while the section was still building (i.e. a watermark, not the real count)
       // would remap the resume page against the finalized count and teleport the reader.
       cachedChapterTotalPageCount = 0;
+      cachedVisibleTextOffset.reset();
     }
     const bool cacheComplete = cacheLoaded && !section->isPartial();
     if (!cacheComplete) {
@@ -1450,16 +1459,25 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 }
 
 bool EpubReaderActivity::applyDeferredReposition() {
-  if (cachedChapterTotalPageCount == 0 || !section || section->isBuilding()) {
+  if ((!cachedVisibleTextOffset.has_value() && cachedChapterTotalPageCount == 0) || !section || section->isBuilding()) {
     return false;
   }
   bool changed = false;
-  // Only remap when the chapter actually re-paginated (e.g. after a settings change). A plain
-  // resume has identical pagination, so section->pageCount == cachedChapterTotalPageCount and
-  // nothing moves.
-  if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
-    const float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
-    int newPage = static_cast<int>(progress * static_cast<float>(section->pageCount));
+  // Re-derive the page from the saved content offset after a settings reflow.
+  // Older 4/6-byte progress files retain the page-fraction fallback.
+  if (currentSpineIndex == cachedSpineIndex) {
+    int newPage = section->currentPage;
+    bool mappedOffset = false;
+    if (cachedVisibleTextOffset.has_value()) {
+      if (const auto offsetPage = section->getPageForVisibleTextOffset(*cachedVisibleTextOffset)) {
+        newPage = *offsetPage;
+        mappedOffset = true;
+      }
+    }
+    if (!mappedOffset && cachedChapterTotalPageCount > 0 && section->pageCount != cachedChapterTotalPageCount) {
+      const float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
+      newPage = static_cast<int>(progress * static_cast<float>(section->pageCount));
+    }
     if (newPage < 0) newPage = 0;
     if (section->pageCount > 0 && newPage >= static_cast<int>(section->pageCount)) {
       newPage = section->pageCount - 1;
@@ -1470,11 +1488,23 @@ bool EpubReaderActivity::applyDeferredReposition() {
     }
   }
   cachedChapterTotalPageCount = 0;  // consumed; don't read cached progress again
+  cachedVisibleTextOffset.reset();
   return changed;
 }
 
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {
-  return EpubReaderUtils::saveProgress(*epub, spineIndex, currentPage, pageCount);
+  std::optional<uint32_t> offset;
+  if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
+    offset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage));
+  }
+  return EpubReaderUtils::saveProgress(*epub, spineIndex, currentPage, pageCount, offset);
+}
+
+void EpubReaderActivity::rememberCurrentContentOffset() {
+  cachedVisibleTextOffset.reset();
+  if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
+    cachedVisibleTextOffset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(section->currentPage));
+  }
 }
 void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int orientedMarginTop,
                                         const int orientedMarginRight, const int orientedMarginBottom,
@@ -1970,6 +2000,12 @@ CrossPointPosition EpubReaderActivity::getCurrentPosition() const {
   }
 
   CrossPointPosition localPos = {currentSpineIndex, currentPage, totalPages};
+  if (section && currentPage >= 0 && currentPage < section->pageCount) {
+    if (const auto offset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage))) {
+      localPos.visibleTextOffset = *offset;
+      localPos.hasVisibleTextOffset = true;
+    }
+  }
   if (paragraphIndex.has_value()) {
     localPos.paragraphIndex = *paragraphIndex;
     localPos.hasParagraphIndex = true;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -747,6 +747,26 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     loadCachedBookmarks();
     if (!result.isCancelled) {
       const auto& sync = std::get<ProgressChangeResult>(result.data);
+
+      // Preferred path: a bookmark carrying an exact content offset. It is immune to
+      // re-pagination, so resolve by content instead of trusting a page number saved under
+      // possibly-different settings.
+      if (sync.hasVisibleTextOffset && sync.spineIndex >= 0 && sync.spineIndex < epub->getSpineItemsCount()) {
+        RenderLock lock(*this);
+        if (section && currentSpineIndex == sync.spineIndex) {
+          // Already in this chapter and laid out: resolve straight away, no reload.
+          const auto page = section->getPageForVisibleTextOffset(sync.visibleTextOffset);
+          section->currentPage = page.value_or(std::max(0, sync.page));
+        } else {
+          // Different chapter: reload and let render() build to the offset before drawing.
+          currentSpineIndex = sync.spineIndex;
+          pendingOffsetJump = sync.visibleTextOffset;
+          nextPageNumber = std::max(0, sync.page);  // hint until the offset resolves
+          section.reset();
+        }
+        return;
+      }
+
       int targetSpineIndex = sync.spineIndex;
       int targetPage = sync.page;
       const int activeTotalPages = section ? section->estimatedTotalPages() : 0;
@@ -1146,6 +1166,16 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       cachedVisibleTextOffset.reset();
     }
     const bool cacheComplete = cacheLoaded && !section->isPartial();
+    // Land this render by content offset when one applies. An explicit bookmark jump
+    // (pendingOffsetJump) always wins -- it is a deliberate navigation to a stored content anchor.
+    // Otherwise fall back to the settings-change reposition: read after the cache-hit reset above,
+    // a spec match means the saved page number still names the same content so there is nothing to
+    // reposition, while a page jump or fragment anchor is a deliberate navigation that outranks it.
+    const std::optional<uint32_t> offsetJump =
+        pendingOffsetJump.has_value() ? pendingOffsetJump
+        : (pendingPageJump.has_value() || !pendingAnchor.empty() || currentSpineIndex != cachedSpineIndex)
+            ? std::nullopt
+            : cachedVisibleTextOffset;
     if (!cacheComplete) {
       if (section->isPartial()) {
         LOG_DBG("ERS", "Partial cache found (%d pages), resuming build...", section->pageCount);
@@ -1255,9 +1285,14 @@ void EpubReaderActivity::render(RenderLock&& lock) {
             return;
           }
           while (!section->isBuildComplete() &&
-                 (anchorJump ? !section->findAnchor(pendingAnchor) : static_cast<int>(section->pageCount) <= target)) {
+                 (anchorJump               ? !section->findAnchor(pendingAnchor)
+                  : offsetJump.has_value() ? !section->buildReachedVisibleTextOffset(*offsetJump)
+                                           : static_cast<int>(section->pageCount) <= target)) {
             // Anchor jump: build until the anchor's page is laid out (usually page 0), checking a
             // partial's on-disk anchor map too so an already-indexed anchor resolves immediately.
+            // Re-pagination: build until the content the reader was on has been laid out. Costs the
+            // same parse work as the old page target did -- it is the same content -- but it stops
+            // at the right place, so the landing page is known before anything is drawn.
             // Otherwise: build until the target page exists. loop() builds the rest behind it.
             if (buildPopupPending && millis() - buildStartMs >= BUILD_POPUP_DEADLINE_MS) {
               // The predictive gates guessed fast but the build blew the silent budget.
@@ -1287,6 +1322,17 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         section->currentPage = 0;
       }
     }
+
+    // The chapter re-paginated, so nextPageNumber above named the old pagination's page.
+    // The build loop stopped once this offset was laid out, so resolve it now, before the
+    // first draw. Leaving it to applyDeferredReposition() is what made the stale page paint
+    // first and then jump when the background build finished the chapter.
+    if (offsetJump.has_value()) {
+      if (const auto offsetPage = section->getPageForVisibleTextOffset(*offsetJump)) {
+        section->currentPage = *offsetPage;
+      }
+    }
+    pendingOffsetJump.reset();  // one-shot explicit jump: consumed on this render
 
     if (!pendingAnchor.empty()) {
       // Resolve from the pages laid out so far and/or the on-disk map (finalized or partial).
@@ -1422,6 +1468,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
     pageLoadRetryCount = 0;  // Reset the retry counter once a page loads cleanly
 
+    // Cache this page's content offset (read alongside the page, no extra file open) so
+    // saveProgress and addBookmark can use it without reopening section.bin.
+    currentPageVisibleOffset = p->visibleTextOffset;
+
     // Collect footnotes from the loaded page
     currentPageFootnotes = std::move(p->footnotes);
 
@@ -1495,7 +1545,11 @@ bool EpubReaderActivity::applyDeferredReposition() {
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {
   std::optional<uint32_t> offset;
   if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
-    offset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage));
+    // The on-screen page's offset was captured at load; reuse it to avoid a fresh section-file
+    // open on every page turn. Any other page (rare) falls back to a direct lookup.
+    offset = (currentPage == section->currentPage && currentPageVisibleOffset.has_value())
+                 ? currentPageVisibleOffset
+                 : section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage));
   }
   return EpubReaderUtils::saveProgress(*epub, spineIndex, currentPage, pageCount, offset);
 }
@@ -1943,6 +1997,17 @@ void EpubReaderActivity::addBookmark() {
     entry.computedSpineIndex = currentSpineIndex;
     entry.computedChapterPageCount = pageCount;
     entry.computedChapterProgress = currentPage;
+    // Record the exact content offset so the bookmark lands correctly after any re-pagination.
+    // currentPageVisibleOffset was captured for this very page at its last render.
+    const std::optional<uint32_t> offset =
+        currentPageVisibleOffset.has_value() ? currentPageVisibleOffset
+        : (currentPage >= 0 && currentPage < section->pageCount)
+            ? section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage))
+            : std::nullopt;
+    if (offset.has_value()) {
+      entry.visibleTextOffset = *offset;
+      entry.hasVisibleTextOffset = true;
+    }
     cachedBookmarks.insert(cachedBookmarks.begin(), entry);
     bookmarkRemoved = false;
     currentPageBookmarked = true;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -27,6 +27,13 @@ class EpubReaderActivity final : public Activity {
   int cachedSpineIndex = 0;
   int cachedChapterTotalPageCount = 0;
   std::optional<uint32_t> cachedVisibleTextOffset;
+  // Visible-codepoint offset of the page currently on screen, captured when the page is loaded
+  // (Page::visibleTextOffset). Lets saveProgress persist the offset without reopening section.bin.
+  std::optional<uint32_t> currentPageVisibleOffset;
+  // Explicit "land at this visible-codepoint offset in the target spine" request (bookmark open).
+  // Resolved in render() once the section is loaded/built far enough, then cleared. Unlike a
+  // settings-change reposition it always resolves by content, so it survives any re-pagination.
+  std::optional<uint32_t> pendingOffsetJump;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
   // Signals that the next render should reposition within the newly loaded section

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -26,6 +26,7 @@ class EpubReaderActivity final : public Activity {
   bool forcedRefreshPending = false;
   int cachedSpineIndex = 0;
   int cachedChapterTotalPageCount = 0;
+  std::optional<uint32_t> cachedVisibleTextOffset;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
   // Signals that the next render should reposition within the newly loaded section
@@ -159,10 +160,11 @@ class EpubReaderActivity final : public Activity {
   bool buildPopupPending = false;
   // Draw the indexing popup mid-build (parser image-probe callback and deadline backstop).
   void showBuildPopup();
-  // Remap the cached relative reading position once the section's real page count is known
-  // (used after a settings change re-paginates a chapter). Returns true if currentPage moved.
+  // Map the cached content position into the rebuilt section (used after a
+  // settings change re-paginates a chapter). Returns true if currentPage moved.
   // No-op while the section is still building or when the pagination is unchanged (plain resume).
   bool applyDeferredReposition();
+  void rememberCurrentContentOffset();
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -56,9 +56,13 @@ void EpubReaderBookmarksActivity::loop() {
     result.xpath = bookmark.xpath;
     result.percentage = bookmark.percentage;
     result.hasSavedProgress = true;
+    result.hasVisibleTextOffset = bookmark.hasVisibleTextOffset;
+    result.visibleTextOffset = bookmark.visibleTextOffset;
+    // The offset is spine-relative, so carry its spine even when the legacy page hints below
+    // are stale. The reader validates the index.
+    result.spineIndex = bookmark.computedSpineIndex;
     if (bookmark.computedChapterPageCount > 0 && bookmark.computedChapterProgress < bookmark.computedChapterPageCount &&
         bookmark.computedSpineIndex < epub->getSpineItemsCount()) {
-      result.spineIndex = bookmark.computedSpineIndex;
       result.page = bookmark.computedChapterProgress;
       result.totalPages = bookmark.computedChapterPageCount;
     }

--- a/src/activities/reader/EpubReaderUtils.h
+++ b/src/activities/reader/EpubReaderUtils.h
@@ -3,28 +3,39 @@
 #include <Epub.h>
 #include <Logging.h>
 
+#include <optional>
+
 #include "ProgressFile.h"
 
 namespace EpubReaderUtils {
 
 // Persists reader progress for an EPUB to its cache directory. Returns true on success.
-inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int pageCount) {
+inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int pageCount,
+                         std::optional<uint32_t> visibleTextOffset = std::nullopt) {
   if (spineIndex < 0 || spineIndex > 0xFFFF || pageNumber < 0 || pageNumber > 0xFFFF || pageCount < 0 ||
       pageCount > 0xFFFF) {
     LOG_ERR("ERS", "Progress values out of range: spine=%d page=%d count=%d", spineIndex, pageNumber, pageCount);
     return false;
   }
-  uint8_t data[6];
+  uint8_t data[10];
   data[0] = spineIndex & 0xFF;
   data[1] = (spineIndex >> 8) & 0xFF;
   data[2] = pageNumber & 0xFF;
   data[3] = (pageNumber >> 8) & 0xFF;
   data[4] = pageCount & 0xFF;
   data[5] = (pageCount >> 8) & 0xFF;
-  if (!ProgressFile::writeAtomic(epub.getCachePath(), data, sizeof(data))) {
+  size_t dataSize = 6;
+  if (visibleTextOffset.has_value()) {
+    data[6] = *visibleTextOffset & 0xFF;
+    data[7] = (*visibleTextOffset >> 8) & 0xFF;
+    data[8] = (*visibleTextOffset >> 16) & 0xFF;
+    data[9] = (*visibleTextOffset >> 24) & 0xFF;
+    dataSize = sizeof(data);
+  }
+  if (!ProgressFile::writeAtomic(epub.getCachePath(), data, dataSize)) {
     return false;
   }
-  LOG_DBG("ERS", "Progress saved: spine=%d page=%d", spineIndex, pageNumber);
+  LOG_DBG("ERS", "Progress saved: spine=%d offset=%u page=%d", spineIndex, visibleTextOffset.value_or(0), pageNumber);
   return true;
 }
 

--- a/src/activities/reader/EpubReaderUtils.h
+++ b/src/activities/reader/EpubReaderUtils.h
@@ -44,8 +44,10 @@ inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int p
   if (!ProgressFile::writeAtomic(epub.getCachePath(), data, dataSize)) {
     return false;
   }
-  LOG_DBG("ERS", "Progress saved: spine=%d page=%d vertical=%d furigana=%d offset=%u", spineIndex, pageNumber,
-          verticalOverride, furiganaOverride, visibleTextOffset.value_or(0));
+  // offsetKnown distinguishes "no offset available" from a real chapter-start offset of 0.
+  LOG_DBG("ERS", "Progress saved: spine=%d page=%d vertical=%d furigana=%d offsetKnown=%d offset=%u", spineIndex,
+          pageNumber, verticalOverride, furiganaOverride, visibleTextOffset.has_value() ? 1 : 0,
+          visibleTextOffset.value_or(0));
   return true;
 }
 

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -241,7 +241,10 @@ void KOReaderSyncActivity::performSync() {
   SavedProgressPosition koPos = {remoteProgress.progress, remoteProgress.percentage};
   remotePosition = ProgressMapper::toCrossPoint(epub, koPos, renderer, currentSpineIndex, totalPagesInSpine);
   if (!remotePosition.hasVisibleTextOffset && remoteProgress.position.has_value()) {
-    if (const auto richMapped = ProgressMapper::fromRichPosition(epub, *remoteProgress.position, renderer)) {
+    // toCrossPoint above already tried koPos.xpath; if the rich position carries the same XPath,
+    // tell fromRichPosition to skip re-resolving it and use its page hints directly.
+    const bool sameXPath = remoteProgress.position->xpath == remoteProgress.progress;
+    if (const auto richMapped = ProgressMapper::fromRichPosition(epub, *remoteProgress.position, renderer, sameXPath)) {
       remotePosition = *richMapped;
     }
   }

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -84,7 +84,11 @@ void KOReaderSyncActivity::saveProgressAndReturn(int spineIndex, int page) {
   // epub is guaranteed non-null here: ensureEpubLoaded() was called in performSync() before
   // SHOWING_RESULT state is entered, and this method is only called from that state.
   assert(epub);
-  if (!EpubReaderUtils::saveProgress(*epub, spineIndex, page, 0)) {
+  std::optional<uint32_t> offset;
+  if (remotePosition.hasVisibleTextOffset && remotePosition.spineIndex == spineIndex) {
+    offset = remotePosition.visibleTextOffset;
+  }
+  if (!EpubReaderUtils::saveProgress(*epub, spineIndex, page, 0, offset)) {
     {
       RenderLock lock(*this);
       state = SYNC_FAILED;
@@ -232,17 +236,14 @@ void KOReaderSyncActivity::performSync() {
     return;
   }
 
-  // Prefer the exact spine/page supplied by the CrossPoint sync server; fall
-  // back to the approximate XPath mapping when it cannot be applied.
-  std::optional<CrossPointPosition> richMapped;
-  if (remoteProgress.position.has_value()) {
-    richMapped = ProgressMapper::fromRichPosition(epub, *remoteProgress.position, renderer);
-  }
-  if (richMapped.has_value()) {
-    remotePosition = *richMapped;
-  } else {
-    SavedProgressPosition koPos = {remoteProgress.progress, remoteProgress.percentage};
-    remotePosition = ProgressMapper::toCrossPoint(epub, koPos, renderer, currentSpineIndex, totalPagesInSpine);
+  // The standard KOReader progress XPath is the authoritative content anchor.
+  // The CrossPoint server's existing rich page hints remain a legacy fallback.
+  SavedProgressPosition koPos = {remoteProgress.progress, remoteProgress.percentage};
+  remotePosition = ProgressMapper::toCrossPoint(epub, koPos, renderer, currentSpineIndex, totalPagesInSpine);
+  if (!remotePosition.hasVisibleTextOffset && remoteProgress.position.has_value()) {
+    if (const auto richMapped = ProgressMapper::fromRichPosition(epub, *remoteProgress.position, renderer)) {
+      remotePosition = *richMapped;
+    }
   }
 
   if (smartSyncEnabled()) {

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -126,13 +126,15 @@ void OtaUpdateActivity::render(RenderLock&&) {
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, top + height * 2 + metrics.verticalSpacing * 2,
                       (std::string(tr(STR_NEW_VERSION)) + updater.getLatestVersion()).c_str());
 
-    const auto actionRects = getOtaActionRects(renderer);
-    const int cancelTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_CANCEL));
-    renderer.drawText(UI_10_FONT_ID, actionRects.cancel.x + (actionRects.cancel.width - cancelTextWidth) / 2,
-                      actionRects.cancel.y + 28, tr(STR_CANCEL));
-    const int updateTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_UPDATE));
-    renderer.drawText(UI_10_FONT_ID, actionRects.update.x + (actionRects.update.width - updateTextWidth) / 2,
-                      actionRects.update.y + 28, tr(STR_UPDATE));
+    if (mappedInput.hasTouch()) {
+      const auto actionRects = getOtaActionRects(renderer);
+      const int cancelTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_CANCEL));
+      renderer.drawText(UI_10_FONT_ID, actionRects.cancel.x + (actionRects.cancel.width - cancelTextWidth) / 2,
+                        actionRects.cancel.y + 28, tr(STR_CANCEL));
+      const int updateTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_UPDATE));
+      renderer.drawText(UI_10_FONT_ID, actionRects.update.x + (actionRects.update.width - updateTextWidth) / 2,
+                        actionRects.update.y + 28, tr(STR_UPDATE));
+    }
 
     const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/activities/settings/TextSettingsPreview.cpp
+++ b/src/activities/settings/TextSettingsPreview.cpp
@@ -52,8 +52,9 @@ void relayout(PreviewLayout& layout, const GfxRenderer& renderer, int fontId, in
     }
   }
 
-  parsed.layoutAndExtractLines(renderer, fontId, static_cast<uint16_t>(textWidth),
-                               [&layout](std::shared_ptr<TextBlock> line) { layout.lines.push_back(std::move(line)); });
+  parsed.layoutAndExtractLines(
+      renderer, fontId, static_cast<uint16_t>(textWidth),
+      [&layout](std::shared_ptr<TextBlock> line, uint32_t) { layout.lines.push_back(std::move(line)); });
 }
 
 }  // namespace

--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -86,12 +86,11 @@ class OptionPopup {
       return true;
     }
 
-    if (input.wasPressed(MappedInputManager::Button::Up) || input.wasPressed(MappedInputManager::Button::Left)) {
+    if (input.wasPressed(MappedInputManager::Button::NavPrevious)) {
       selectedIndex = (selectedIndex - 1 + count) % count;
       requestUpdate();
       return true;
-    } else if (input.wasPressed(MappedInputManager::Button::Down) ||
-               input.wasPressed(MappedInputManager::Button::Right)) {
+    } else if (input.wasPressed(MappedInputManager::Button::NavNext)) {
       selectedIndex = (selectedIndex + 1) % count;
       requestUpdate();
       return true;

--- a/src/util/BookmarkFile.cpp
+++ b/src/util/BookmarkFile.cpp
@@ -29,6 +29,10 @@ bool BookmarkFile::load(const std::string& bookPath, std::vector<BookmarkEntry>&
     bookmark.computedSpineIndex = obj["si"] | static_cast<uint16_t>(0);
     bookmark.computedChapterPageCount = obj["pc"] | static_cast<uint16_t>(0);
     bookmark.computedChapterProgress = obj["pp"] | static_cast<uint16_t>(0);
+    if (!obj["vo"].isNull()) {
+      bookmark.visibleTextOffset = obj["vo"] | static_cast<uint32_t>(0);
+      bookmark.hasVisibleTextOffset = true;
+    }
   }
 
   LOG_DBG("BKM", "Loaded %zu bookmarks from file", bookmarks.size());
@@ -47,6 +51,9 @@ bool BookmarkFile::save(const std::string& bookPath, const std::vector<BookmarkE
     obj["si"] = bookmark.computedSpineIndex;
     obj["pc"] = bookmark.computedChapterPageCount;
     obj["pp"] = bookmark.computedChapterProgress;
+    if (bookmark.hasVisibleTextOffset) {
+      obj["vo"] = bookmark.visibleTextOffset;
+    }
   }
 
   // writeDocToFile ensures /.crosspoint; the bookmarks subdirectory is ours.

--- a/src/util/DictZip.cpp
+++ b/src/util/DictZip.cpp
@@ -4,6 +4,8 @@
 #include <InflateReader.h>
 #include <Memory.h>
 
+#include <cstddef>
+
 namespace DictZip {
 namespace {
 
@@ -22,6 +24,49 @@ bool readLe16(HalFile& file, uint16_t* out) {
   return true;
 }
 
+// Compressed input for one chunk, pulled from the file on demand instead of
+// buffered whole. A dictzip chunk is ~58KB uncompressed (measured at 18KB
+// compressed for a real dictionary), so the old whole-chunk buffer was a large
+// contiguous request made while the 32KB inflate window was about to be taken
+// as well — two big blocks live at once, on a heap that during a reading
+// session has well under 50KB free (#2744). This holds INPUT_BUF_BYTES instead.
+//
+// InflateReader MUST stay the first member: the uzlib callback receives only a
+// uzlib_uncomp* and recovers this struct by casting it (see InflateReader.h).
+constexpr size_t INPUT_BUF_BYTES = 2048;
+
+struct ChunkSource {
+  InflateReader reader;  // must be first
+  HalFile* file = nullptr;
+  uint32_t remaining = 0;  // compressed bytes left in this chunk
+  bool readFailed = false;
+  uint8_t buf[INPUT_BUF_BYTES] = {};
+};
+
+static_assert(offsetof(ChunkSource, reader) == 0, "InflateReader must be first for the uzlib callback cast");
+
+// Refills from the file and returns the next byte, or -1 at the chunk's end.
+// Never reads past compressedSize: the following bytes belong to the next
+// chunk, and stopping there reproduces exactly the hard limit the whole-chunk
+// buffer used to impose.
+int chunkReadCb(uzlib_uncomp* u) {
+  auto* src = reinterpret_cast<ChunkSource*>(u);
+  if (src->remaining == 0) return -1;
+
+  const uint32_t want = src->remaining < INPUT_BUF_BYTES ? src->remaining : INPUT_BUF_BYTES;
+  const int n = src->file->read(src->buf, static_cast<int>(want));
+  if (n <= 0) {
+    // Remember the cause: uzlib collapses this into a generic decode failure,
+    // but an IO error is a ReadError, not a corrupt .dz.
+    src->readFailed = true;
+    return -1;
+  }
+  src->remaining -= static_cast<uint32_t>(n);
+  u->source = src->buf + 1;
+  u->source_limit = src->buf + n;
+  return src->buf[0];
+}
+
 bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compressedSize, uint32_t discardSize,
                        uint32_t extractSize, HalFile& outFile, ExtractError* outError) {
   const auto fail = [outError](ExtractError e) {
@@ -29,32 +74,51 @@ bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compre
     return false;
   };
   if (extractSize == 0) return true;
-  auto compBuf = makeUniqueNoThrow<uint8_t[]>(compressedSize);
-  if (!compBuf) return fail(ExtractError::LowMemory);  // couldn't get the compressed-chunk buffer
+
+  // Largest block FIRST. Every allocation here is carved from the same big free
+  // run, so taking the ~3KB ChunkSource before the 32KB ring left the ring's
+  // block 12 bytes short on device (largest=32756 against need=32768) even on a
+  // barely fragmented heap. Ordering by size removes that failure mode: the ring
+  // gets the big block while it is still whole, and the small buffers fit in
+  // what remains — or in one of the smaller free blocks.
+  auto window = makeUniqueNoThrow<uint8_t[]>(InflateReader::RING_BYTES);
+  if (!window) return fail(ExtractError::LowMemory);
+
+  auto src = makeUniqueNoThrow<ChunkSource>();
+  if (!src) return fail(ExtractError::LowMemory);
+  src->file = &file;
+  src->remaining = compressedSize;
 
   // compressedOffset comes from the untrusted .dz chunk table, so an out-of-range
   // seek is possible — guard it rather than reading from the prior position.
   if (!file.seekSet(compressedOffset)) return fail(ExtractError::ReadError);
-  if (file.read(compBuf.get(), static_cast<int>(compressedSize)) != static_cast<int>(compressedSize))
-    return fail(ExtractError::ReadError);
 
-  InflateReader reader;
-  if (!reader.init(true)) return fail(ExtractError::LowMemory);  // 32KB inflate window allocation failed
-  reader.setSource(compBuf.get(), compressedSize);
+  // `window` outlives the reader (declared above it, destroyed after), as
+  // initWithRing() requires.
+  if (!src->reader.initWithRing(window.get())) return fail(ExtractError::LowMemory);
+  // initWithRing() leaves source/source_limit null, so the very first byte
+  // already comes through the callback. Set it after, which resets state.
+  src->reader.setReadCallback(&chunkReadCb);
 
   auto buf = makeUniqueNoThrow<uint8_t[]>(512);
   if (!buf) return fail(ExtractError::LowMemory);
 
+  // A decode failure after the callback hit an IO error is a read failure, not
+  // a corrupt stream — keep the two distinguishable for the caller.
+  const auto decodeFail = [&src, &fail] {
+    return fail(src->readFailed ? ExtractError::ReadError : ExtractError::Decompress);
+  };
+
   uint32_t batch;
   while (discardSize > 0) {
     batch = discardSize < 512 ? discardSize : 512;
-    if (!reader.read(buf.get(), batch)) return fail(ExtractError::Decompress);
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
     discardSize -= batch;
   }
 
   while (extractSize > 0) {
     batch = extractSize < 512 ? extractSize : 512;
-    if (!reader.read(buf.get(), batch)) return fail(ExtractError::Decompress);
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
     if (outFile.write(buf.get(), batch) != batch) return fail(ExtractError::ReadError);
     extractSize -= batch;
   }

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -98,9 +98,9 @@ bool Dictionary::open(const char* folderName) {
     return false;
   }
   // Checked once here so buildPath() can never fail on the lookup path.
-  if (resolved.size() + strlen(LONGEST_SUFFIX) + 1 > PATH_BUF_BYTES) {
+  if (resolved.size() + LONGEST_SUFFIX_LEN + 1 > PATH_BUF_BYTES) {
     LOG_ERR("DICT", "Dictionary path too long (%u chars, max %u)", static_cast<unsigned>(resolved.size()),
-            static_cast<unsigned>(PATH_BUF_BYTES - strlen(LONGEST_SUFFIX) - 1));
+            static_cast<unsigned>(PATH_BUF_BYTES - LONGEST_SUFFIX_LEN - 1));
     return false;
   }
 
@@ -118,16 +118,13 @@ bool Dictionary::buildPath(char* buf, size_t bufSize, const char* suffix) const 
 }
 
 bool Dictionary::needsIndex() {
-  if (!isOpen()) return false;
-
-  HalFile idx;
-  if (!Storage.openFileForRead("DICT", basePath + ".idx", idx)) return false;
-  const uint32_t idxSize = static_cast<uint32_t>(idx.fileSize());
-
-  HalFile qidx;
-  if (!Storage.openFileForRead("DICT", basePath + ".qidx", qidx)) return true;
-  const QidxHeader header = readQidxHeader(qidx, SAMPLE_INTERVAL);
-  return !header.valid || header.idxFileSize != idxSize;
+  // Expressed on openSession() so the "is the sidecar usable?" rule lives in
+  // exactly one place, and so this costs no path allocations either. A
+  // successful buildIndex() always writes at least one sample (entry 0), so
+  // sampleCount == 0 means absent, stale or corrupt — all of which rebuild.
+  LookupSession session;
+  if (!openSession(session)) return false;
+  return session.sampleCount == 0;
 }
 
 bool Dictionary::buildIndex(void (*yieldFn)(void*), void* ctx, IndexResult* outResult) {

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstring>
 
 #include "DictZip.h"
@@ -96,8 +97,23 @@ bool Dictionary::open(const char* folderName) {
     LOG_ERR("DICT", "%s uses 64-bit index offsets (unsupported)", resolved.c_str());
     return false;
   }
+  // Checked once here so buildPath() can never fail on the lookup path.
+  if (resolved.size() + strlen(LONGEST_SUFFIX) + 1 > PATH_BUF_BYTES) {
+    LOG_ERR("DICT", "Dictionary path too long (%u chars, max %u)", static_cast<unsigned>(resolved.size()),
+            static_cast<unsigned>(PATH_BUF_BYTES - strlen(LONGEST_SUFFIX) - 1));
+    return false;
+  }
 
   basePath = std::move(resolved);
+  return true;
+}
+
+bool Dictionary::buildPath(char* buf, size_t bufSize, const char* suffix) const {
+  const int n = snprintf(buf, bufSize, "%s%s", basePath.c_str(), suffix);
+  if (n < 0 || static_cast<size_t>(n) >= bufSize) {
+    LOG_ERR("DICT", "Path too long: %s%s", basePath.c_str(), suffix);
+    return false;
+  }
   return true;
 }
 
@@ -219,59 +235,68 @@ int Dictionary::readWordInto(HalFile& file, char* buf, size_t bufSize) {
   return static_cast<int>(bufSize - 1);
 }
 
-DictLocation Dictionary::locate(const char* target, std::string* matchedHeadwordOut) {
-  DictLocation result;
-  if (!isOpen()) return result;
+bool Dictionary::openSession(LookupSession& session) {
+  if (!isOpen()) return false;
 
-  HalFile idx;
-  if (!Storage.openFileForRead("DICT", basePath + ".idx", idx)) {
-    result.readError = true;
-    return result;
+  // One buffer reused for both paths — no transient heap on the lookup path.
+  char path[PATH_BUF_BYTES];
+  if (!buildPath(path, sizeof(path), ".idx")) return false;
+  if (!Storage.openFileForRead("DICT", path, session.idx)) return false;
+  session.idxSize = static_cast<uint32_t>(session.idx.fileSize());
+
+  // The sidecar is optional and its header only has to be validated once per
+  // lookup; without a usable one locate() scans from byte 0.
+  if (!buildPath(path, sizeof(path), ".qidx")) return true;
+  if (Storage.openFileForRead("DICT", path, session.qidx)) {
+    const QidxHeader header = readQidxHeader(session.qidx, SAMPLE_INTERVAL);
+    if (header.valid && header.idxFileSize == session.idxSize) session.sampleCount = header.sampleCount;
   }
-  const uint32_t idxSize = static_cast<uint32_t>(idx.fileSize());
+  return true;
+}
+
+// Both files stay open across the stem-variant probes; every read below seeks
+// absolutely first, so a shared handle carries no position state between calls.
+DictLocation Dictionary::locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut) {
+  DictLocation result;
 
   // Bisect the sampled offsets to the last sample whose headword <= target.
   // Falls back to a full scan from byte 0 when the sidecar is unusable.
   uint32_t startByte = 0;
-  HalFile qidx;
-  if (Storage.openFileForRead("DICT", basePath + ".qidx", qidx)) {
-    const QidxHeader header = readQidxHeader(qidx, SAMPLE_INTERVAL);
-    if (header.valid && header.idxFileSize == idxSize && header.sampleCount > 0) {
-      uint32_t lo = 0;
-      uint32_t hi = header.sampleCount - 1;
-      while (lo < hi) {
-        const uint32_t mid = (lo + hi + 1) / 2;
-        uint32_t offset = 0;
-        if (!readSampleOffset(qidx, mid, &offset) || !idx.seekSet(offset) ||
-            readWordInto(idx, wordBuf, sizeof(wordBuf)) < 0) {
-          lo = 0;
-          break;
-        }
-        if (StringUtils::asciiCaseCmp(wordBuf, target) <= 0) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
+  if (session.sampleCount > 0) {
+    uint32_t lo = 0;
+    uint32_t hi = session.sampleCount - 1;
+    while (lo < hi) {
+      const uint32_t mid = (lo + hi + 1) / 2;
+      uint32_t offset = 0;
+      if (!readSampleOffset(session.qidx, mid, &offset) || !session.idx.seekSet(offset) ||
+          readWordInto(session.idx, wordBuf, sizeof(wordBuf)) < 0) {
+        lo = 0;
+        break;
       }
-      readSampleOffset(qidx, lo, &startByte);
+      if (StringUtils::asciiCaseCmp(wordBuf, target) <= 0) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
     }
+    readSampleOffset(session.qidx, lo, &startByte);
   }
 
   // Linear scan of at most SAMPLE_INTERVAL entries: headword NUL, BE32 offset,
   // BE32 size. The index is sorted, so stop at the first headword > target.
-  if (!idx.seekSet(startByte)) {
+  if (!session.idx.seekSet(startByte)) {
     LOG_ERR("DICT", "Index seek to %lu failed", static_cast<unsigned long>(startByte));
     result.readError = true;
     return result;
   }
-  while (static_cast<uint32_t>(idx.position()) < idxSize) {
+  while (static_cast<uint32_t>(session.idx.position()) < session.idxSize) {
     // Not flagged as readError: readWordInto returns -1 for EOF and IO error
     // alike, so a short tail can't be told from a truncated .idx. Treat it as
     // the end of the index rather than risk reporting a read failure for what
     // is really a miss.
-    if (readWordInto(idx, wordBuf, sizeof(wordBuf)) < 0) break;
+    if (readWordInto(session.idx, wordBuf, sizeof(wordBuf)) < 0) break;
     uint8_t suffix[8];
-    if (idx.read(suffix, 8) != 8) break;
+    if (session.idx.read(suffix, 8) != 8) break;
 
     const int cmp = StringUtils::asciiCaseCmp(wordBuf, target);
     if (cmp == 0) {
@@ -306,19 +331,21 @@ bool Dictionary::readDefinition(const DictLocation& location, std::string& out, 
     return fail(LookupResult::LowMemory);
   }
 
-  std::string path;
+  char pathBuf[PATH_BUF_BYTES];
+  const char* path = pathBuf;
   uint32_t offset = 0;
   if (hasPlainDict) {
-    path = basePath + ".dict";
+    if (!buildPath(pathBuf, sizeof(pathBuf), ".dict")) return fail(LookupResult::ReadError);
     offset = location.offset;
   } else {
+    if (!buildPath(pathBuf, sizeof(pathBuf), ".dict.dz")) return fail(LookupResult::ReadError);
     HalFile tmp = Storage.open(DICT_TMP_FILE, O_WRITE | O_CREAT | O_TRUNC);
     if (!tmp) {
       LOG_ERR("DICT", "Failed to open %s", DICT_TMP_FILE);
       return fail(LookupResult::ReadError);
     }
     DictZip::ExtractError xerr = DictZip::ExtractError::None;
-    if (!DictZip::extractEntry((basePath + ".dict.dz").c_str(), location.offset, size, tmp, &xerr)) {
+    if (!DictZip::extractEntry(pathBuf, location.offset, size, tmp, &xerr)) {
       // Map the specific extraction cause to the lookup result: allocation
       // failure (heap fragmentation) vs corrupt/truncated .dz vs an IO error.
       LOG_ERR("DICT", "dictzip extraction failed for %s (error %d)", basePath.c_str(), static_cast<int>(xerr));
@@ -412,15 +439,29 @@ bool Dictionary::lookup(const char* word, std::string& definitionOut, std::strin
   const std::string cleaned = cleanWord(word);
   if (cleaned.empty() || !isOpen()) return false;
 
-  DictLocation location = locate(cleaned.c_str(), &matchedHeadwordOut);
-  bool searchFailed = location.readError;
-  if (!location.found) {
-    std::vector<std::string> variants;
-    stemVariants(cleaned, variants);
-    for (const auto& variant : variants) {
-      location = locate(variant.c_str(), &matchedHeadwordOut);
-      searchFailed = searchFailed || location.readError;
-      if (location.found) break;
+  // One set of open handles for the exact-match probe and every stem variant,
+  // scoped so .idx/.qidx close before readDefinition() opens the data file.
+  DictLocation location;
+  bool searchFailed = false;
+  {
+    LookupSession session;
+    // Couldn't open .idx: the search never reached a verdict, so this is a read
+    // failure, not a miss.
+    if (!openSession(session)) {
+      setResult(LookupResult::ReadError);
+      return false;
+    }
+
+    location = locate(session, cleaned.c_str(), &matchedHeadwordOut);
+    searchFailed = location.readError;
+    if (!location.found) {
+      std::vector<std::string> variants;
+      stemVariants(cleaned, variants);
+      for (const auto& variant : variants) {
+        location = locate(session, variant.c_str(), &matchedHeadwordOut);
+        searchFailed = searchFailed || location.readError;
+        if (location.found) break;
+      }
     }
   }
   if (!location.found) {

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -77,7 +77,39 @@ class Dictionary {
  private:
   static constexpr uint32_t SAMPLE_INTERVAL = 256;
 
-  DictLocation locate(const char* target, std::string* matchedHeadwordOut);
+  // Longest "<basePath><suffix>" the lookup path builds, rounded up. basePath is
+  // "/dictionaries/<folder>/<stem>" (14 fixed chars) and the longest suffix is
+  // ".dict.dz", leaving ~137 chars for folder + stem — far beyond any real
+  // dictionary. open() rejects anything that would not fit, so the hot path
+  // cannot fail on length. Kept under the 256-byte stack-local guideline.
+  static constexpr size_t PATH_BUF_BYTES = 160;
+
+  // Longest suffix appended to basePath; used for the open()-time length check.
+  static constexpr const char* LONGEST_SUFFIX = ".dict.dz";
+
+  // Compose "<basePath><suffix>" into a caller-supplied stack buffer. The
+  // lookup path runs this instead of `basePath + suffix` so probing a word
+  // costs no transient heap at all — see LookupSession. False (and logs) when
+  // the path would not fit, which open() has already ruled out.
+  bool buildPath(char* buf, size_t bufSize, const char* suffix) const;
+
+  // The .idx / .qidx handles shared by every locate() call in one lookup. A
+  // lookup probes up to ~5 stem variants; opening the two files per probe cost
+  // ~10 SD opens and ~10 std::string path temporaries per word, churning the
+  // same heap whose fragmentation makes lookups fail mid-session. Opened once
+  // per lookup instead, with the paths built via buildPath().
+  struct LookupSession {
+    HalFile idx;
+    HalFile qidx;
+    uint32_t idxSize = 0;
+    uint32_t sampleCount = 0;  // 0 when the sidecar is absent, stale or empty
+  };
+
+  // Open .idx (required) and .qidx (optional — locate() falls back to a full
+  // scan without it). False when the dictionary is closed or .idx won't open.
+  bool openSession(LookupSession& session);
+
+  DictLocation locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut);
   // Read the definition at location. On failure returns false and, if outResult
   // is given, sets it to the specific reason (Decompress / LowMemory / ReadError).
   bool readDefinition(const DictLocation& location, std::string& out, LookupResult* outResult = nullptr);

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -84,13 +84,15 @@ class Dictionary {
   // cannot fail on length. Kept under the 256-byte stack-local guideline.
   static constexpr size_t PATH_BUF_BYTES = 160;
 
-  // Longest suffix appended to basePath; used for the open()-time length check.
-  static constexpr const char* LONGEST_SUFFIX = ".dict.dz";
+  // Length of the longest suffix appended to basePath (".dict.dz"); used for
+  // the open()-time length check.
+  static constexpr size_t LONGEST_SUFFIX_LEN = sizeof(".dict.dz") - 1;
 
   // Compose "<basePath><suffix>" into a caller-supplied stack buffer. The
-  // lookup path runs this instead of `basePath + suffix` so probing a word
-  // costs no transient heap at all — see LookupSession. False (and logs) when
-  // the path would not fit, which open() has already ruled out.
+  // lookup path runs this instead of `basePath + suffix` so path construction
+  // costs no transient heap — see LookupSession. (A lookup still allocates
+  // elsewhere: cleanWord(), stemVariants() and the matched headword.) False
+  // (and logs) when the path would not fit, which open() has already ruled out.
   bool buildPath(char* buf, size_t bufSize, const char* suffix) const;
 
   // The .idx / .qidx handles shared by every locate() call in one lookup. A


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Sync the fork with upstream CrossPoint `develop` (11 commits), taking every upstream fix while keeping all fork features (Japanese dictionary, vertical text, furigana, per-word fonts, footnote panel, per-book prefs) intact.
* **What changes are included?**
  * **Dictionary perf/fixes** (#2733, #2791, upstream sidecar-freshness commit): index files open once per lookup via a `LookupSession`, `.qidx` freshness checked once per open, `.dict.dz` definition inflation no longer OOMs. Integrated with the fork's multi-dictionary `folderName` open and `normalizeIndexHeadword` (both preserved inside the new session-based `locate`).
  * **Content-based sync positions** (#2805) + **re-pagination-proof bookmarks**: every laid-out page records the visible-codepoint offset of its first word. The offset threads through `ParsedText`/`ChapterHtmlSlimParser`/`Section` **alongside the fork's per-word font channel** — including the fork-only paths upstream doesn't have (dedicated image pages, list-style markers, keep-together buffering, `breakPage()`).
    * `progress.bin`: offset appended at bytes 9–12 **after** the fork's vertical/furigana/percent bytes, presence signaled by file size ≥ 13 — old fork files parse unchanged.
    * `section.bin`: `SECTION_FILE_VERSION` 69 → 70 (header gains a fifth `uint32_t` + per-page offset LUT; the fork's section-wide footnote table stays the file's final trailer, so `loadSectionFootnotes`' final-4-bytes contract holds). `docs/file-formats.md` updated.
  * **`std::deque` token storage** (#2814): `words`/`rubyTexts` become deques (fixes the fresh-open CJK crash from one giant contiguous vector realloc). The fork's focus-reading and per-word-font paths adapted; a stale vector-only `reserve` block from the fork side was removed in favor of upstream's deque-aware `ensureTokenCapacity`.
  * **Bookmarks survive re-pagination**, **shared bidi scratch buffer** (~1.5 KB RAM, #2554), **no duplicate OTA actions** (#2807), **orientation-aware OptionPopup and dictionary navigation buttons** (#2749).
  * **Deliberately dropped**: upstream's new `TEXT_SETTINGS` menu case (the fork has no such menu action — it uses `READER_SETTINGS` plus the `LayoutSig` in-place reflow, which now also benefits from content-offset repositioning via `rememberCurrentContentOffset()`).
  * **Net-zero**: the two upstream `freeink-sdk` pointer bumps cancel out — the submodule is untouched.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

## Additional Context

* **Merge mechanics**: true merge of `upstream/develop` (ancestry recorded, future syncs stay cheap); 12 files hand-resolved, the rest auto-merged. Conflict resolutions are unions — both features live at each collision site.
* **Memory**: upstream's changes *save* RAM (deque nodes ~512 B vs one 64–128 KB vector block; shared bidi scratch −1.5 KB; dictionary handles reused per lookup). The offset channel costs 2 B/word transient during layout (uint16 deltas) and 4 B/page in the section file.
* **Cache**: all section caches rebuild on first open after the version bump (deliberate — v69 files lack the offset LUT).
* **Risks / focus areas**: the progress.bin layout extension (fork bytes 6–8 + offset 9–12) vs upstream's 6–9 layout — readers/writers were all updated together in `EpubReaderUtils.h`/`EpubReaderActivity::onEnter`; offset bookkeeping on fork-only pagination paths (image pages, keep-together replay, `breakPage`); dictionary lookup behavior with the fork's normalization inside the session-based bisect.
* Verified: `pio run -e default` builds clean; all **129 host unit tests pass**; clang-format 21 clean on resolved files. On-device verification pending.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWncbpyJwf7FoGWh1ewFq3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWncbpyJwf7FoGWh1ewFq3)_