### PR TITLE
fix: apply Japanese reader settings

### DIFF
--- a/lib/EpdFont/SdCardFontManager.cpp
+++ b/lib/EpdFont/SdCardFontManager.cpp
@@ -105,7 +105,6 @@ void SdCardFontManager::unloadAll(GfxRenderer& renderer) {
   // sdCardFonts_ streaming entry for each id this manager owns.
   // Drop UI CJK fallbacks before the SD fonts they point at are freed.
   renderer.clearFallbackFonts();
-  renderer.clearSdCardFonts();
   for (auto& lf : loaded_) {
     renderer.removeFont(lf.fontId);
     delete lf.font;

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -10,6 +10,7 @@
 #include <XmlParserUtils.h>
 #include <expat.h>
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 
@@ -58,7 +59,8 @@ namespace {
 // under X3 heap pressure (no manual .crosspoint deletion needed).
 // v104: glyph records are fixed-size (textId) with a per-page text pool appended after
 // the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
-constexpr uint8_t VSECTION_FILE_VERSION = 104;
+// v105: the header includes the vertical column-spacing setting.
+constexpr uint8_t VSECTION_FILE_VERSION = 105;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -554,7 +556,7 @@ namespace {
 
 // ---- Page (de)serialization (cache format v37) -----------------------------------------------
 // File layout:
-//   header: u8 version, i32 fontId, u16 viewportWidth, u16 viewportHeight,
+//   header: u8 version, i32 fontId, u16 viewportWidth, u16 viewportHeight, u8 lineSpacing,
 //           u16 pageCount, u32 indexOffset          (pageCount/indexOffset patched post-stream)
 //   page records (variable length, written as pages are laid out)
 //   footer at indexOffset: pageCount x u32 file offset of each page record
@@ -1179,13 +1181,13 @@ struct LayoutPageSink final : ParagraphSink {
   }
 };
 
-// Byte offset of the pageCount field in the header: u8 version + i32 fontId + 2x u16 viewport.
-constexpr size_t HEADER_PAGECOUNT_OFFSET = 1 + sizeof(int) + 2 * sizeof(uint16_t);
+// Byte offset of the pageCount field in the header.
+constexpr size_t HEADER_PAGECOUNT_OFFSET = 1 + sizeof(int) + 2 * sizeof(uint16_t) + sizeof(uint8_t);
 
 }  // namespace
 
 bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const uint16_t viewportWidth,
-                                           const uint16_t viewportHeight) {
+                                           const uint16_t viewportHeight, const uint8_t lineSpacing) {
   lastBuildDroppedForHeap_ = false;
   // Diagnostic: the "sparse page" investigation found maxAlloc already down at the very first
   // paragraph flush, staying flat for the rest of the chapter -- logging both metrics here checks
@@ -1245,9 +1247,12 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   VerticalParsedText layout(renderer, fontId, viewportWidth, viewportHeight);
   layout.preallocateStream();
   const int lineH = renderer.getLineHeight(fontId);
-  layout.setColumnGapPx((lineH / 3) < 4 ? 4 : (lineH / 3));
+  // Tight/Normal/Wide use one, two, or four sixths of a line between columns.
+  const int clampedLineSpacing = std::clamp<int>(lineSpacing, 0, 2);
+  const int gapSixths = clampedLineSpacing == 2 ? 4 : clampedLineSpacing + 1;
+  layout.setColumnGapPx(std::max(4, lineH * gapSixths / 6));
   if (hasRuby) {
-    layout.setColumnGapPx(lineH * 2 / 3);
+    layout.setColumnGapPx(std::max(4, lineH * (gapSixths + 2) / 6));
     layout.setRightPaddingPx((lineH / 2) < 2 ? 2 : (lineH / 2));
   }
 
@@ -1377,7 +1382,8 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   return true;
 }
 
-bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight) {
+bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight,
+                                        const uint8_t lineSpacing) {
   const auto vsectionsDir = epub->getCachePath() + "/vsections";
   Storage.mkdir(vsectionsDir.c_str());
 
@@ -1397,12 +1403,13 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   serialization::writePod(file, fontId);
   serialization::writePod(file, viewportWidth);
   serialization::writePod(file, viewportHeight);
+  serialization::writePod(file, lineSpacing);
   const uint16_t pageCountPlaceholder = 0;
   const uint32_t indexOffsetPlaceholder = 0;
   serialization::writePod(file, pageCountPlaceholder);
   serialization::writePod(file, indexOffsetPlaceholder);
 
-  if (!streamParseAndLayout(file, fontId, viewportWidth, viewportHeight)) {
+  if (!streamParseAndLayout(file, fontId, viewportWidth, viewportHeight, lineSpacing)) {
     file.close();
     Storage.remove(filePath.c_str());
     pageOffsets_.clear();
@@ -1446,7 +1453,8 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   return true;
 }
 
-bool VerticalSection::loadSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight) {
+bool VerticalSection::loadSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight,
+                                      const uint8_t lineSpacing) {
   // A missing cache file is the NORMAL case here, not an error: the book-progress counter probes
   // every spine's section on each page turn, and unbuilt chapters simply don't have one yet.
   // openFileForRead would print "File does not exist" per spine per probe -- pure log spam.
@@ -1472,11 +1480,14 @@ bool VerticalSection::loadSectionFile(const int fontId, const uint16_t viewportW
 
   int cachedFontId;
   uint16_t cachedWidth, cachedHeight;
+  uint8_t cachedLineSpacing;
   serialization::readPod(file, cachedFontId);
   serialization::readPod(file, cachedWidth);
   serialization::readPod(file, cachedHeight);
+  serialization::readPod(file, cachedLineSpacing);
 
-  if (cachedFontId != fontId || cachedWidth != viewportWidth || cachedHeight != viewportHeight) {
+  if (cachedFontId != fontId || cachedWidth != viewportWidth || cachedHeight != viewportHeight ||
+      cachedLineSpacing != lineSpacing) {
     file.close();
     LOG_DBG("VSC", "Parameter mismatch, clearing cache");
     clearCache();

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -48,7 +48,8 @@ class VerticalSection {
   // a valid cache. See lastReadHeapRefused().
   mutable bool lastReadHeapRefused_ = false;
 
-  bool streamParseAndLayout(HalFile& out, int fontId, uint16_t viewportWidth, uint16_t viewportHeight);
+  bool streamParseAndLayout(HalFile& out, int fontId, uint16_t viewportWidth, uint16_t viewportHeight,
+                            uint8_t lineSpacing);
 
   // Set by streamParseAndLayout when the layout dropped chars/glyphs on low heap. The pages that
   // made it to disk are readable (this session keeps working), but createSectionFile stamps the
@@ -99,8 +100,8 @@ class VerticalSection {
   // collapse to the final target.
   void requestPageDuringBuild(int pageIndex) { buildPageRequest_.store(pageIndex, std::memory_order_relaxed); }
 
-  bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight);
-  bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight);
+  bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing);
+  bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing);
   bool clearCache() const;
   const VerticalPage* getPage() const;
   const VerticalPage* getPage(int pageIndex) const;

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -276,14 +276,15 @@ void SdCardFontSystem::ensureJpFallback(GfxRenderer& renderer, const uint8_t poi
     return;
   }
 
-  // Selected font (built-in, or a Latin-only SD font) can't render Japanese: prefer
-  // NotoSerifJP, then any other family that proves CJK-capable when loaded.
-  auto extensionRank = [](const std::string& name) {
+  // Selected font (built-in, or a Latin-only SD font) can't render Japanese: pair a
+  // built-in Noto face with its matching JP extension, then try the other extension.
+  const bool preferSans = selected.empty() && SETTINGS.fontFamily == CrossPointSettings::NOTOSANS;
+  auto extensionRank = [preferSans](const std::string& name) {
     std::string norm;
     for (const char c : name) {
       if (std::isalnum(static_cast<unsigned char>(c))) norm.push_back(static_cast<char>(std::tolower(c)));
     }
-    return norm == "notoserifjp" ? 0 : 1;
+    return norm == (preferSans ? "notosansjp" : "notoserifjp") ? 0 : 1;
   };
   std::vector<const SdCardFontFamilyInfo*> candidates;
   for (const auto& fam : registry_.getFamilies()) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1661,7 +1661,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       sectionFootnotes.clear();  // vertical sections don't collect footnotes
 
       const int fontId = effectiveReaderFontId();
-      if (!verticalSection->loadSectionFile(fontId, viewportWidth, viewportHeight)) {
+      if (!verticalSection->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
         LOG_DBG("ERS", "Vertical cache not found, building...");
         GUI.drawPopup(renderer, tr(STR_INDEXING));
         // Same force every horizontal Indexing-popup site applies: the popup paints FAST, and a
@@ -1702,7 +1702,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         earlyPageActuallyDisplayed_ = false;
         earlyDisplayedPage_.store(earlyTarget, std::memory_order_relaxed);
         verticalBuildInProgress_.store(true, std::memory_order_relaxed);
-        const bool built = verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight);
+        const bool built =
+            verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing);
         verticalBuildInProgress_.store(false, std::memory_order_relaxed);
         if (!built) {
           LOG_ERR("ERS", "Failed to build vertical section");
@@ -2486,7 +2487,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
 
     VerticalSection nextVSection(epub, nextSpineIndex, renderer);
     const int fontId = effectiveReaderFontId();
-    if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight)) return;
+    if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) return;
 
     // The vertical build is the most memory-intensive step in the reader, and this
     // silent path runs it at the worst heap moment: right after a page render, with
@@ -2517,7 +2518,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     silentIndexBackoffUntilMs_ = 0;
 
     LOG_DBG("ERS", "Silently indexing next vertical chapter: %d (maxAlloc=%u)", nextSpineIndex, ESP.getMaxAllocHeap());
-    if (!nextVSection.createSectionFile(fontId, viewportWidth, viewportHeight)) {
+    if (!nextVSection.createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
       LOG_ERR("ERS", "Failed silent indexing for vertical chapter: %d", nextSpineIndex);
     }
     return;
@@ -2656,7 +2657,7 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
       // full-page illustration is its own one-page spine item, so this cross-boundary peek is
       // the common case -- silentIndexNextChapterIfNeeded has already built the section file.
       nextV.emplace(epub, currentSpineIndex + 1, renderer);
-      if (nextV->loadSectionFile(fontId, viewportWidth, viewportHeight) && nextV->pageCount > 0) {
+      if (nextV->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing) && nextV->pageCount > 0) {
         vp = nextV->getPage(0);
       } else {
         LOG_DBG("IWARM", "boundary peek failed: spine %d section not loadable", currentSpineIndex + 1);  // TEMP
@@ -3122,7 +3123,7 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
       bool probed = false;
       if (vertical) {
         VerticalSection sibling(epub, i, renderer);
-        if (sibling.loadSectionFile(fontId, viewportWidth, viewportHeight)) {
+        if (sibling.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
           spinePagesReal[i] = sibling.pageCount;
           probed = true;
         }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1111,7 +1111,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       // margin changes are picked up on return: the SD font system reloads to the new selection
       // and the next render's section-cache parameter check rebuilds the layout if needed.
       startActivityForResult(std::make_unique<SettingsActivity>(renderer, mappedInput, /*initialCategory=*/1,
-                                                                /*finishOnBack=*/true),
+                                                                /*finishOnBack=*/true, isJapaneseBook()),
                              [this](const ActivityResult&) {
                                sdFontSystem.ensureLoaded(renderer);
                                sdFontSystem.setJpFallbackNeeded(renderer, isJapaneseBook() || useVerticalText());

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -53,10 +53,9 @@ void SettingsActivity::rebuildSettingsLists() {
   // reader activity ran — otherwise the font-family picker shows stale list.
   sdFontSystem.refreshIfDirty();
 
-  // Rescan /dictionaries on every rebuild: cheap (one directory listing) and
-  // picks up dictionaries copied to the SD card since the last visit.
+  // Japanese books use their own dictionary flow, so omit the regular picker there.
   std::vector<DictionaryEntry> dictionaries;
-  if (!finishOnBack || selectedCategoryIndex == 1) DictionaryRegistry::discover(dictionaries);
+  if (!japaneseBook && (!finishOnBack || selectedCategoryIndex == 1)) DictionaryRegistry::discover(dictionaries);
 
   // Reader-launched settings lock the UI to one category while the book remains
   // resident. Avoid materializing every web/device setting in that low-heap path.
@@ -455,7 +454,7 @@ void SettingsActivity::toggleCurrentSetting() {
         break;
       case SettingAction::TextSettings:
         startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                                      TextSettingsActivity::Tab::Family),
+                                                                      TextSettingsActivity::Tab::Family, japaneseBook),
                                [this](const ActivityResult&) {
                                  saveSettings();
                                  rebuildSettingsLists();

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -154,6 +154,7 @@ class SettingsActivity final : public Activity {
   ButtonNavigator buttonNavigator;
   int initialCategory = 0;
   bool finishOnBack = false;
+  bool japaneseBook = false;
 
   int selectedCategoryIndex = 0;  // Currently selected category
   int selectedSettingIndex = 0;
@@ -186,8 +187,11 @@ class SettingsActivity final : public Activity {
   // finishOnBack: pop back to the pushing activity (e.g. the reader menu's "Reader Settings")
   // instead of replacing the stack with Home.
   explicit SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const int initialCategory = 0,
-                            const bool finishOnBack = false)
-      : Activity("Settings", renderer, mappedInput), initialCategory(initialCategory), finishOnBack(finishOnBack) {}
+                            const bool finishOnBack = false, const bool japaneseBook = false)
+      : Activity("Settings", renderer, mappedInput),
+        initialCategory(initialCategory),
+        finishOnBack(finishOnBack),
+        japaneseBook(japaneseBook) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -512,9 +512,8 @@ int TextSettingsActivity::tabCount() const {
 }
 
 TextSettingsActivity::LayoutRow TextSettingsActivity::layoutRowAt(const int visibleIndex) const {
-  const int row =
-      japaneseBook_ && visibleIndex >= static_cast<int>(LayoutRow::Alignment) ? visibleIndex + 1 : visibleIndex;
-  return static_cast<LayoutRow>(row);
+  if (japaneseBook_ && visibleIndex > 0) return LayoutRow::ScreenMargin;
+  return static_cast<LayoutRow>(visibleIndex);
 }
 
 int TextSettingsActivity::currentListSize() const {
@@ -524,7 +523,7 @@ int TextSettingsActivity::currentListSize() const {
     case Tab::Size:
       return static_cast<int>(sizes_.size());
     case Tab::Layout:
-      return static_cast<int>(LayoutRow::Count) - (japaneseBook_ ? 1 : 0);
+      return static_cast<int>(LayoutRow::Count) - (japaneseBook_ ? 2 : 0);
     case Tab::Style:
       return static_cast<int>(StyleRow::Count);
 

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -51,8 +51,11 @@ constexpr int MARGIN_STEP = CrossPointSettings::SCREEN_MARGIN_STEP;
 }  // namespace
 
 TextSettingsActivity::TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                           const SdCardFontRegistry* registry, Tab initialTab)
-    : Activity("TextSettings", renderer, mappedInput), registry_(registry), tab_(initialTab) {}
+                                           const SdCardFontRegistry* registry, Tab initialTab, const bool japaneseBook)
+    : Activity("TextSettings", renderer, mappedInput),
+      registry_(registry),
+      tab_(initialTab),
+      japaneseBook_(japaneseBook) {}
 
 void TextSettingsActivity::onEnter() {
   Activity::onEnter();
@@ -147,8 +150,8 @@ bool TextSettingsActivity::handleTouch() {
   // (similar to handleListTouch)
   auto buildTabs = [this]() {
     std::vector<TabInfo> tabs;
-    tabs.reserve(static_cast<int>(Tab::Count));
-    for (int t = 0; t < static_cast<int>(Tab::Count); t++) {
+    tabs.reserve(tabCount());
+    for (int t = 0; t < tabCount(); t++) {
       tabs.push_back({I18N.get(TAB_NAME_IDS[t]), tab_ == static_cast<Tab>(t)});
     }
     return tabs;
@@ -253,8 +256,8 @@ void TextSettingsActivity::render(RenderLock&&) {
 
   const bool onTabBar = selectedIndex() == 0;
   std::vector<TabInfo> tabs;
-  tabs.reserve(static_cast<int>(Tab::Count));
-  for (int t = 0; t < static_cast<int>(Tab::Count); t++) {
+  tabs.reserve(tabCount());
+  for (int t = 0; t < tabCount(); t++) {
     tabs.push_back({I18N.get(TAB_NAME_IDS[t]), tab_ == static_cast<Tab>(t)});
   }
   GUI.drawTabBar(renderer, Rect{0, geo.tabTop, pageWidth, metrics_.tabBarHeight}, tabs, onTabBar);
@@ -281,17 +284,16 @@ void TextSettingsActivity::render(RenderLock&&) {
       break;
 
     case Tab::Layout: {
-      constexpr int LAYOUT_ROWS = static_cast<int>(LayoutRow::Count);
-      static constexpr StrId ROW_NAME_IDS[LAYOUT_ROWS] = {StrId::STR_LINE_SPACING, StrId::STR_EXTRA_SPACING,
-                                                          StrId::STR_ALIGNMENT, StrId::STR_SCREEN_MARGIN};
+      static constexpr StrId ROW_NAME_IDS[] = {StrId::STR_LINE_SPACING, StrId::STR_EXTRA_SPACING, StrId::STR_ALIGNMENT,
+                                               StrId::STR_SCREEN_MARGIN};
       GUI.drawList(
-          renderer, listRect, LAYOUT_ROWS, selectedItem,
-          [](int index) { return std::string(I18N.get(ROW_NAME_IDS[index])); }, nullptr, nullptr,
-          [this](int index) { return layoutValueText(index); }, true);
+          renderer, listRect, currentListSize(), selectedItem,
+          [this](int index) { return std::string(I18N.get(ROW_NAME_IDS[static_cast<int>(layoutRowAt(index))])); },
+          nullptr, nullptr, [this](int index) { return layoutValueText(static_cast<int>(layoutRowAt(index))); }, true);
       if (onTabBar)
-        confirmLabel = tr(STR_STYLE);
+        confirmLabel = japaneseBook_ ? tr(STR_FONT) : tr(STR_STYLE);
       else  // Extra Paragraph Spacing toggles; the rest open a picker
-        confirmLabel = (selectedItem == static_cast<int>(LayoutRow::ParaSpacing)) ? tr(STR_TOGGLE) : tr(STR_SELECT);
+        confirmLabel = layoutRowAt(selectedItem) == LayoutRow::ParaSpacing ? tr(STR_TOGGLE) : tr(STR_SELECT);
       break;
     }
 
@@ -379,7 +381,7 @@ void TextSettingsActivity::activateRow(int row) {
       }
       break;
     case Tab::Layout:
-      confirmLayoutRow(row);
+      confirmLayoutRow(static_cast<int>(layoutRowAt(row)));
       break;
     case Tab::Style:
       confirmStyleRow(row);
@@ -499,10 +501,20 @@ bool TextSettingsActivity::focusedRowHasNoPreview() const {
 
 void TextSettingsActivity::switchTab(int direction) {
   const bool onTabBar = selectedIndex() == 0;
-  constexpr int tabCount = static_cast<int>(Tab::Count);
-  tab_ = static_cast<Tab>((static_cast<int>(tab_) + direction + tabCount) % tabCount);
+  const int count = tabCount();
+  tab_ = static_cast<Tab>((static_cast<int>(tab_) + direction + count) % count);
   if (onTabBar) selectedIndex() = 0;
   requestUpdate();
+}
+
+int TextSettingsActivity::tabCount() const {
+  return japaneseBook_ ? static_cast<int>(Tab::Style) : static_cast<int>(Tab::Count);
+}
+
+TextSettingsActivity::LayoutRow TextSettingsActivity::layoutRowAt(const int visibleIndex) const {
+  const int row =
+      japaneseBook_ && visibleIndex >= static_cast<int>(LayoutRow::Alignment) ? visibleIndex + 1 : visibleIndex;
+  return static_cast<LayoutRow>(row);
 }
 
 int TextSettingsActivity::currentListSize() const {
@@ -512,7 +524,7 @@ int TextSettingsActivity::currentListSize() const {
     case Tab::Size:
       return static_cast<int>(sizes_.size());
     case Tab::Layout:
-      return static_cast<int>(LayoutRow::Count);
+      return static_cast<int>(LayoutRow::Count) - (japaneseBook_ ? 1 : 0);
     case Tab::Style:
       return static_cast<int>(StyleRow::Count);
 

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -31,7 +31,7 @@ class TextSettingsActivity final : public Activity {
   };
 
   TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const SdCardFontRegistry* registry,
-                       Tab initialTab = Tab::Family);
+                       Tab initialTab = Tab::Family, bool japaneseBook = false);
 
   void onEnter() override;
   void onExit() override;
@@ -71,7 +71,9 @@ class TextSettingsActivity final : public Activity {
   // True when the focused list row is a setting the preview cannot reflect.
   bool focusedRowHasNoPreview() const;
   void switchTab(int direction = 1);
+  int tabCount() const;
   int currentListSize() const;
+  LayoutRow layoutRowAt(int visibleIndex) const;
   // Navigation ring position for the active tab: 0 = tab bar, 1..N = list item N-1.
   int& selectedIndex();
   int selectedIndex() const;
@@ -99,6 +101,7 @@ class TextSettingsActivity final : public Activity {
   textsettings::PreviewLayout previewLayout_;  // cached preview line layout; relaid only on setting/geometry change
 
   Tab tab_;
+  bool japaneseBook_ = false;
   int selectedIndex_[static_cast<int>(Tab::Count)] =
       {};  // per-Tab nav position (0 = tab bar, 1..N = row); set in onEnter
   int currentFamilyIndex_ = 0;


### PR DESCRIPTION
## Summary

- make Japanese books correctly apply font-family changes, including Noto Sans JP
- hide reader options that do not apply to the Japanese reading flow
- apply Line Spacing to vertical column gaps and include it in vertical pagination cache invalidation
- keep existing screen-margin pagination working for vertical text

## Root cause

Japanese books use the vertical layout and SD-card font paths, which bypassed parts of the horizontal reader settings flow. Noto Sans JP also did not match the expected font-family registration path, and vertical pagination used a fixed column gap.

## Validation

- `.pio-venv/bin/pio run -e default`
- flashed and tested on an X4
- verified Japanese font switching, hidden inapplicable settings, screen margins, and Tight/Normal/Wide column spacing

Closes #33