### PR TITLE
perf: book opening optimizations

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -196,7 +196,13 @@ void SdCardFont::freeStyleAll(PerStyle& s) {
 
 // --- Global free/cleanup ---
 
+bool SdCardFont::ensureFontFile() const {
+  if (fontFile_.isOpen()) return true;
+  return Storage.openFileForRead("SDCF", filePath_, fontFile_);
+}
+
 void SdCardFont::freeAll() {
+  fontFile_.close();
   clearOverflow();
   clearPersistentCache();
   for (uint8_t i = 0; i < MAX_STYLES; i++) {
@@ -432,13 +438,13 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
   }
 
   // Step 6: read the full matrix's rows for each used left class, keep only
-  // columns for used right classes.
-  HalFile file;
-  if (!Storage.openFileForRead("SDCF", filePath_, file)) {
+  // columns for used right classes. Shared handle: this runs per page turn.
+  if (!ensureFontFile()) {
     LOG_ERR("SDCF", "Failed to open .cpfont for mini kern: %s", filePath_);
     freeStyleMiniKern(s);
     return false;
   }
+  HalFile& file = fontFile_;
 
   // Fast path: pull the whole matrix in ONE seek+read and slice rows from RAM.
   // The per-row loop below costs one HalFile round-trip (mutex + seek + ~200B
@@ -1608,12 +1614,13 @@ const EpdGlyph* SdCardFont::onGlyphMiss(void* ctx, uint32_t codepoint) {
   uint32_t slot = self->overflowNext_;
   bool wasAtCapacity = (self->overflowCount_ == OVERFLOW_CAPACITY);
 
-  // Read glyph metadata into temporary
-  HalFile file;
-  if (!Storage.openFileForRead("SDCF", self->filePath_, file)) {
+  // Read glyph metadata into temporary. The shared handle skips the per-miss file open
+  // (~5-8ms of FAT walk) that dominated mid-build early renders.
+  if (!self->ensureFontFile()) {
     LOG_ERR("SDCF", "Overflow: failed to open .cpfont");
     return nullptr;
   }
+  HalFile& file = self->fontFile_;
 
   EpdGlyph tempGlyph = {};
   uint32_t glyphFileOff = s.glyphsFileOffset + static_cast<uint32_t>(globalIdx) * sizeof(EpdGlyph);
@@ -1624,6 +1631,7 @@ const EpdGlyph* SdCardFont::onGlyphMiss(void* ctx, uint32_t codepoint) {
   }
   if (file.read(reinterpret_cast<uint8_t*>(&tempGlyph), sizeof(EpdGlyph)) != sizeof(EpdGlyph)) {
     LOG_ERR("SDCF", "Overflow: failed to read glyph metadata for U+%04X style %u", codepoint, styleIdx);
+    file.close();
     return nullptr;
   }
 
@@ -1644,6 +1652,7 @@ const EpdGlyph* SdCardFont::onGlyphMiss(void* ctx, uint32_t codepoint) {
     if (file.read(tempBitmap, tempGlyph.dataLength) != static_cast<int>(tempGlyph.dataLength)) {
       LOG_ERR("SDCF", "Overflow: failed to read bitmap for U+%04X", codepoint);
       delete[] tempBitmap;
+      file.close();
       return nullptr;
     }
   }

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -90,7 +90,10 @@ bool ensureArrayCapacity(T*& buf, CapT& capacity, const uint32_t needed) {
 
 }  // namespace
 
-SdCardFont::~SdCardFont() { freeAll(); }
+SdCardFont::~SdCardFont() {
+  freeAll();
+  if (fontFileMutex_) vSemaphoreDelete(fontFileMutex_);
+}
 
 // --- Per-style free/cleanup ---
 
@@ -438,7 +441,9 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
   }
 
   // Step 6: read the full matrix's rows for each used left class, keep only
-  // columns for used right classes. Shared handle: this runs per page turn.
+  // columns for used right classes. Shared handle: this runs per page turn; the lock
+  // keeps its seek+read sequences atomic against any other task using the handle.
+  FontFileLock fontFileLock(fontFileMutex_);
   if (!ensureFontFile()) {
     LOG_ERR("SDCF", "Failed to open .cpfont for mini kern: %s", filePath_);
     freeStyleMiniKern(s);
@@ -483,12 +488,14 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
       const uint32_t rowFileOff = s.kernMatrixFileOffset + (oldL - 1u) * s.header.kernRightClassCount;
       if (!file.seekSet(rowFileOff)) {
         LOG_ERR("SDCF", "Failed to seek to kern row %u", oldL);
+        file.close();  // clean reopen after an SD hiccup (same policy as the miss path)
         freeStyleMiniKern(s);
         return false;
       }
       if (file.read(reinterpret_cast<uint8_t*>(rowBuf.get()), s.header.kernRightClassCount) !=
           static_cast<int>(s.header.kernRightClassCount)) {
         LOG_ERR("SDCF", "Failed to read kern row %u", oldL);
+        file.close();
         freeStyleMiniKern(s);
         return false;
       }
@@ -1615,7 +1622,9 @@ const EpdGlyph* SdCardFont::onGlyphMiss(void* ctx, uint32_t codepoint) {
   bool wasAtCapacity = (self->overflowCount_ == OVERFLOW_CAPACITY);
 
   // Read glyph metadata into temporary. The shared handle skips the per-miss file open
-  // (~5-8ms of FAT walk) that dominated mid-build early renders.
+  // (~5-8ms of FAT walk) that dominated mid-build early renders. The lock keeps this
+  // seek+read sequence atomic against any other task using the handle.
+  FontFileLock fontFileLock(self->fontFileMutex_);
   if (!self->ensureFontFile()) {
     LOG_ERR("SDCF", "Overflow: failed to open .cpfont");
     return nullptr;

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -432,8 +432,7 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
   }
 
   // Step 6: read the full matrix's rows for each used left class, keep only
-  // columns for used right classes. One SD seek + one read per used left class;
-  // a row is kernRightClassCount bytes (~200 for Literata).
+  // columns for used right classes.
   HalFile file;
   if (!Storage.openFileForRead("SDCF", filePath_, file)) {
     LOG_ERR("SDCF", "Failed to open .cpfont for mini kern: %s", filePath_);
@@ -441,30 +440,56 @@ bool SdCardFont::buildMiniKernMatrix(PerStyle& s, const uint32_t* codepoints, ui
     return false;
   }
 
-  std::unique_ptr<int8_t[]> rowBuf(new (std::nothrow) int8_t[s.header.kernRightClassCount]);
-  if (!rowBuf) {
-    LOG_ERR("SDCF", "Failed to allocate row buffer (%u bytes)", s.header.kernRightClassCount);
-    freeStyleMiniKern(s);
-    return false;
+  // Fast path: pull the whole matrix in ONE seek+read and slice rows from RAM.
+  // The per-row loop below costs one HalFile round-trip (mutex + seek + ~200B
+  // read) per used left class -- measured on an X3 device log at ~150ms per
+  // page turn for a 26-row page, vs ~10ms for one contiguous read of the full
+  // 148x107 (~16KB) matrix. The buffer is transient (freed before return) and
+  // heap-gated: on a tight heap the row loop still works, so this is a pure
+  // speedup, never a new failure mode.
+  const uint32_t fullMatrixBytes = static_cast<uint32_t>(s.header.kernLeftClassCount) * s.header.kernRightClassCount;
+  constexpr uint32_t FULL_MATRIX_READ_CAP = 24 * 1024;
+  std::unique_ptr<int8_t[]> fullBuf;
+  if (fullMatrixBytes > 0 && fullMatrixBytes <= FULL_MATRIX_READ_CAP &&
+      ESP.getMaxAllocHeap() >= fullMatrixBytes + 8 * 1024) {
+    fullBuf.reset(new (std::nothrow) int8_t[fullMatrixBytes]);
   }
+  if (fullBuf && file.seekSet(s.kernMatrixFileOffset) &&
+      file.read(reinterpret_cast<uint8_t*>(fullBuf.get()), fullMatrixBytes) == static_cast<int>(fullMatrixBytes)) {
+    for (uint8_t newL = 1; newL <= numLeft; newL++) {
+      const int8_t* row = fullBuf.get() + (newToOldLeft[newL] - 1u) * s.header.kernRightClassCount;
+      int8_t* miniRow = s.miniKernMatrix + (newL - 1u) * numRight;
+      for (uint8_t newR = 1; newR <= numRight; newR++) {
+        miniRow[newR - 1] = row[newToOldRight[newR] - 1u];
+      }
+    }
+  } else {
+    fullBuf.reset();  // failed alloc/read: fall back to per-row round-trips
+    std::unique_ptr<int8_t[]> rowBuf(new (std::nothrow) int8_t[s.header.kernRightClassCount]);
+    if (!rowBuf) {
+      LOG_ERR("SDCF", "Failed to allocate row buffer (%u bytes)", s.header.kernRightClassCount);
+      freeStyleMiniKern(s);
+      return false;
+    }
 
-  for (uint8_t newL = 1; newL <= numLeft; newL++) {
-    const uint8_t oldL = newToOldLeft[newL];
-    const uint32_t rowFileOff = s.kernMatrixFileOffset + (oldL - 1u) * s.header.kernRightClassCount;
-    if (!file.seekSet(rowFileOff)) {
-      LOG_ERR("SDCF", "Failed to seek to kern row %u", oldL);
-      freeStyleMiniKern(s);
-      return false;
-    }
-    if (file.read(reinterpret_cast<uint8_t*>(rowBuf.get()), s.header.kernRightClassCount) !=
-        static_cast<int>(s.header.kernRightClassCount)) {
-      LOG_ERR("SDCF", "Failed to read kern row %u", oldL);
-      freeStyleMiniKern(s);
-      return false;
-    }
-    int8_t* miniRow = s.miniKernMatrix + (newL - 1u) * numRight;
-    for (uint8_t newR = 1; newR <= numRight; newR++) {
-      miniRow[newR - 1] = rowBuf[newToOldRight[newR] - 1u];
+    for (uint8_t newL = 1; newL <= numLeft; newL++) {
+      const uint8_t oldL = newToOldLeft[newL];
+      const uint32_t rowFileOff = s.kernMatrixFileOffset + (oldL - 1u) * s.header.kernRightClassCount;
+      if (!file.seekSet(rowFileOff)) {
+        LOG_ERR("SDCF", "Failed to seek to kern row %u", oldL);
+        freeStyleMiniKern(s);
+        return false;
+      }
+      if (file.read(reinterpret_cast<uint8_t*>(rowBuf.get()), s.header.kernRightClassCount) !=
+          static_cast<int>(s.header.kernRightClassCount)) {
+        LOG_ERR("SDCF", "Failed to read kern row %u", oldL);
+        freeStyleMiniKern(s);
+        return false;
+      }
+      int8_t* miniRow = s.miniKernMatrix + (newL - 1u) * numRight;
+      for (uint8_t newR = 1; newR <= numRight; newR++) {
+        miniRow[newR - 1] = rowBuf[newToOldRight[newR] - 1u];
+      }
     }
   }
 

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -205,7 +205,7 @@ bool SdCardFont::ensureFontFile() const {
 }
 
 void SdCardFont::freeAll() {
-  fontFile_.close();
+  if (fontFile_.isOpen()) fontFile_.close();
   clearOverflow();
   clearPersistentCache();
   for (uint8_t i = 0; i < MAX_STYLES; i++) {

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <HalStorage.h>
+
 #include <cstdint>
 #include <deque>
 #include <string>
@@ -329,6 +331,12 @@ class SdCardFont {
 
   // Global helpers
   void freeAll();
+  // Shared read handle for the per-glyph hot paths (overflow miss, mini kern matrix, tail
+  // glyph lookup). A fresh openFileForRead costs ~5-8ms of FAT walk per call -- the dominant
+  // cost of mid-build early renders, which miss on nearly every glyph. Opened lazily,
+  // closed in freeAll() and on any read failure (so an SD hiccup gets a clean reopen).
+  mutable HalFile fontFile_;
+  bool ensureFontFile() const;
   void clearOverflow();
   static void computeStyleFileOffsets(PerStyle& s, uint32_t baseOffset);
 

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <HalStorage.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 #include <cstdint>
 #include <deque>
@@ -26,7 +28,7 @@ class SdCardFont {
   static constexpr uint16_t MAX_PAGE_GLYPHS = 512;
   static constexpr uint8_t MAX_STYLES = 4;
 
-  SdCardFont() = default;
+  SdCardFont() : fontFileMutex_(xSemaphoreCreateMutex()) {}
   ~SdCardFont();
   // Owns raw buffers freed in dtor — no shallow-copy semantics. Make any
   // accidental pass-by-value or move a compile-time error.
@@ -331,12 +333,30 @@ class SdCardFont {
 
   // Global helpers
   void freeAll();
-  // Shared read handle for the per-glyph hot paths (overflow miss, mini kern matrix, tail
-  // glyph lookup). A fresh openFileForRead costs ~5-8ms of FAT walk per call -- the dominant
-  // cost of mid-build early renders, which miss on nearly every glyph. Opened lazily,
-  // closed in freeAll() and on any read failure (so an SD hiccup gets a clean reopen).
+  // Shared read handle for the per-glyph hot paths (overflow miss, mini kern matrix). A
+  // fresh openFileForRead costs ~5-8ms of FAT walk per call -- the dominant cost of
+  // mid-build early renders, which miss on nearly every glyph. Opened lazily, closed in
+  // freeAll() and on any read failure (so an SD hiccup gets a clean reopen).
+  //
+  // fontFileMutex_ makes each seek+read SEQUENCE atomic: HalFile's storage mutex only
+  // serializes individual calls, and while the RenderLock serializes the known callers
+  // today (render task draws; loop-task build ticks hold the RenderLock), that invariant
+  // is implicit -- a background path measuring text while the render task resolves a miss
+  // would interleave seeks and read the wrong offsets. Uncontended take is ~1us, nothing
+  // against the SD reads it guards. Lock order: fontFileMutex_ -> storage mutex (inside
+  // HalFile); nothing takes them in the other order.
   mutable HalFile fontFile_;
+  mutable SemaphoreHandle_t fontFileMutex_ = nullptr;
   bool ensureFontFile() const;
+  struct FontFileLock {
+    SemaphoreHandle_t m;
+    explicit FontFileLock(SemaphoreHandle_t mutex) : m(mutex) {
+      if (m) xSemaphoreTake(m, portMAX_DELAY);
+    }
+    ~FontFileLock() {
+      if (m) xSemaphoreGive(m);
+    }
+  };
   void clearOverflow();
   static void computeStyleFileOffsets(PerStyle& s, uint32_t baseOffset);
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -865,7 +865,12 @@ bool Epub::extractItemToFile(const std::string& itemHref, const std::string& des
   if (!Storage.openFileForWrite("EBP", destPath, out)) {
     return false;
   }
-  const bool ok = readItemContentsToStream(itemHref, out, 4096);
+  // Extraction targets are images (hundreds of KB): SD write throughput is dominated by
+  // per-chunk latency, so 4KB chunks measured ~100KB/s on an X3 device log (9.3s for one
+  // 928KB illustration). 16KB chunks cut the round-trips 4x. readFileToStream allocates
+  // 2x chunkSize transiently, so gate on the heap and keep 4KB as the tight-heap fallback.
+  const size_t chunkSize = ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : 4096;
+  const bool ok = readItemContentsToStream(itemHref, out, chunkSize);
   out.flush();
   out.close();
   if (!ok) {

--- a/lib/Epub/Epub/PageTextExtractor.cpp
+++ b/lib/Epub/Epub/PageTextExtractor.cpp
@@ -45,8 +45,9 @@ std::string PageTextExtractor::fromVerticalPage(const VerticalPage& page) {
     // companion font mid-page (confirmed on-device: Kyokasho page flipping to NotoSans after
     // the first tate-chu-yoko number).
     if (g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
-      if (!g.rotatedRunText.empty()) {
-        text += g.rotatedRunText;
+      const std::string& runText = page.glyphTextStr(g);
+      if (!runText.empty()) {
+        text += runText;
       }
       continue;
     }
@@ -58,8 +59,9 @@ std::string PageTextExtractor::fromVerticalPage(const VerticalPage& page) {
     // the prewarm covers them too; otherwise every ruby character is an on-demand SD read
     // through the 8-slot overflow ring on EVERY page render (measured: 120 reads, ~750ms/page
     // on a furigana-dense book).
-    if (!g.rubyText.empty()) {
-      text += g.rubyText;
+    const std::string& rubyText = page.glyphTextStr(g);
+    if (!rubyText.empty()) {
+      text += rubyText;
     }
   }
 

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -651,7 +651,12 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   int columnYShift = 0;
   uint16_t shiftColumn = UINT16_MAX;
 
-  auto pushGlyph = [this, &columnYShift, &shiftColumn](std::vector<VerticalGlyph>& glyphs, VerticalGlyph g) {
+  auto pushGlyph = [this, &columnYShift, &shiftColumn](VerticalPage& pg, VerticalGlyph g,
+                                                       const std::string& text = std::string()) {
+    std::vector<VerticalGlyph>& glyphs = pg.glyphs;
+    // Intern before the push: on a dropped glyph the orphaned pool entry is a few wasted
+    // bytes, while interning after would need the glyph's index to patch -- not worth it.
+    if (!text.empty()) g.textId = pg.internText(text);
     if (g.column != shiftColumn) {
       columnYShift = 0;
       shiftColumn = g.column;
@@ -795,8 +800,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       g.x = static_cast<uint16_t>(columnLeftX(col));
       g.y = static_cast<uint16_t>(rowIdx * cellPx);
       g.renderKind = VerticalGlyph::RotatedPunct;
-      g.rubyText = pc.rubyText;
-      pushGlyph(page.glyphs, g);
+      pushGlyph(page, g, pc.rubyText);
       return;
     }
 
@@ -807,8 +811,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       g.x = static_cast<uint16_t>(columnLeftX(col) + std::max(1, cellPx / 8));
       g.y = static_cast<uint16_t>(rowIdx * cellPx + ascender - std::max(1, cellPx / 8));
       g.renderKind = VerticalGlyph::Upright;
-      g.rubyText = pc.rubyText;
-      pushGlyph(page.glyphs, g);
+      pushGlyph(page, g, pc.rubyText);
       return;
     }
 
@@ -829,8 +832,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     g.x = static_cast<uint16_t>(gx);
     g.y = static_cast<uint16_t>(gy);
     g.renderKind = VerticalGlyph::Upright;
-    g.rubyText = pc.rubyText;
-    pushGlyph(page.glyphs, g);
+    pushGlyph(page, g, pc.rubyText);
   };
 
   auto placeUpright = [&](const PendingChar& pc) { placeUprightAt(pc, column, row); };
@@ -923,8 +925,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     g.byteOffset = stream_[i0].byteOffset;
     g.style = stream_[i0].style;
     g.renderKind = VerticalGlyph::UprightRun;
-    g.rotatedRunText = runUtf8;
-    pushGlyph(page.glyphs, g);
+    pushGlyph(page, g, runUtf8);
 
     row++;
     if (row >= rowsPerColumn) {
@@ -1249,8 +1250,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         g.byteOffset = pc.byteOffset;
         g.style = pc.style;
         g.renderKind = VerticalGlyph::RotatedRun;
-        g.rotatedRunText = runUtf8;
-        pushGlyph(page.glyphs, g);
+        pushGlyph(page, g, runUtf8);
 
         const uint16_t digitColumn = column;
         row = static_cast<uint16_t>(row + rowsNeeded);
@@ -1353,8 +1353,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.byteOffset = pc.byteOffset;
           g.style = pc.style;
           g.renderKind = VerticalGlyph::RotatedRun;
-          g.rotatedRunText = remaining;
-          pushGlyph(page.glyphs, g);
+          pushGlyph(page, g, remaining);
           row = static_cast<uint16_t>(row + remRows);
           takeUpRunSlack(startY, runInkWidth(remaining, remWidthPx, runStyle), row, g.column, nextInkOffset);
           if (row >= rowsPerColumn) {
@@ -1411,8 +1410,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
             g.byteOffset = pc.byteOffset;
             g.style = pc.style;
             g.renderKind = VerticalGlyph::RotatedRun;
-            g.rotatedRunText = remaining;
-            pushGlyph(page.glyphs, g);
+            pushGlyph(page, g, remaining);
             row = static_cast<uint16_t>(std::min<int>(row + remRows, rowsPerColumn));
             if (row >= rowsPerColumn) {
               column++;
@@ -1448,8 +1446,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         g.byteOffset = pc.byteOffset;
         g.style = pc.style;
         g.renderKind = VerticalGlyph::RotatedRun;
-        g.rotatedRunText = chunk;
-        pushGlyph(page.glyphs, g);
+        pushGlyph(page, g, chunk);
 
         row = static_cast<uint16_t>(row + chunkRows);
         if (row >= rowsPerColumn) {
@@ -1515,7 +1512,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           }
           g.paragraphIndex = pc.paragraphIndex;
           g.byteOffset = pc.byteOffset;
-          pushGlyph(prevPage.glyphs, g);
+          pushGlyph(prevPage, g, pc.rubyText);
           idx++;
           continue;
         }

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -1082,6 +1082,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     if (column < columnsPerPage && !page.glyphs.empty() && !pageVectorCanTakeMore()) {
       LOG_INF("VPT", "Page glyph buffer cannot grow (%u glyphs, maxAlloc=%u); early page break",
               static_cast<unsigned>(page.glyphs.size()), ESP.getMaxAllocHeap());
+      everSplitForHeap_ = true;
       column = columnsPerPage;
       finalizePageIfNeeded();
       row = columnStartRow(false);

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -596,10 +596,27 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     const size_t requestBytes = glyphsPerPage * sizeof(VerticalGlyph);
     if (ESP.getMaxAllocHeap() >= requestBytes + MIN_FREE_HEAP_FOR_RESERVE) {
       p.glyphs.reserve(glyphsPerPage);
-    } else {
-      LOG_ERR("VPT", "Skipping page glyphs reserve (%u bytes doesn't fit, free=%u); growing incrementally",
-              static_cast<unsigned>(requestBytes), ESP.getMaxAllocHeap());
+      return;
     }
+    // Partial fallback: reserve the largest fitting fraction of the page instead of nothing.
+    // Starting from capacity 0 makes the vector double 1-2-4-...-256, and every doubling's
+    // grow-copy (old + new buffer coexisting) is a fresh chance to land on a heap dip -- on
+    // the X3's tighter heap that fired the emergency page split constantly, which the reader
+    // sees as pages breaking at random fill levels. This runs right after the previous page
+    // was flushed and freed (the heap's local best), so one medium block now prevents most of
+    // the risky growth steps later at the dips.
+    for (size_t fraction = 2; fraction <= 8; fraction *= 2) {
+      const size_t partial = glyphsPerPage / fraction;
+      if (partial < 32) break;
+      if (ESP.getMaxAllocHeap() >= (partial * sizeof(VerticalGlyph)) + MIN_FREE_HEAP_FOR_RESERVE) {
+        p.glyphs.reserve(partial);
+        LOG_DBG("VPT", "Partial page glyphs reserve: %u/%u elements (maxAlloc=%u)", static_cast<unsigned>(partial),
+                static_cast<unsigned>(glyphsPerPage), ESP.getMaxAllocHeap());
+        return;
+      }
+    }
+    LOG_ERR("VPT", "Skipping page glyphs reserve (%u bytes doesn't fit, free=%u); growing incrementally",
+            static_cast<unsigned>(requestBytes), ESP.getMaxAllocHeap());
   };
 
   // Skipping the reserve above is only safe if every individual push_back is ALSO guarded --

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -234,6 +234,10 @@ class VerticalParsedText {
   // that dropped content produced sparse pages and must not be persisted as a VALID cache --
   // that makes the truncation permanent. Fresh object per build, so no explicit clear needed.
   bool everDroppedForHeap() const { return everDroppedForHeap_; }
+  // True when any page was closed early by the emergency split (glyph vector could not grow on
+  // a heap dip). No content is lost, but the pagination is degraded -- pages end at arbitrary
+  // fill levels -- so the build path treats it like a drop: usable now, rebuilt next open.
+  bool everSplitForHeap() const { return everSplitForHeap_; }
   // Pin stream_'s backing store once at build start, while the heap is freshest. Mid-build
   // growth (alloc-copy-free every few dozen entries) interleaved with ruby-string churn walks
   // the buffer through the heap and shreds the largest contiguous block -- observed on a real
@@ -280,6 +284,7 @@ class VerticalParsedText {
   // canPushStreamChar()).
   bool oom_ = false;
   bool everDroppedForHeap_ = false;  // see everDroppedForHeap()
+  bool everSplitForHeap_ = false;    // see everSplitForHeap()
 
   // Boxed-block state. inBox_/boxStartCol_ persist across batches (a box can span many flushes);
   // the marker vectors are per-batch (cleared in reset(), with boundary carry flags above).

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -37,19 +37,21 @@ struct VerticalGlyph {
   uint8_t renderKind = Upright;
   uint8_t style = 0;      // EpdFontFamily::Style flags (BOLD, ITALIC, etc.)
   bool emphasis = false;  // text-emphasis (sesame dots beside character)
-  // Populated for run render kinds (RotatedRun/UprightRun).
-  std::string rotatedRunText;
-  // Furigana/ruby annotation for this glyph (UTF-8). Rendered in a smaller
-  // font to the right of the base character in vertical layout.
-  std::string rubyText;
+  // Index into the owning VerticalPage's texts pool: the run string for
+  // RotatedRun/UprightRun glyphs, the furigana/ruby annotation (UTF-8) for
+  // every other kind. NO_TEXT = none. An id instead of inline std::strings
+  // keeps the glyph a ~28-byte POD -- two always-present strings cost ~48
+  // bytes per glyph even when empty, tripling every page buffer, reserve and
+  // grow-copy on the heap-tight X3. The id travels WITH the glyph through
+  // oikomi moves and drop paths, so there is no side table to desync.
+  static constexpr uint16_t NO_TEXT = 0xFFFF;
+  uint16_t textId = NO_TEXT;
 };
 
 // One screen's worth of vertically laid out text, ready to hand to
-// VerticalTextBlock::render(). Most fields are fixed-size and serialize
-// trivially; the only variable-length piece is VerticalGlyph::rotatedRunText
-// on entries where rotated == true, which needs a length-prefixed write/read
-// (see docs/vertical-text-design.md for the proposed vsections/*.bin layout)
-// rather than a flat memcpy of the vector.
+// VerticalTextBlock::render(). Glyph records are fixed-size; the variable-length
+// ruby/run strings live in the page's texts pool (length-prefixed on disk, after
+// the glyph array -- see VerticalSection's writePage/readPage).
 // Pixel-space border rectangle for a boxed (kakomi) block on this page, in the same logical
 // coordinate space as VerticalGlyph::x/y (the renderer adds its offsets identically).
 struct VerticalBoxRect {
@@ -85,6 +87,20 @@ struct VerticalBlockParams {
 struct VerticalPage {
   std::vector<VerticalGlyph> glyphs;
   std::vector<VerticalBoxRect> boxes;
+  // Variable-length glyph texts (ruby annotations, rotated/upright run strings), referenced
+  // by VerticalGlyph::textId. Pooled per page so the glyph array stays fixed-size POD.
+  std::vector<std::string> texts;
+  const char* glyphText(const VerticalGlyph& g) const { return g.textId < texts.size() ? texts[g.textId].c_str() : ""; }
+  const std::string& glyphTextStr(const VerticalGlyph& g) const {
+    static const std::string kEmpty;
+    return g.textId < texts.size() ? texts[g.textId] : kEmpty;
+  }
+  // Appends `s` to the pool and returns its id; NO_TEXT for an empty string or a full pool.
+  uint16_t internText(std::string s) {
+    if (s.empty() || texts.size() >= VerticalGlyph::NO_TEXT) return VerticalGlyph::NO_TEXT;
+    texts.push_back(std::move(s));
+    return static_cast<uint16_t>(texts.size() - 1);
+  }
   uint16_t columnCount = 0;
   uint16_t rowsPerColumn = 0;
   // If non-empty, this page is an image page — render the image instead of glyphs.

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1112,7 +1112,11 @@ struct LayoutPageSink final : ParagraphSink {
           // Restore hands back a white framebuffer, which the next page render repaints anyway;
           // the panel keeps showing its last refreshed image throughout (e-ink is persistent).
           GfxRenderer::FrameBufferLoan loan(renderer);
-          extracted = epub.readItemContentsToStream(resolvedSrc, cachedFile, 4096);
+          // 16KB chunks when the heap allows (the loan just freed 48KB): SD write throughput
+          // is per-chunk-latency bound -- 4KB chunks measured ~100KB/s on an X3 (9.3s for one
+          // 928KB illustration). 4KB stays as the tight-heap fallback.
+          extracted =
+              epub.readItemContentsToStream(resolvedSrc, cachedFile, ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : 4096);
         }
         cachedFile.flush();
         cachedFile.close();
@@ -1184,7 +1188,10 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
     if (!Storage.openFileForWrite("VSC", tmpHtmlPath, tmpHtml)) {
       continue;
     }
-    success = epub->readItemContentsToStream(localPath, tmpHtml, PARSE_BUFFER_SIZE);
+    // Larger extraction chunks when the heap allows -- this is a fresh build with fonts
+    // released, and the ~600-800ms per-chapter inflate+write is chunk-latency bound.
+    success = epub->readItemContentsToStream(localPath, tmpHtml,
+                                             ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
     tmpHtml.close();
     if (!success && Storage.exists(tmpHtmlPath.c_str())) {
       Storage.remove(tmpHtmlPath.c_str());

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -53,7 +53,10 @@ namespace {
 // v102: aside/figure/figcaption joined isBlockTag (parity with the horizontal parser's
 // SECTION_FILE_VERSION 68 bump), so kakomi boxes and figure blocks on those tags now break
 // paragraphs and pick up styled-block params. A v101 cache flowed them as inline text.
-constexpr uint8_t VSECTION_FILE_VERSION = 102;
+// v103: no format change -- bumped so every vertical cache re-paginates once with the
+// partial-reserve fix, replacing pages that older builds split at random fill levels
+// under X3 heap pressure (no manual .crosspoint deletion needed).
+constexpr uint8_t VSECTION_FILE_VERSION = 103;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -1331,7 +1334,10 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
 
   // OR, don't assign: the styled-block collect above may already have flagged this build
   // (unstyled fallback under heap pressure).
-  lastBuildDroppedForHeap_ = lastBuildDroppedForHeap_ || layout.everDroppedForHeap();
+  // Emergency page splits count as heap degradation too: no content is lost, but pages end at
+  // arbitrary fill levels, so the same usable-now/rebuild-next-open path applies (and the same
+  // rebuildingFromStale_ guard breaks the loop when a retry degrades again).
+  lastBuildDroppedForHeap_ = lastBuildDroppedForHeap_ || layout.everDroppedForHeap() || layout.everSplitForHeap();
   // Persist harvested furigana pairs; runs after the parse buffers are freed, so the
   // transient merge buffer doesn't compete with layout's peak memory.
   RubyGlossary::merge(epub->getCachePath(), sink.rubyHarvest);

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -609,7 +609,9 @@ bool writePage(Sink& file, const VerticalPage& page) {
   const auto textCount = static_cast<uint16_t>(page.texts.size());
   serialization::writePod(file, textCount);
   for (const auto& t : page.texts) {
-    const auto len = static_cast<uint16_t>(t.size());
+    // Clamp instead of wrapping: a >64KB entry is impossible today (runs are bounded by the
+    // 16KB paragraph cap), but a wrapped uint16_t would silently desync the record.
+    const auto len = static_cast<uint16_t>(std::min<size_t>(t.size(), 0xFFFF));
     serialization::writePod(file, len);
     if (len > 0) {
       file.write(reinterpret_cast<const uint8_t*>(t.data()), len);
@@ -712,12 +714,24 @@ ReadResult readPage(HalFile& file, VerticalPage& page) {
     LOG_ERR("VSC", "Corrupt page record: %u pool texts", textCount);
     return ReadResult::Corrupt;
   }
+  // Same discipline as the glyph reserve above: reserve()/resize() abort under
+  // -fno-exceptions, and a valid on-disk record read on a momentarily tight heap must come
+  // back as HeapRefused (retry later), never a crash and never a cache invalidation.
+  const uint32_t textVecBytes = static_cast<uint32_t>(textCount) * sizeof(std::string);
+  if (page.texts.capacity() < textCount && ESP.getMaxAllocHeap() < textVecBytes + 2 * 1024) {
+    LOG_ERR("VSC", "Text pool needs %u bytes, maxAlloc=%u; refusing read", textVecBytes, ESP.getMaxAllocHeap());
+    return ReadResult::HeapRefused;
+  }
   page.texts.reserve(textCount);
   for (uint16_t ti = 0; ti < textCount; ti++) {
     uint16_t len = 0;
     serialization::readPod(file, len);
     std::string t;
     if (len > 0) {
+      if (ESP.getMaxAllocHeap() < static_cast<uint32_t>(len) + 2 * 1024) {
+        LOG_ERR("VSC", "Pool text %u needs %u bytes, maxAlloc=%u; refusing read", ti, len, ESP.getMaxAllocHeap());
+        return ReadResult::HeapRefused;
+      }
       t.resize(len);
       if (file.read(reinterpret_cast<uint8_t*>(t.data()), len) != static_cast<int>(len)) {
         LOG_ERR("VSC", "Corrupt page record: truncated pool text %u", ti);

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -56,7 +56,9 @@ namespace {
 // v103: no format change -- bumped so every vertical cache re-paginates once with the
 // partial-reserve fix, replacing pages that older builds split at random fill levels
 // under X3 heap pressure (no manual .crosspoint deletion needed).
-constexpr uint8_t VSECTION_FILE_VERSION = 103;
+// v104: glyph records are fixed-size (textId) with a per-page text pool appended after
+// the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
+constexpr uint8_t VSECTION_FILE_VERSION = 104;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -600,19 +602,17 @@ bool writePage(Sink& file, const VerticalPage& page) {
     serialization::writePod(file, g.renderKind);
     serialization::writePod(file, g.style);
     serialization::writePod(file, g.emphasis);
+    serialization::writePod(file, g.textId);
+  }
 
-    if (g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
-      const auto runLen = static_cast<uint16_t>(g.rotatedRunText.size());
-      serialization::writePod(file, runLen);
-      if (runLen > 0) {
-        file.write(reinterpret_cast<const uint8_t*>(g.rotatedRunText.data()), runLen);
-      }
-    }
-
-    const auto rubyLen = static_cast<uint16_t>(g.rubyText.size());
-    serialization::writePod(file, rubyLen);
-    if (rubyLen > 0) {
-      file.write(reinterpret_cast<const uint8_t*>(g.rubyText.data()), rubyLen);
+  // Per-page text pool (v104): ruby annotations and run strings, referenced by textId.
+  const auto textCount = static_cast<uint16_t>(page.texts.size());
+  serialization::writePod(file, textCount);
+  for (const auto& t : page.texts) {
+    const auto len = static_cast<uint16_t>(t.size());
+    serialization::writePod(file, len);
+    if (len > 0) {
+      file.write(reinterpret_cast<const uint8_t*>(t.data()), len);
     }
   }
   return true;
@@ -628,6 +628,7 @@ enum class ReadResult { Ok, HeapRefused, Corrupt };
 ReadResult readPage(HalFile& file, VerticalPage& page) {
   page.glyphs.clear();
   page.boxes.clear();
+  page.texts.clear();
   page.imagePath.clear();
   page.imageSrcPath.clear();
 
@@ -699,23 +700,31 @@ ReadResult readPage(HalFile& file, VerticalPage& page) {
     serialization::readPod(file, g.renderKind);
     serialization::readPod(file, g.style);
     serialization::readPod(file, g.emphasis);
+    serialization::readPod(file, g.textId);
+    page.glyphs.push_back(g);
+  }
 
-    if (g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
-      uint16_t runLen;
-      serialization::readPod(file, runLen);
-      if (runLen > 0) {
-        g.rotatedRunText.resize(runLen);
-        file.read(reinterpret_cast<uint8_t*>(g.rotatedRunText.data()), runLen);
+  // Per-page text pool (v104). Out-of-range textIds render as "no text" (glyphText bounds-
+  // checks), so a short pool degrades visibly but safely.
+  uint16_t textCount = 0;
+  serialization::readPod(file, textCount);
+  if (textCount > MAX_GLYPHS_PER_PAGE) {
+    LOG_ERR("VSC", "Corrupt page record: %u pool texts", textCount);
+    return ReadResult::Corrupt;
+  }
+  page.texts.reserve(textCount);
+  for (uint16_t ti = 0; ti < textCount; ti++) {
+    uint16_t len = 0;
+    serialization::readPod(file, len);
+    std::string t;
+    if (len > 0) {
+      t.resize(len);
+      if (file.read(reinterpret_cast<uint8_t*>(t.data()), len) != static_cast<int>(len)) {
+        LOG_ERR("VSC", "Corrupt page record: truncated pool text %u", ti);
+        return ReadResult::Corrupt;
       }
     }
-
-    uint16_t rubyLen;
-    serialization::readPod(file, rubyLen);
-    if (rubyLen > 0) {
-      g.rubyText.resize(rubyLen);
-      file.read(reinterpret_cast<uint8_t*>(g.rubyText.data()), rubyLen);
-    }
-    page.glyphs.push_back(std::move(g));
+    page.texts.push_back(std::move(t));
   }
   return ReadResult::Ok;
 }

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -62,13 +62,13 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
     int dy = g.y + offsetY + globalDownNudge;
 
     if (g.renderKind == VerticalGlyph::RotatedRun) {
-      renderer.drawTextRotated90CCW(fontId, dx, dy, g.rotatedRunText.c_str(), black,
+      renderer.drawTextRotated90CCW(fontId, dx, dy, page.glyphText(g), black,
                                     static_cast<EpdFontFamily::Style>(g.style));
       continue;
     }
 
     if (g.renderKind == VerticalGlyph::UprightRun) {
-      renderer.drawText(fontId, dx, dy, g.rotatedRunText.c_str(), black, static_cast<EpdFontFamily::Style>(g.style));
+      renderer.drawText(fontId, dx, dy, page.glyphText(g), black, static_cast<EpdFontFamily::Style>(g.style));
       continue;
     }
 
@@ -143,7 +143,8 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
   uint16_t prevRubyColumn = UINT16_MAX;
 
   for (const VerticalGlyph& g : page_.glyphs) {
-    if (g.rubyText.empty() || g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
+    const std::string& rubyText = page_.glyphTextStr(g);
+    if (rubyText.empty() || g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
       continue;
     }
 
@@ -152,8 +153,8 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
     size_t rubyCharCount = 0;
     {
       size_t ri = 0;
-      while (ri < g.rubyText.size()) {
-        const auto c0 = static_cast<unsigned char>(g.rubyText[ri]);
+      while (ri < rubyText.size()) {
+        const auto c0 = static_cast<unsigned char>(rubyText[ri]);
         if (c0 < 0x80)
           ri += 1;
         else if ((c0 & 0xE0) == 0xC0)
@@ -180,8 +181,8 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
     prevRubyColumn = g.column;
 
     size_t ri = 0;
-    while (ri < g.rubyText.size()) {
-      const auto c0 = static_cast<unsigned char>(g.rubyText[ri]);
+    while (ri < rubyText.size()) {
+      const auto c0 = static_cast<unsigned char>(rubyText[ri]);
       size_t charLen = 1;
       if (c0 >= 0xF0)
         charLen = 4;
@@ -190,10 +191,10 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
       else if (c0 >= 0xC0)
         charLen = 2;
 
-      if (ri + charLen > g.rubyText.size()) break;
+      if (ri + charLen > rubyText.size()) break;
 
       char buf[5];
-      std::memcpy(buf, g.rubyText.data() + ri, charLen);
+      std::memcpy(buf, rubyText.data() + ri, charLen);
       buf[charLen] = '\0';
 
       renderer.drawText(rubyFontId, rubyX, rubyY, buf, black, rubyStyle);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make book opening, first-time chapter builds, and page turns faster on the X3 (269 KB total heap, wider 528 px viewport), and fix the "pages split at random fill levels" report — all driven by one tester's serial log and a reproducing EPUB.
* **What changes are included?**
  * **Kern matrix in one SD read** (`SdCardFont::buildMiniKernMatrix`): the per-page mini kern build did one `HalFile` round-trip per used class row (~150 ms per page turn measured); it now reads the whole matrix (≤24 KB transient, heap-gated) in one seek+read and slices rows from RAM. Row loop kept as the tight-heap fallback.
  * **Shared persistent font read handle** (`SdCardFont`): the per-glyph miss path paid a fresh `openFileForRead` (~5–8 ms FAT walk) per missed glyph — mid-build early renders miss on nearly every glyph (~2 s per served page in the log). Overflow misses and the kern read now reuse one lazily-opened handle, closed in `freeAll()` and on read failures.
  * **16 KB extraction chunks** (heap-gated, 4 KB fallback): EPUB→SD streaming was per-chunk-latency bound (~100 KB/s; one 928 KB illustration took 9.3 s). Applied to `extractItemToFile`, the vertical build's image extraction (the actual logged path), and the chapter HTML temp write.
  * **Random page splits fixed** (`reservePageGlyphs`): the full-page glyph reserve rarely fit mid-build on the X3, so the vector doubled from zero and every grow-copy was a chance to land on a heap dip and trigger the emergency page split. The reserve now falls back to the largest fitting fraction (½/¼/⅛, min 32) instead of nothing.
  * **Split caches self-heal**: emergency splits now flag the build heap-degraded, reusing the existing usable-now → stale-mark → rebuild-next-open path (loop-guarded by `rebuildingFromStale_`).
  * **`VerticalGlyph` slimmed to a ~28-byte POD**: two always-present `std::string`s (~48 B even when empty) tripled every page buffer (~20 KB → ~8 KB per X3 page). Ruby/run strings move to a per-page `texts` pool referenced by a `uint16_t textId` that travels **with** the glyph through oikomi moves and drop paths — no index-keyed side table to desync. Bonus: cross-page oikomi pull-back now preserves ruby it previously dropped.
  * `VSECTION_FILE_VERSION` 102 → 104 (103: no format change, forces one re-paginate so split caches heal without manual `.crosspoint` deletion; 104: fixed-size glyph records + appended text pool). Neither shipped, so users pay one rebuild total.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

`freeink-sdk/` and `lib/hal/` are untouched.

## Additional Context

* **Evidence**: every fix maps to a measured line in an X3 device log (per-turn kern reload timings, `advance merge` at maxAlloc=2804 during builds, the 9.3 s ZIP inflate, "Page glyph buffer cannot grow" splits) plus a reproducing single-TOC novel EPUB.
* **Memory**: net reduction everywhere — smaller glyph structs shrink every page buffer, reserve, grow-copy, and cache read-back; the extraction buffers and kern matrix buffer are transient and heap-gated with the previous behavior as fallback.
* **Risks / focus areas**: the shared font handle's lifecycle (closed on `freeAll()` and read failures for clean reopen); textId/pool consistency through oikomi and drop paths; the v104 serialization round-trip (pool bounds-guarded on read; out-of-range ids render as no text, never OOB).
* Verified: `pio run -e default` clean; all 129 host unit tests pass; clang-format 21 clean. On-device verification pending — an X4 checklist (furigana, rotated Latin runs, tate-chu-yoko, toggle, resume, lookup) has been handed to a tester; X3 confirmation of fewer splits/faster builds outstanding.
* All caches rebuild once on first open per book after flashing (deliberate; slow first open, fast after).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWncbpyJwf7FoGWh1ewFq3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWncbpyJwf7FoGWh1ewFq3)_