### PR TITLE
fix: avoid EPUB indexing heap pressure

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -952,7 +952,7 @@ bool Epub::extractItemToFile(const std::string& itemHref, const std::string& des
   // per-chunk latency, so 4KB chunks measured ~100KB/s on an X3 device log (9.3s for one
   // 928KB illustration). 16KB chunks cut the round-trips 4x. readFileToStream allocates
   // 2x chunkSize transiently, so gate on the heap and keep 4KB as the tight-heap fallback.
-  const size_t chunkSize = ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : 4096;
+  const size_t chunkSize = ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : 4096;
   const bool ok = readItemContentsToStream(itemHref, out, chunkSize);
   out.flush();
   out.close();

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1142,8 +1142,7 @@ struct LayoutPageSink final : ParagraphSink {
           // is per-chunk-latency bound -- 4KB chunks measured ~100KB/s on an X3 (9.3s for one
           // 928KB illustration). 4KB stays as the tight-heap fallback.
           extracted = epub.readItemContentsToStream(
-              resolvedSrc, cachedFile,
-              canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : 4096);
+              resolvedSrc, cachedFile, canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : 4096);
         }
         cachedFile.flush();
         cachedFile.close();
@@ -1222,8 +1221,7 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
       const bool canLendFrameBuffer = renderer.hasFrameBuffer();
       GfxRenderer::FrameBufferLoan loan(renderer);
       success = epub->readItemContentsToStream(
-          localPath, tmpHtml,
-          canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
+          localPath, tmpHtml, canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
     }
     tmpHtml.close();
     if (!success && Storage.exists(tmpHtmlPath.c_str())) {

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1138,11 +1138,11 @@ struct LayoutPageSink final : ParagraphSink {
           // the panel keeps showing its last refreshed image throughout (e-ink is persistent).
           const bool canLendFrameBuffer = renderer.hasFrameBuffer();
           GfxRenderer::FrameBufferLoan loan(renderer);
-          // 16KB chunks when the heap allows (the loan just freed 48KB): SD write throughput
-          // is per-chunk-latency bound -- 4KB chunks measured ~100KB/s on an X3 (9.3s for one
-          // 928KB illustration). 4KB stays as the tight-heap fallback.
-          extracted = epub.readItemContentsToStream(
-              resolvedSrc, cachedFile, canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : 4096);
+          // Prefer 16KB chunks when the framebuffer loan is available or the heap is already
+          // roomy; SD write throughput is per-chunk-latency bound. 4KB remains the fallback.
+          const bool useFastChunks = canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024;
+          const size_t chunkSize = useFastChunks ? 16384 : 4096;
+          extracted = epub.readItemContentsToStream(resolvedSrc, cachedFile, chunkSize);
         }
         cachedFile.flush();
         cachedFile.close();
@@ -1215,13 +1215,14 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
       continue;
     }
     // The chapter HTML is fully on SD before parsing or early rendering starts, so temporarily
