### PR TITLE
fix: preserve EPUB chapter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Reading streak, weekly minutes, books finished, total time, and a monthly calend
 - **Per-book reader settings** — font, size, spacing, margins, orientation and more are remembered per book; the global settings page holds the defaults for books you haven't opened yet
 - **CJK fallback font** — a non-Japanese book with the odd kanji renders it from a built-in font covering kana, the 2,136 Jōyō and 863 Jinmeiyō kanji
 - **Chapter splitting** — Japanese novels shipped as one giant XHTML file get real chapters (and a working ToC) when uploaded with **Optimize EPUB**
-- **Device-ready EPUB images** — **Optimize EPUB** fits images to the X3/X4 screen and writes dithered 1-bit BMPs using the manga pipeline's Atkinson diffusion
+- **Device-ready EPUB images** — **Optimize EPUB** fits images to the X3/X4 reader viewport and writes 1-bit BMPs using serpentine Floyd–Steinberg dithering
 - **Instant image page turns** — the next page's image decodes in the background, so illustrated novels don't stall on it
 - **Transparent sleep screen** — a wallpaper overlaid on the page you were reading, so the book shows through
 - **Book side margins** — ignore the book's own CSS side margins by default, so the text column follows your margin setting

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4992,6 +4992,8 @@ async function splitEpubChapters(file) {
   const newFiles = {};
   const tocAdditions = [];   // {href (opf-relative), title}
   const spineChapters = [];
+  const tocOrder = new Map();
+  const spineOrder = new Map(spineIds.map((idref, index) => [idref, index]));
   const structuralKey = href => {
     const m = href.match(/^(.*?)(\d+)(\.(?:xhtml|html|htm))$/i);
     return m ? m[1] + '#' + m[3].toLowerCase() : null;
@@ -5015,6 +5017,7 @@ async function splitEpubChapters(file) {
       if (key && structuralCounts.get(key) >= 2) {
         const fallback = href.split('/').pop().replace(/\.[^.]+$/, '');
         spineChapters.push({ href, title: mrchFindChapterTitle(html, fallback) });
+        tocOrder.set(href, spineOrder.get(idref));
       }
       continue;
     }
@@ -5029,6 +5032,7 @@ async function splitEpubChapters(file) {
       const partId = i === 0 ? idref : idref + '-mr' + (i + 1);
       newFiles[opfDir + partHref] = parts[i];
       tocAdditions.push({ href: partHref, title: headings[i].title });
+      tocOrder.set(partHref, spineOrder.get(idref) + i / parts.length);
       if (i > 0) {
         opf = opf.replace('</manifest>',
           '<item id="' + partId + '" href="' + partHref + '" media-type="application/xhtml+xml"/>\n</manifest>');
@@ -5054,6 +5058,7 @@ async function splitEpubChapters(file) {
     chapterCount += spineChapters.length;
   }
   if (!anySplit && !recoverSpineToc) return null;
+  tocAdditions.sort((a, b) => tocOrder.get(a.href) - tocOrder.get(b.href));
 
   const splitNames = new Set(tocAdditions.map(t => baseName(t.href)));
 

--- a/tools/epub_split_chapters.py
+++ b/tools/epub_split_chapters.py
@@ -152,6 +152,8 @@ def main():
     new_files = {}
     toc_additions = []  # (href_rel_to_opf, title)
     spine_chapters = []
+    toc_order = {}
+    spine_order = {idref: index for index, idref in enumerate(spine_ids)}
     spine_replacements = {}  # original idref -> [idrefs]
     manifest_additions = []  # (id, href)
     structural_counts = {}
@@ -175,6 +177,7 @@ def main():
             key = structural_key(href)
             if key and structural_counts[key] >= 2:
                 spine_chapters.append((href, chapter_title(html, Path(href).stem)))
+                toc_order[href] = spine_order[idref]
             continue
 
         offsets = [o for o, _ in headings]
@@ -195,6 +198,7 @@ def main():
             new_files[str(Path(opf_dir) / part_href)] = part.encode("utf-8")
             part_ids.append(part_id)
             toc_additions.append((part_href, headings[i][1]))
+            toc_order[part_href] = spine_order[idref] + i / len(parts)
         spine_replacements[idref] = part_ids
         total_new_chapters += len(parts)
         print(f"{href}: {len(parts)} chapters ({', '.join(t for _, t in headings)})")
@@ -215,6 +219,7 @@ def main():
     if not spine_replacements and not recover_spine_toc:
         print("No chapter structure repair needed; nothing to do.")
         sys.exit(0)
+    toc_additions.sort(key=lambda item: toc_order[item[0]])
 
     # --- Rewrite OPF ---
     for part_id, part_href in manifest_additions:


### PR DESCRIPTION
Follow-up to #28.

- keep mixed split/recovered chapter entries in spine order
- align the README with the actual serpentine Floyd–Steinberg converter

Validated with the mixed-structure EPUB fixture and a private firmware build.