### PR TITLE
feat: improve EPUB image conversion and chapter recovery

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4600,8 +4600,6 @@ async function processImage(data, imageState = 0, imagePath = '') {
       const sourceCanvas = source.canvas;
       const sourceW = source.width;
       const sourceH = source.height;
-      const sourceWasCropped = !!source.crop;
-
       // imageState: 0=Normal, 1=H-Split (CW/CCW), 2=V-Split, 3=Rotate & Fit
       // ========================================================================
       // STATE 1: H-Split (Rotate + Split) - EXACT COPY FROM index.html
@@ -4843,91 +4841,55 @@ async function processImage(data, imageState = 0, imagePath = '') {
         rotCtx.drawImage(sourceCanvas, 0, 0);
         rotCtx.setTransform(1, 0, 0, 1, 0, 0);
 
-        // Step 2: Scale to fit the reader viewport (if needed)
-        const fitsInScreen = rotW <= MAX_WIDTH && rotH <= MAX_HEIGHT;
-        
-        if (fitsInScreen && !sourceWasCropped) {
-          // Already fits after rotation - just apply grayscale
-          applyGrayscale(rotCtx, rotW, rotH);
-          const blob = await canvasToDitheredBmp(rotCanvas);
-          const arrBuf = await blob.arrayBuffer();
-          resolve({
-            parts: [{ data: arrBuf, suffix: '', width: rotW, height: rotH, size: arrBuf.byteLength }],
-            meta: { origW, origH, origSize, wasSplit: false, rotated: true, finalW: rotW, finalH: rotH, finalSize: arrBuf.byteLength, imageState: 3 }
-          });
-        } else {
-          // Scale to fit the reader viewport
-          const scale = Math.min(MAX_WIDTH / rotW, MAX_HEIGHT / rotH);
-          const newW = Math.round(rotW * scale);
-          const newH = Math.round(rotH * scale);
+        // Step 2: Scale to fill one viewport dimension before dithering.
+        const scale = Math.min(MAX_WIDTH / rotW, MAX_HEIGHT / rotH);
+        const newW = Math.round(rotW * scale);
+        const newH = Math.round(rotH * scale);
 
-          const scaledCanvas = document.createElement('canvas');
-          scaledCanvas.width = newW;
-          scaledCanvas.height = newH;
-          const scaledCtx = scaledCanvas.getContext('2d');
-          scaledCtx.imageSmoothingEnabled = true;
-          scaledCtx.imageSmoothingQuality = 'high';
-          scaledCtx.fillStyle = '#FFF';
-          scaledCtx.fillRect(0, 0, newW, newH);
-          scaledCtx.drawImage(rotCanvas, 0, 0, newW, newH);
-          applyGrayscale(scaledCtx, newW, newH);
+        const scaledCanvas = document.createElement('canvas');
+        scaledCanvas.width = newW;
+        scaledCanvas.height = newH;
+        const scaledCtx = scaledCanvas.getContext('2d');
+        scaledCtx.imageSmoothingEnabled = true;
+        scaledCtx.imageSmoothingQuality = 'high';
+        scaledCtx.fillStyle = '#FFF';
+        scaledCtx.fillRect(0, 0, newW, newH);
+        scaledCtx.drawImage(rotCanvas, 0, 0, newW, newH);
+        applyGrayscale(scaledCtx, newW, newH);
 
-          const blob = await canvasToDitheredBmp(scaledCanvas);
-          const arrBuf = await blob.arrayBuffer();
-          resolve({
-            parts: [{ data: arrBuf, suffix: '', width: newW, height: newH, size: arrBuf.byteLength }],
-            meta: { origW, origH, origSize, wasSplit: false, rotated: true, finalW: newW, finalH: newH, finalSize: arrBuf.byteLength, imageState: 3 }
-          });
-        }
+        const blob = await canvasToDitheredBmp(scaledCanvas);
+        const arrBuf = await blob.arrayBuffer();
+        resolve({
+          parts: [{ data: arrBuf, suffix: '', width: newW, height: newH, size: arrBuf.byteLength }],
+          meta: { origW, origH, origSize, wasSplit: false, rotated: true, finalW: newW, finalH: newH, finalSize: arrBuf.byteLength, imageState: 3 }
+        });
       }
       // ========================================================================
       // STATE 0: Normal processing (scale to fit, no split/rotation)
       // ========================================================================
       else {
-        // Normal processing: check if scaling is needed
-        const fitsInScreen = sourceW <= MAX_WIDTH && sourceH <= MAX_HEIGHT;
+        // Always fill one viewport dimension before dithering, including upscaling.
+        const scale = Math.min(MAX_WIDTH / sourceW, MAX_HEIGHT / sourceH);
+        const newW = Math.round(sourceW * scale);
+        const newH = Math.round(sourceH * scale);
 
-        if (fitsInScreen && !sourceWasCropped) {
-          // Image already fits - just convert to native grayscale BMP
-          const c = document.createElement('canvas');
-          c.width = sourceW;
-          c.height = sourceH;
-          const ctx = c.getContext('2d');
-          ctx.fillStyle = '#FFF';
-          ctx.fillRect(0, 0, sourceW, sourceH);
-          ctx.drawImage(sourceCanvas, 0, 0);
-          applyGrayscale(ctx, sourceW, sourceH);
+        const c = document.createElement('canvas');
+        c.width = newW;
+        c.height = newH;
+        const ctx = c.getContext('2d');
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = 'high';
+        ctx.fillStyle = '#FFF';
+        ctx.fillRect(0, 0, newW, newH);
+        ctx.drawImage(sourceCanvas, 0, 0, newW, newH);
+        applyGrayscale(ctx, newW, newH);
 
-          const blob = await canvasToDitheredBmp(c);
-          const arrBuf = await blob.arrayBuffer();
-          resolve({
-            parts: [{ data: arrBuf, suffix: '', width: sourceW, height: sourceH, size: arrBuf.byteLength }],
-            meta: { origW, origH, origSize, wasSplit: false, rotated: false, finalW: sourceW, finalH: sourceH, finalSize: arrBuf.byteLength, imageState: 0 }
-          });
-        } else {
-          // Scale to fit the reader viewport
-          const scale = Math.min(MAX_WIDTH / sourceW, MAX_HEIGHT / sourceH);
-          const newW = Math.round(sourceW * scale);
-          const newH = Math.round(sourceH * scale);
-
-          const c = document.createElement('canvas');
-          c.width = newW;
-          c.height = newH;
-          const ctx = c.getContext('2d');
-          ctx.imageSmoothingEnabled = true;
-          ctx.imageSmoothingQuality = 'high';
-          ctx.fillStyle = '#FFF';
-          ctx.fillRect(0, 0, newW, newH);
-          ctx.drawImage(sourceCanvas, 0, 0, newW, newH);
-          applyGrayscale(ctx, newW, newH);
-
-          const blob = await canvasToDitheredBmp(c);
-          const arrBuf = await blob.arrayBuffer();
-          resolve({
-            parts: [{ data: arrBuf, suffix: '', width: newW, height: newH, size: arrBuf.byteLength }],
-            meta: { origW, origH, origSize, wasSplit: false, rotated: false, finalW: newW, finalH: newH, finalSize: arrBuf.byteLength, imageState: 0 }
-          });
-        }
+        const blob = await canvasToDitheredBmp(c);
+        const arrBuf = await blob.arrayBuffer();
+        resolve({
+          parts: [{ data: arrBuf, suffix: '', width: newW, height: newH, size: arrBuf.byteLength }],
+          meta: { origW, origH, origSize, wasSplit: false, rotated: false, finalW: newW, finalH: newH, finalSize: arrBuf.byteLength, imageState: 0 }
+        });
       }
     };
     img.onerror = () => {
@@ -4940,12 +4902,8 @@ async function processImage(data, imageState = 0, imagePath = '') {
 }
 
 // --- Chapter splitting for single-file novels -------------------------------------------
-// Many Japanese EPUBs ship the whole novel as one or two huge XHTML files whose chapters
-// exist only as visual number headings (a paragraph containing nothing but 1 / ２ / 三).
-// Detect those, split the file at each heading into its own XHTML (real ToC entries, per-
-// chapter page counters on the device, far less RAM pressure while paginating), rewrite
-// the OPF spine/manifest plus nav/NCX. Returns {blob, chapters} or null when there is
-// nothing to split. Mirror of tools/epub_split_chapters.py -- keep the two in sync.
+// Recover missing ToC entries from spine-file headings and split single-file novels at
+// number-only headings. Mirror of tools/epub_split_chapters.py -- keep the two in sync.
 const MRCH_NUM = '(?:[0-9]{1,3}|[０-９]{1,3}|[〇一二三四五六七八九十百]{1,4})';
 const MRCH_HEADING_RE = new RegExp(
   '(?:<div[^>]*>\\s*)?<p[^>]*>\\s*(?:<span[^>]*>\\s*)?(' + MRCH_NUM + ')\\s*(?:<\\/span>\\s*)?<\\/p>\\s*(?:<\\/div>)?', 'gs');
@@ -4960,6 +4918,17 @@ function mrchFindHeadings(html) {
     out.push({ offset: m.index, title: m[1] });
   }
   return out;
+}
+
+function mrchFindChapterTitle(html, fallback) {
+  const body = (html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i) || [])[1] || html;
+  const textOf = markup => markup.replace(/<rt\b[^>]*>[\s\S]*?<\/rt>/gi, '')
+    .replace(/<[^>]+>/g, '').replace(/&nbsp;|&#160;/gi, ' ').trim();
+  const semanticHeading = body.slice(0, 5000).match(/<h[1-6]\b[^>]*>[\s\S]*?<\/h[1-6]>/i);
+  if (semanticHeading) return textOf(semanticHeading[0]) || fallback;
+  const firstText = (body.match(/<p\b[^>]*>[\s\S]*?<\/p>/gi) || [])
+    .map(textOf).find(Boolean);
+  return firstText && firstText.length <= 80 ? firstText : fallback;
 }
 
 function mrchOpenBlocks(html, upto) {
@@ -5022,6 +4991,16 @@ async function splitEpubChapters(file) {
 
   const newFiles = {};
   const tocAdditions = [];   // {href (opf-relative), title}
+  const spineChapters = [];
+  const structuralKey = href => {
+    const m = href.match(/^(.*?)(\d+)(\.(?:xhtml|html|htm))$/i);
+    return m ? m[1] + '#' + m[3].toLowerCase() : null;
+  };
+  const structuralCounts = new Map();
+  for (const idref of spineIds) {
+    const key = structuralKey(manifest[idref] || '');
+    if (key) structuralCounts.set(key, (structuralCounts.get(key) || 0) + 1);
+  }
   let anySplit = false;
   let chapterCount = 0;
 
@@ -5031,7 +5010,14 @@ async function splitEpubChapters(file) {
     const html = await readText(opfDir + href);
     if (!html) continue;
     const headings = mrchFindHeadings(html);
-    if (headings.length < 2) continue;
+    if (headings.length < 2) {
+      const key = structuralKey(href);
+      if (key && structuralCounts.get(key) >= 2) {
+        const fallback = href.split('/').pop().replace(/\.[^.]+$/, '');
+        spineChapters.push({ href, title: mrchFindChapterTitle(html, fallback) });
+      }
+      continue;
+    }
 
     const parts = mrchSplitFile(html, headings.map(h => h.offset));
     const dot = href.lastIndexOf('.');
@@ -5054,16 +5040,25 @@ async function splitEpubChapters(file) {
     anySplit = true;
     chapterCount += parts.length;
   }
-  if (!anySplit) return null;
-
-  const splitNames = new Set(tocAdditions.map(t => t.href.split('/').pop()));
   const baseName = p => (p.split('#')[0]).split('/').pop();
+  let nav = navPath ? await readText(navPath) : null;
+  let ncx = ncxPath ? await readText(ncxPath) : null;
+  const existingNames = new Set();
+  const tocRefRe = /(?:href|src)="([^"]+)"/g;
+  let tocRef;
+  while ((tocRef = tocRefRe.exec(nav || ncx || '')) !== null) existingNames.add(baseName(tocRef[1]));
+  const recoverSpineToc = spineChapters.length >= 2 &&
+    spineChapters.some(t => !existingNames.has(baseName(t.href)));
+  if (recoverSpineToc) {
+    tocAdditions.push(...spineChapters);
+    chapterCount += spineChapters.length;
+  }
+  if (!anySplit && !recoverSpineToc) return null;
 
-  // Nav: numbered entries REPLACE any existing entries pointing into the split files (a
-  // whole-novel title entry would otherwise be listed as if it were a chapter).
-  if (navPath) {
-    let nav = await readText(navPath);
-    if (nav) {
+  const splitNames = new Set(tocAdditions.map(t => baseName(t.href)));
+
+  // Recovered entries replace any existing whole-book entry pointing at the same files.
+  if (navPath && nav) {
       const navDir = navPath.includes('/') ? navPath.slice(0, navPath.lastIndexOf('/') + 1) : '';
       const rel = h => {
         const target = opfDir + h;
@@ -5084,13 +5079,10 @@ async function splitEpubChapters(file) {
         if (mOl) insertAt = nav.indexOf(mOl[1], mOl.index);
       }
       if (insertAt >= 0) newFiles[navPath] = nav.slice(0, insertAt) + items + nav.slice(insertAt);
-    }
   }
 
   // NCX: same replacement semantics.
-  if (ncxPath) {
-    let ncx = await readText(ncxPath);
-    if (ncx) {
+  if (ncxPath && ncx) {
       const ncxDir = ncxPath.includes('/') ? ncxPath.slice(0, ncxPath.lastIndexOf('/') + 1) : '';
       const rel = h => {
         const target = opfDir + h;
@@ -5113,7 +5105,6 @@ async function splitEpubChapters(file) {
         ncx = ncx.replace('</navMap>', points + '</navMap>');
       }
       newFiles[ncxPath] = ncx;
-    }
   }
   newFiles[opfPath] = opf;
 
@@ -5854,12 +5845,11 @@ async function uploadFile() {
         // converted blob and makes file.size point at the optimised size.
         const origFileSize = file.size;
 
-        // Chapter splitting pre-pass: single-file novels whose chapters exist only as
-        // number headings get real per-chapter files + ToC entries (see splitEpubChapters).
+        // Repair chapter structure before image conversion (see splitEpubChapters).
         try {
           const split = await splitEpubChapters(file);
           if (split) {
-            log(`Chapter split: ${split.chapters} number-heading chapters extracted`, '', 'INFO');
+            log(`Chapter structure: ${split.chapters} sections prepared`, '', 'INFO');
             file = new File([split.blob], file.name, { type: 'application/epub+zip' });
           }
         } catch (splitError) {

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1597,7 +1597,7 @@
 
           <div class="convert-settings" id="convertSettings" style="display:block;">
             <span>⚫ True-Grayscale</span>
-          <span id="convertSizeSummary">📏 Max 480×800px</span>
+          <span id="convertSizeSummary">📏 Max 464×764px</span>
           <span>📦 85% JPEG</span>
           <span>🔧 Fix SVG</span>
         </div>
@@ -3287,10 +3287,10 @@ const WS_CHUNK_SIZE = 4096; // 4KB chunks - smaller for ESP32 stability
 // EPUB Image Conversion Functions (from Baseline JPEG Converter)
 // ============================================================================
 
-// Device profiles (short edge × long edge in portrait orientation)
+// Default reader viewport: panel size minus viewable-area and 5px reader margins.
 const DEVICE_PROFILES = {
-  X4: { width: 480, height: 800, label: 'X4' },
-  X3: { width: 528, height: 792, label: 'X3' },
+  X4: { width: 464, height: 764, label: 'X4' },
+  X3: { width: 512, height: 756, label: 'X3' },
 };
 
 // Default conversion settings
@@ -4605,14 +4605,14 @@ async function processImage(data, imageState = 0, imagePath = '') {
       // imageState: 0=Normal, 1=H-Split (CW/CCW), 2=V-Split, 3=Rotate & Fit
       // ========================================================================
       // STATE 1: H-Split (Rotate + Split) - EXACT COPY FROM index.html
-      // Step 1: Scale WIDTH to 800px (keep aspect ratio)
+      // Step 1: Scale WIDTH to the viewport's long edge (keep aspect ratio)
       // Step 2: Rotate 90° CW or CCW based on HANDEDNESS
-      // Step 3: If WIDTH > 480, split vertically with overlap
+      // Step 3: If WIDTH exceeds the viewport, split vertically with overlap
       // ========================================================================
       if (imageState === 1) {
-        // Step 1: Scale WIDTH to 800 (this is the key difference!)
-        const scale = MAX_HEIGHT / sourceW;  // 800 / sourceW
-        const scaledW = MAX_HEIGHT;  // 800
+        // Step 1: Scale WIDTH to the viewport's long edge (this is the key difference!)
+        const scale = MAX_HEIGHT / sourceW;
+        const scaledW = MAX_HEIGHT;
         const scaledH = Math.round(sourceH * scale);
 
         const scaledCanvas = document.createElement('canvas');
@@ -4627,7 +4627,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
 
         // Step 2: Rotate 90° CW or CCW
         const rotW = scaledH;
-        const rotH = scaledW;  // 800
+        const rotH = scaledW;
 
         const rotCanvas = document.createElement('canvas');
         rotCanvas.width = rotW;
@@ -4650,7 +4650,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         rotCtx.setTransform(1, 0, 0, 1, 0, 0); // Reset transform
         applyGrayscale(rotCtx, rotW, rotH);
 
-        // Step 3: If WIDTH > 480, split vertically
+        // Step 3: If WIDTH exceeds the viewport, split vertically
         if (rotW <= MAX_WIDTH) {
           const blob = await canvasToDitheredBmp(rotCanvas);
           const arrBuf = await blob.arrayBuffer();
@@ -4661,7 +4661,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         } else {
           // Split by WIDTH (vertical cuts) - from RIGHT to LEFT for CW, LEFT to RIGHT for CCW
           const parts = [];
-          const maxW = MAX_WIDTH;  // 480
+          const maxW = MAX_WIDTH;
           
           // Centered distribution: calculate numParts first, then distribute evenly
           let overlapPx, step, numParts;
@@ -4731,14 +4731,14 @@ async function processImage(data, imageState = 0, imagePath = '') {
       }
       // ========================================================================
       // STATE 2: V-Split (Vertical Split, no rotation)
-      // Step 1: Scale HEIGHT to 800px (up or down)
-      // Step 2: If WIDTH > 480, split vertically with overlap
+      // Step 1: Scale HEIGHT to the viewport's long edge (up or down)
+      // Step 2: If WIDTH exceeds the viewport, split vertically with overlap
       // ========================================================================
       else if (imageState === 2) {
-        // ALWAYS scale height to 800 (up or down)
-        const scale = MAX_HEIGHT / sourceH;  // 800 / sourceH
+        // Always scale height to the viewport's long edge (up or down)
+        const scale = MAX_HEIGHT / sourceH;
         const scaledW = Math.round(sourceW * scale);
-        const scaledH = MAX_HEIGHT;  // Always 800
+        const scaledH = MAX_HEIGHT;
 
         const scaledCanvas = document.createElement('canvas');
         scaledCanvas.width = scaledW;
@@ -4818,7 +4818,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         }
       }
       // ========================================================================
-      // STATE 3: Rotate & Fit (Rotate 90°, then scale to fit 480x800, no split)
+      // STATE 3: Rotate & Fit (Rotate 90°, then scale to fit the reader viewport, no split)
       // ========================================================================
       else if (imageState === 3) {
         // Step 1: Rotate 90° based on handedness
@@ -4843,7 +4843,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         rotCtx.drawImage(sourceCanvas, 0, 0);
         rotCtx.setTransform(1, 0, 0, 1, 0, 0);
 
-        // Step 2: Scale to fit 480x800 (if needed)
+        // Step 2: Scale to fit the reader viewport (if needed)
         const fitsInScreen = rotW <= MAX_WIDTH && rotH <= MAX_HEIGHT;
         
         if (fitsInScreen && !sourceWasCropped) {
@@ -4856,7 +4856,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
             meta: { origW, origH, origSize, wasSplit: false, rotated: true, finalW: rotW, finalH: rotH, finalSize: arrBuf.byteLength, imageState: 3 }
           });
         } else {
-          // Scale to fit 480x800
+          // Scale to fit the reader viewport
           const scale = Math.min(MAX_WIDTH / rotW, MAX_HEIGHT / rotH);
           const newW = Math.round(rotW * scale);
           const newH = Math.round(rotH * scale);
@@ -4905,7 +4905,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
             meta: { origW, origH, origSize, wasSplit: false, rotated: false, finalW: sourceW, finalH: sourceH, finalSize: arrBuf.byteLength, imageState: 0 }
           });
         } else {
-          // Scale to fit 480x800
+          // Scale to fit the reader viewport
           const scale = Math.min(MAX_WIDTH / sourceW, MAX_HEIGHT / sourceH);
           const newW = Math.round(sourceW * scale);
           const newH = Math.round(sourceH * scale);

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4383,8 +4383,9 @@ function applyGrayscale(ctx, width, height) {
   ctx.putImageData(imageData, 0, 0);
 }
 
-// Same 1-bit Atkinson diffusion used by the manga thumbnail pipeline. Images
-// have already been fitted to the device canvas before this runs.
+// Images are fitted to the selected device before a serpentine Floyd-Steinberg
+// pass. Alternating direction avoids the diagonal "woven" texture produced by
+// the old left-to-right Atkinson pass while keeping the compact 1-bit BMP output.
 async function canvasToDitheredBmp(canvas) {
   const { width, height } = canvas;
   const pixels = canvas.getContext('2d').getImageData(0, 0, width, height).data;
@@ -4396,17 +4397,29 @@ async function canvasToDitheredBmp(canvas) {
   view.setUint16(26, 1, true); view.setUint16(28, 1, true); view.setUint32(34, rowBytes * height, true);
   view.setUint32(38, 2835, true); view.setUint32(42, 2835, true); view.setUint32(46, 2, true); view.setUint32(50, 2, true);
   bytes.set([0, 0, 0, 0, 255, 255, 255, 0], 54);
-  let e0 = new Int16Array(width + 4), e1 = new Int16Array(width + 4), e2 = new Int16Array(width + 4);
+  let currentError = new Int16Array(width + 2);
+  let nextError = new Int16Array(width + 2);
   for (let y = 0; y < height; y++) {
     const dst = 62 + y * rowBytes;
-    for (let x = 0; x < width; x++) {
+    const reverse = (y & 1) !== 0;
+    for (let step = 0; step < width; step++) {
+      const x = reverse ? width - 1 - step : step;
       const i = (y * width + x) * 4, a = pixels[i + 3] / 255;
-      let gray = Math.max(0, Math.min(255, Math.round((pixels[i] * .299 + pixels[i + 1] * .587 + pixels[i + 2] * .114) * a + 255 * (1 - a)) + e0[x + 2]));
-      const white = gray >= 128, error = (gray - (white ? 255 : 0)) >> 3;
-      e0[x + 3] += error; e0[x + 4] += error; e1[x + 1] += error; e1[x + 2] += error; e1[x + 3] += error; e2[x + 2] += error;
+      const sourceGray = Math.round((pixels[i] * .299 + pixels[i + 1] * .587 + pixels[i + 2] * .114) * a + 255 * (1 - a));
+      const gray = Math.max(0, Math.min(255, sourceGray + currentError[x + 1]));
+      const white = gray >= 128;
+      const error = gray - (white ? 255 : 0);
+      const direction = reverse ? -1 : 1;
+      currentError[x + 1 + direction] += (error * 7) >> 4;
+      nextError[x + 1 - direction] += (error * 3) >> 4;
+      nextError[x + 1] += (error * 5) >> 4;
+      nextError[x + 1 + direction] += error >> 4;
       if (white) bytes[dst + (x >> 3)] |= 0x80 >> (x & 7);
     }
-    [e0, e1, e2] = [e1, e2, new Int16Array(width + 4)];
+    const oldError = currentError;
+    currentError = nextError;
+    nextError = oldError;
+    nextError.fill(0);
   }
   return new Blob([bytes], { type: 'image/bmp' });
 }
@@ -4875,7 +4888,7 @@ async function processImage(data, imageState = 0, imagePath = '') {
         const fitsInScreen = sourceW <= MAX_WIDTH && sourceH <= MAX_HEIGHT;
 
         if (fitsInScreen && !sourceWasCropped) {
-          // Image already fits - just convert to JPEG with grayscale
+          // Image already fits - just convert to native grayscale BMP
           const c = document.createElement('canvas');
           c.width = sourceW;
           c.height = sourceH;

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1598,7 +1598,7 @@
           <div class="convert-settings" id="convertSettings" style="display:block;">
             <span>⚫ True-Grayscale</span>
           <span id="convertSizeSummary">📏 Max 464×764px</span>
-          <span>📦 85% JPEG</span>
+          <span>📦 1-bit BMP</span>
           <span>🔧 Fix SVG</span>
         </div>
         <!-- Advanced Settings Content -->
@@ -5047,7 +5047,7 @@ async function splitEpubChapters(file) {
   const tocRefRe = /(?:href|src)="([^"]+)"/g;
   let tocRef;
   while ((tocRef = tocRefRe.exec(nav || ncx || '')) !== null) existingNames.add(baseName(tocRef[1]));
-  const recoverSpineToc = spineChapters.length >= 2 &&
+  const recoverSpineToc = !!(nav || ncx) && spineChapters.length >= 2 &&
     spineChapters.some(t => !existingNames.has(baseName(t.href)));
   if (recoverSpineToc) {
     tocAdditions.push(...spineChapters);

--- a/tools/epub_split_chapters.py
+++ b/tools/epub_split_chapters.py
@@ -205,7 +205,7 @@ def main():
     elif ncx_path and ncx_path in files:
         toc_source = files[ncx_path].decode("utf-8")
     existing_names = {Path(h.split("#", 1)[0]).name for h in re.findall(r'(?:href|src)="([^"]+)"', toc_source)}
-    recover_spine_toc = len(spine_chapters) >= 2 and any(
+    recover_spine_toc = bool(toc_source) and len(spine_chapters) >= 2 and any(
         Path(href).name not in existing_names for href, _ in spine_chapters
     )
     if recover_spine_toc:
@@ -302,7 +302,7 @@ def main():
                 continue
             zout.writestr(name, data, compress_type=zipfile.ZIP_DEFLATED)
 
-    print(f"Wrote {dst} ({total_new_chapters} chapter files)")
+    print(f"Wrote {dst} ({total_new_chapters} sections prepared)")
 
 
 if __name__ == "__main__":

--- a/tools/epub_split_chapters.py
+++ b/tools/epub_split_chapters.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Split single-file EPUB novels into per-chapter files with real ToC entries.
+"""Repair EPUB chapter structure and ToC entries.
 
 Many Japanese EPUBs ship a whole novel as one or two huge XHTML files whose
 chapters exist only as visual number headings (a paragraph containing nothing
@@ -7,12 +7,9 @@ but 1 / ２ / 三 between empty paragraphs). E-readers then see a single giant
 "chapter": no ToC navigation, page counters spanning the whole book, and heavy
 memory pressure while paginating the file.
 
-This tool detects those number-only heading blocks, splits each spine file at
-the heading boundaries into separate XHTML files, rewrites the OPF manifest and
-spine, and appends matching entries to the EPUB3 nav document and the EPUB2
-NCX. The first part keeps the original filename so existing ToC hrefs and
-anchors stay valid. Content bytes are never modified -- only sliced -- so text,
-furigana, and styling are untouched.
+It also recovers missing ToC entries when the OPF spine already contains a
+numbered sequence of XHTML files. File structure decides what is a section;
+the first heading or paragraph is used only as its display label.
 
 Usage:
     python3 epub_split_chapters.py input.epub [output.epub]
@@ -47,6 +44,31 @@ def find_headings(html: str):
             continue
         out.append((m.start(), m.group(1)))
     return out
+
+
+def structural_key(href: str):
+    """Group numbered XHTML files by directory, prefix, and extension."""
+    match = re.match(r"^(.*?)(\d+)(\.(?:xhtml|html|htm))$", href, re.I)
+    return (match.group(1), match.group(3).lower()) if match else None
+
+
+def chapter_title(html: str, fallback: str):
+    """Use visible heading text only as a label; structure decides membership."""
+    body_match = re.search(r"<body\b[^>]*>(.*?)</body>", html, re.I | re.S)
+    body = body_match.group(1) if body_match else html
+
+    def text_of(markup):
+        markup = re.sub(r"<rt\b[^>]*>.*?</rt>", "", markup, flags=re.I | re.S)
+        return re.sub(r"<[^>]+>", "", markup).replace("&nbsp;", " ").replace("&#160;", " ").strip()
+
+    heading = re.search(r"<h[1-6]\b[^>]*>.*?</h[1-6]>", body[:5000], re.I | re.S)
+    if heading:
+        return text_of(heading.group(0)) or fallback
+    for paragraph in re.findall(r"<p\b[^>]*>.*?</p>", body, re.I | re.S)[:8]:
+        text = text_of(paragraph)
+        if text:
+            return text if len(text) <= 80 else fallback
+    return fallback
 
 
 def open_block_tags(html: str, upto: int):
@@ -129,8 +151,14 @@ def main():
 
     new_files = {}
     toc_additions = []  # (href_rel_to_opf, title)
+    spine_chapters = []
     spine_replacements = {}  # original idref -> [idrefs]
     manifest_additions = []  # (id, href)
+    structural_counts = {}
+    for idref in spine_ids:
+        key = structural_key(manifest.get(idref, ""))
+        if key:
+            structural_counts[key] = structural_counts.get(key, 0) + 1
 
     total_new_chapters = 0
     for idref in spine_ids:
@@ -144,6 +172,9 @@ def main():
         html = files[full].decode("utf-8")
         headings = find_headings(html)
         if len(headings) < MIN_HEADINGS_PER_FILE:
+            key = structural_key(href)
+            if key and structural_counts[key] >= 2:
+                spine_chapters.append((href, chapter_title(html, Path(href).stem)))
             continue
 
         offsets = [o for o, _ in headings]
@@ -168,8 +199,21 @@ def main():
         total_new_chapters += len(parts)
         print(f"{href}: {len(parts)} chapters ({', '.join(t for _, t in headings)})")
 
-    if not spine_replacements:
-        print("No splittable number-heading chapters found; nothing to do.")
+    toc_source = ""
+    if nav_path and nav_path in files:
+        toc_source = files[nav_path].decode("utf-8")
+    elif ncx_path and ncx_path in files:
+        toc_source = files[ncx_path].decode("utf-8")
+    existing_names = {Path(h.split("#", 1)[0]).name for h in re.findall(r'(?:href|src)="([^"]+)"', toc_source)}
+    recover_spine_toc = len(spine_chapters) >= 2 and any(
+        Path(href).name not in existing_names for href, _ in spine_chapters
+    )
+    if recover_spine_toc:
+        toc_additions.extend(spine_chapters)
+        total_new_chapters += len(spine_chapters)
+
+    if not spine_replacements and not recover_spine_toc:
+        print("No chapter structure repair needed; nothing to do.")
         sys.exit(0)
 
     # --- Rewrite OPF ---


### PR DESCRIPTION
## Summary
- convert EPUB images to viewport-sized 1-bit BMPs using serpentine Floyd-Steinberg dithering
- scale images to fill one target dimension before dithering, including upscaling
- recover incomplete EPUB navigation from numbered XHTML spine structure
- preserve and expose existing split-chapter conversion support

## Validation
- `pio run -e private`
- browser-side `splitEpubChapters` run against epub from tester
- generated EPUB ZIP, BMP, OPF, nav, and NCX validation