-    // lend the framebuffer to InflateStream. This keeps the fast 16KB path available even when
-    // the normal heap is fragmented; the popup remains on the e-ink panel while the loan is held.
+    // lend the framebuffer to InflateStream. This keeps the fast 16KB path available when the
+    // loan is held or the heap is roomy; the popup remains on the e-ink panel during the loan.
     {
       const bool canLendFrameBuffer = renderer.hasFrameBuffer();
       GfxRenderer::FrameBufferLoan loan(renderer);
-      success = epub->readItemContentsToStream(
-          localPath, tmpHtml, canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
+      const bool useFastChunks = canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024;
+      const size_t chunkSize = useFastChunks ? 16384 : PARSE_BUFFER_SIZE;
+      success = epub->readItemContentsToStream(localPath, tmpHtml, chunkSize);
     }
     tmpHtml.close();
     if (!success && Storage.exists(tmpHtmlPath.c_str())) {

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1136,12 +1136,14 @@ struct LayoutPageSink final : ParagraphSink {
           // lent, and the early-render hook only fires at page boundaries, never inside this call.
           // Restore hands back a white framebuffer, which the next page render repaints anyway;
           // the panel keeps showing its last refreshed image throughout (e-ink is persistent).
+          const bool canLendFrameBuffer = renderer.hasFrameBuffer();
           GfxRenderer::FrameBufferLoan loan(renderer);
           // 16KB chunks when the heap allows (the loan just freed 48KB): SD write throughput
           // is per-chunk-latency bound -- 4KB chunks measured ~100KB/s on an X3 (9.3s for one
           // 928KB illustration). 4KB stays as the tight-heap fallback.
-          extracted =
-              epub.readItemContentsToStream(resolvedSrc, cachedFile, ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : 4096);
+          extracted = epub.readItemContentsToStream(
+              resolvedSrc, cachedFile,
+              canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : 4096);
         }
         cachedFile.flush();
         cachedFile.close();
@@ -1213,10 +1215,16 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
     if (!Storage.openFileForWrite("VSC", tmpHtmlPath, tmpHtml)) {
       continue;
     }
-    // Larger extraction chunks when the heap allows -- this is a fresh build with fonts
-    // released, and the ~600-800ms per-chapter inflate+write is chunk-latency bound.
-    success = epub->readItemContentsToStream(localPath, tmpHtml,
-                                             ESP.getMaxAllocHeap() >= 64 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
+    // The chapter HTML is fully on SD before parsing or early rendering starts, so temporarily
+    // lend the framebuffer to InflateStream. This keeps the fast 16KB path available even when
+    // the normal heap is fragmented; the popup remains on the e-ink panel while the loan is held.
+    {
+      const bool canLendFrameBuffer = renderer.hasFrameBuffer();
+      GfxRenderer::FrameBufferLoan loan(renderer);
+      success = epub->readItemContentsToStream(
+          localPath, tmpHtml,
+          canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024 ? 16384 : PARSE_BUFFER_SIZE);
+    }
     tmpHtml.close();
     if (!success && Storage.exists(tmpHtmlPath.c_str())) {
       Storage.remove(tmpHtmlPath.c_str());

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2509,7 +2509,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     // also leaves short pages on screen if the reader pages into it this session. Leave the
     // section unbuilt instead: a roomier later tick retries, and the foreground open path
     // (which frees more up front and early-renders) builds it properly on arrival.
-    constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 64 * 1024;
+    constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 96 * 1024;
     if (ESP.getMaxAllocHeap() < SILENT_VBUILD_MIN_ALLOC) {
       LOG_DBG("ERS", "Silent vertical index skipped, heap too tight (maxAlloc=%u)", ESP.getMaxAllocHeap());
       silentIndexBackoffUntilMs_ = millis() + 5000;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Prevent EPUB indexing/page-load failures caused by heap pressure during vertical reflow.
* **What changes are included?**
  * Raise the fast 16 KB extraction threshold from 64 KB to 96 KB.
  * Temporarily lend the framebuffer to the inflater during initial chapter extraction when available.
  * Defer silent vertical indexing when the largest heap block is below 96 KB.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, so maintainer coordination is not needed.

## Additional Context

The failure occurred when a fragmented heap left roughly 69 KB as the largest contiguous block. The 16 KB extraction path needs more room for its two transient buffers plus inflater state, so retries failed and the reader showed a page-load error. The framebuffer loan provides temporary scratch memory for the extraction without changing the rendered UI; the 4 KB path remains as the tight-heap fallback.

Validation:
- `.pio-venv/bin/pio run -e default` passed.
- Flashed and tested on X4.
- Japanese reflow completed with first-page render around 700 ms, full layout around 4.0 s, and 22 cached pages, with no inflater or page-load errors.

Memory / flash impact:
- No new persistent allocation.
- Build image: 6,267,651 bytes; flash usage 95.4%; DRAM usage 16.3%.

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**