### PR TITLE
fix: reader menu showed dead options and orphaned toggles

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -987,12 +987,6 @@ void EpubReaderActivity::openReaderMenu() {
   // never show Word Lookup at all.
   const bool isJapaneseContent = isJapaneseBook() || verticalOverride == 1;
   const bool hasWordLookup = isJapaneseContent && (verticalSection || section) && DictIndex::isAvailable();
-  // Same reasoning as isJapaneseContent above, and for a worse failure: verticalOverride is
-  // persisted per book in progress.bin, so a book whose metadata isn't dc:language=ja but
-  // that has vertical forced on reopens in tategaki -- vertical columns, CJK breaking, no
-  // word spaces. Gating the toggle on isJapaneseBook() alone then HIDES the only control
-  // that turns it back off, leaving the book permanently unreadable.
-  const bool showVerticalToggle = isJapaneseBook() || verticalOverride == 1;
   bool hasPageText = false;
   if (verticalSection) {
     // getPage() faults the page into the section's SINGLE shared page slot -- the same slot the
@@ -1012,33 +1006,45 @@ void EpubReaderActivity::openReaderMenu() {
       std::make_unique<EpubReaderMenuActivity>(
           renderer, mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent, SETTINGS.orientation,
           !sectionFootnotes.empty() || !currentPageFootnotes.empty(), !cachedBookmarks.empty(), hasWordLookup,
-          showVerticalToggle, useVerticalText(), useFurigana(), hasPageText),
+          useVerticalText(), useFurigana(), hasPageText, /*imageReaderMinimal=*/false, /*mangaMode=*/false,
+          /*hideGenericLookup=*/isJapaneseBook()),
       [this](const ActivityResult& result) {
         const auto& menu = std::get<MenuResult>(result.data);
         applyOrientation(menu.orientation);
         toggleAutoPageTurn(menu.pageTurnOption);
-        if (menu.verticalOverride >= 0 && menu.verticalOverride != (useVerticalText() ? 1 : 0)) {
-          verticalOverride = menu.verticalOverride;
-          {
-            // Every other section reset in this file takes the render lock: the render task can
-            // still be inside its (multi-second, section-touching) warm tail when the menu
-            // result lands, and freeing the section under it is a use-after-free.
-            RenderLock lock(*this);
-            section.reset();
-            verticalSection.reset();
-          }
-          // Forcing vertical text on a non-ja book is the same signal
-          // isJapaneseBook() covers at open: JP fallback follows it.
-          sdFontSystem.setJpFallbackNeeded(renderer, isJapaneseBook() || useVerticalText());
-        }
-        if (menu.furiganaOverride >= 0 && menu.furiganaOverride != (useFurigana() ? 1 : 0)) {
-          furiganaOverride = menu.furiganaOverride;
-        }
+        applyVerticalFuriganaOverride(menu.verticalOverride, menu.furiganaOverride);
         if (!result.isCancelled) {
           onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action));
         }
         requestUpdate();
       });
+}
+
+// Shared by the reader menu's own result (menu.verticalOverride/furiganaOverride, always the
+// unchanged state it was opened with -- these toggles no longer live there, see
+// EpubReaderMenuActivity::buildMenuItems) and Reader Settings' result (where they DO change,
+// via SettingInfo::DynamicToggle). -1 means "unset/no book context for this toggle" and is a
+// no-op; each override only applies, and only resets the section, when it actually differs from
+// the book's current effective state.
+void EpubReaderActivity::applyVerticalFuriganaOverride(const int8_t verticalOverrideIn,
+                                                       const int8_t furiganaOverrideIn) {
+  if (verticalOverrideIn >= 0 && verticalOverrideIn != (useVerticalText() ? 1 : 0)) {
+    verticalOverride = verticalOverrideIn;
+    {
+      // Every other section reset in this file takes the render lock: the render task can
+      // still be inside its (multi-second, section-touching) warm tail when this result
+      // lands, and freeing the section under it is a use-after-free.
+      RenderLock lock(*this);
+      section.reset();
+      verticalSection.reset();
+    }
+    // Forcing vertical text on a non-ja book is the same signal isJapaneseBook() covers at
+    // open: JP fallback follows it.
+    sdFontSystem.setJpFallbackNeeded(renderer, isJapaneseBook() || useVerticalText());
+  }
+  if (furiganaOverrideIn >= 0 && furiganaOverrideIn != (useFurigana() ? 1 : 0)) {
+    furiganaOverride = furiganaOverrideIn;
+  }
 }
 
 void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action) {
@@ -1107,12 +1113,25 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       // Push settings opened on the Reader tab; Back pops straight back into the book. Font or
       // margin changes are picked up on return: the SD font system reloads to the new selection
       // and the next render's section-cache parameter check rebuilds the layout if needed.
+      // Vertical Text / Furigana (moved here from the reader's own quick menu -- see
+      // EpubReaderMenuActivity::buildMenuItems) come back the same way the quick menu used to
+      // carry them: a MenuResult, read via get_if since SettingsActivity only sets one when
+      // showVerticalToggle() was true here, so std::monostate elsewhere is expected.
       startActivityForResult(std::make_unique<SettingsActivity>(renderer, mappedInput, /*initialCategory=*/1,
                                                                 /*finishOnBack=*/true, isJapaneseBook(),
-                                                                epub ? epub->getLanguage() : std::string{}),
-                             [this](const ActivityResult&) {
+                                                                epub ? epub->getLanguage() : std::string{},
+                                                                showVerticalToggle(), useVerticalText(), useFurigana()),
+                             [this](const ActivityResult& result) {
+                               if (const auto* menu = std::get_if<MenuResult>(&result.data)) {
+                                 applyVerticalFuriganaOverride(menu->verticalOverride, menu->furiganaOverride);
+                               }
                                sdFontSystem.ensureLoaded(renderer);
                                sdFontSystem.setJpFallbackNeeded(renderer, isJapaneseBook() || useVerticalText());
+                               // Reading Orientation now only changes via this screen (removed from the reader's
+                               // own quick menu, which used to apply it straight from the popup via
+                               // applyOrientation(menu.orientation)): pick up a change the same way onEnter()
+                               // does, or it would silently wait for the book's next full open to take effect.
+                               ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
                                // Return to the reader MENU (where the user came from), not the page.
                                openReaderMenu();
                              });
@@ -3719,6 +3738,16 @@ bool EpubReaderActivity::isJapaneseBook() const {
   const auto& lang = epub->getLanguage();
   return lang.size() >= 2 && lang[0] == 'j' && lang[1] == 'a';
 }
+
+// Whether Vertical Text / Furigana are meaningful for this book at all -- shared by opening
+// Reader Settings (to decide whether to show the two toggles there) and this menu's own
+// MenuResult (kept in sync even though nothing here can change them anymore).
+//
+// verticalOverride is persisted per book in progress.bin, so a book whose metadata isn't
+// dc:language=ja but that has vertical forced on reopens in tategaki -- vertical columns, CJK
+// breaking, no word spaces. Gating on isJapaneseBook() alone would then hide the only control
+// that turns it back off, leaving the book permanently unreadable.
+bool EpubReaderActivity::showVerticalToggle() const { return isJapaneseBook() || verticalOverride == 1; }
 
 bool EpubReaderActivity::useVerticalText() const {
   // Vertical (tategaki) is a Japanese typesetting mode: it stacks characters in

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -381,6 +381,8 @@ class EpubReaderActivity final : public Activity {
   bool useVerticalText() const;
   bool useFurigana() const;
   bool isJapaneseBook() const;
+  bool showVerticalToggle() const;
+  void applyVerticalFuriganaOverride(int8_t verticalOverrideIn, int8_t furiganaOverrideIn);
 
  public:
   explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub,

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -54,11 +54,11 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuI
   // Vertical Text and Furigana moved into Reader Settings (SettingInfo::DynamicToggle, gated
   // there on the same condition this menu used to gate TOGGLE_VERTICAL/TOGGLE_FURIGANA) so they
   // sit with the rest of the reading-experience settings instead of this per-page action menu.
-  // Manga has no font/layout settings for this menu to apply -- MangaReaderActivity
-  // doesn't handle READER_SETTINGS at all, so showing it did nothing (issue #44).
-  if (!mangaMode) {
-    items.push_back({MenuAction::READER_SETTINGS, StrId::STR_READER_SETTINGS});
-  }
+  // Reader Settings itself is shown for manga too (issue #44 fix: MangaReaderActivity now
+  // handles READER_SETTINGS -- see its onReaderMenuConfirm), just filtered down there to the
+  // items manga actually has: Rotate Panels, Reading Orientation, Customise Status Bar. Text
+  // Settings and the Images rendering mode are hidden (SettingsActivity's mangaMode).
+  items.push_back({MenuAction::READER_SETTINGS, StrId::STR_READER_SETTINGS});
   if (hasBookmarks) {
     items.push_back({MenuAction::BOOKMARKS, StrId::STR_BOOKMARKS});
   }
@@ -68,15 +68,11 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuI
   if (!mangaMode && !hideGenericLookup) {
     items.push_back({MenuAction::DICTIONARY, StrId::STR_LOOKUP});
   }
-  // Reading Orientation removed from this quick menu for EPUB, where it's already a proper
-  // setting under Settings > Reader (SettingsList.h, tied to CrossPointSettings::orientation
-  // directly) -- but NOT for manga, whose Reader Settings is hidden just above (issue #44), and
-  // whose orientation applies straight from this popup's result (see the resultHandler in
-  // MangaReaderActivity::openReaderMenu: `if (SETTINGS.orientation != menu.orientation) ...`).
-  // Without this item there, manga would have no way to rotate at all.
-  if (mangaMode) {
-    items.push_back({MenuAction::ROTATE_SCREEN, StrId::STR_ORIENTATION});
-  }
+  // Reading Orientation removed from this quick menu entirely; it's a proper setting under
+  // Settings > Reader (SettingsList.h, tied to CrossPointSettings::orientation directly) for
+  // every reader type now that Reader Settings is reachable from manga too (see above) --
+  // ROTATE_SCREEN's handling below (the option popup, pendingOrientation) is unreachable but
+  // left in place rather than torn out along with it.
   items.push_back({MenuAction::AUTO_PAGE_TURN, StrId::STR_AUTO_TURN_PAGES_PER_MIN});
   items.push_back({MenuAction::GO_TO_PERCENT, StrId::STR_GO_TO_PERCENT});
   items.push_back({MenuAction::SCREENSHOT, StrId::STR_SCREENSHOT_BUTTON});

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -7,16 +7,14 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 
-EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                               const std::string& title, const int currentPage, const int totalPages,
-                                               const int bookProgressPercent, const uint8_t currentOrientation,
-                                               const bool hasFootnotes, const bool hasBookmarks,
-                                               const bool hasWordLookup, const bool showVerticalToggle,
-                                               const bool verticalEnabled, const bool furiganaEnabled,
-                                               const bool hasPageText, const bool imageReaderMinimal)
+EpubReaderMenuActivity::EpubReaderMenuActivity(
+    GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title, const int currentPage,
+    const int totalPages, const int bookProgressPercent, const uint8_t currentOrientation, const bool hasFootnotes,
+    const bool hasBookmarks, const bool hasWordLookup, const bool verticalEnabled, const bool furiganaEnabled,
+    const bool hasPageText, const bool imageReaderMinimal, const bool mangaMode, const bool hideGenericLookup)
     : Activity("EpubReaderMenu", renderer, mappedInput),
-      menuItems(buildMenuItems(hasFootnotes, hasBookmarks, hasWordLookup, showVerticalToggle, verticalEnabled,
-                               furiganaEnabled, imageReaderMinimal)),
+      menuItems(
+          buildMenuItems(hasFootnotes, hasBookmarks, hasWordLookup, imageReaderMinimal, mangaMode, hideGenericLookup)),
       hasPageText(hasPageText),
       title(title),
       pendingOrientation(currentOrientation),
@@ -27,8 +25,8 @@ EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInpu
       bookProgressPercent(bookProgressPercent) {}
 
 std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuItems(
-    bool hasFootnotes, bool hasBookmarks, bool hasWordLookup, bool showVerticalToggle, bool verticalEnabled,
-    bool furiganaEnabled, bool imageReaderMinimal) {
+    bool hasFootnotes, bool hasBookmarks, bool hasWordLookup, bool imageReaderMinimal, bool mangaMode,
+    bool hideGenericLookup) {
   std::vector<MenuItem> items;
   items.reserve(16);
 
@@ -53,17 +51,32 @@ std::vector<EpubReaderMenuActivity::MenuItem> EpubReaderMenuActivity::buildMenuI
     items.push_back({MenuAction::WORD_LOOKUP, StrId::STR_WORD_LOOKUP});
   }
   items.push_back({MenuAction::TRANSLATE_PAGE, StrId::STR_TRANSLATE_PAGE});
-  if (showVerticalToggle) {
-    items.push_back({MenuAction::TOGGLE_VERTICAL, StrId::STR_VERTICAL_TEXT_LABEL});
-    items.push_back({MenuAction::TOGGLE_FURIGANA, StrId::STR_FURIGANA_LABEL});
+  // Vertical Text and Furigana moved into Reader Settings (SettingInfo::DynamicToggle, gated
+  // there on the same condition this menu used to gate TOGGLE_VERTICAL/TOGGLE_FURIGANA) so they
+  // sit with the rest of the reading-experience settings instead of this per-page action menu.
+  // Manga has no font/layout settings for this menu to apply -- MangaReaderActivity
+  // doesn't handle READER_SETTINGS at all, so showing it did nothing (issue #44).
+  if (!mangaMode) {
+    items.push_back({MenuAction::READER_SETTINGS, StrId::STR_READER_SETTINGS});
   }
-  items.push_back({MenuAction::READER_SETTINGS, StrId::STR_READER_SETTINGS});
   if (hasBookmarks) {
     items.push_back({MenuAction::BOOKMARKS, StrId::STR_BOOKMARKS});
   }
   items.push_back({MenuAction::TOGGLE_BOOKMARK, StrId::STR_TOGGLE_BOOKMARK});
-  items.push_back({MenuAction::DICTIONARY, StrId::STR_LOOKUP});
-  items.push_back({MenuAction::ROTATE_SCREEN, StrId::STR_ORIENTATION});
+  // Free-form dictionary lookup doesn't apply to manga (Word Lookup covers OCR'd text) or to
+  // unsegmented Japanese text, where Word Lookup is the only lookup that makes sense.
+  if (!mangaMode && !hideGenericLookup) {
+    items.push_back({MenuAction::DICTIONARY, StrId::STR_LOOKUP});
+  }
+  // Reading Orientation removed from this quick menu for EPUB, where it's already a proper
+  // setting under Settings > Reader (SettingsList.h, tied to CrossPointSettings::orientation
+  // directly) -- but NOT for manga, whose Reader Settings is hidden just above (issue #44), and
+  // whose orientation applies straight from this popup's result (see the resultHandler in
+  // MangaReaderActivity::openReaderMenu: `if (SETTINGS.orientation != menu.orientation) ...`).
+  // Without this item there, manga would have no way to rotate at all.
+  if (mangaMode) {
+    items.push_back({MenuAction::ROTATE_SCREEN, StrId::STR_ORIENTATION});
+  }
   items.push_back({MenuAction::AUTO_PAGE_TURN, StrId::STR_AUTO_TURN_PAGES_PER_MIN});
   items.push_back({MenuAction::GO_TO_PERCENT, StrId::STR_GO_TO_PERCENT});
   items.push_back({MenuAction::SCREENSHOT, StrId::STR_SCREENSHOT_BUTTON});

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -41,10 +41,12 @@ class EpubReaderMenuActivity final : public Activity {
   // shown, still navigable) rather than hidden, since that can change
   // page-to-page (e.g. manga panels without OCR'd dialogue, image-only
   // EPUB pages) and hiding/showing per-page would shift menu positions.
-  // mangaMode hides Reader Settings (issue #44: MangaReaderActivity has no font/layout
-  // settings to apply -- the item did nothing) and the generic Look Up dictionary entry
-  // (manga's Word Lookup already covers OCR'd text; unlike imageReaderMinimal, this keeps
-  // Word Lookup, Translate Page and Auto Page Turn, which manga does support).
+  // mangaMode hides the generic Look Up dictionary entry (manga's Word Lookup already covers
+  // OCR'd text; unlike imageReaderMinimal, this keeps Word Lookup, Translate Page and Auto Page
+  // Turn, which manga does support). Reader Settings itself is always shown -- issue #44's fix
+  // is on the other end: MangaReaderActivity now routes READER_SETTINGS to a Settings screen
+  // filtered to what manga actually has (SettingsActivity's own mangaMode), rather than hiding
+  // the menu item, which used to do nothing when tapped.
   // hideGenericLookup independently hides Look Up for a Japanese EPUB: free-form dictionary
   // lookup doesn't apply to unsegmented Japanese text, where Word Lookup is the only
   // sensible entry.

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -41,13 +41,24 @@ class EpubReaderMenuActivity final : public Activity {
   // shown, still navigable) rather than hidden, since that can change
   // page-to-page (e.g. manga panels without OCR'd dialogue, image-only
   // EPUB pages) and hiding/showing per-page would shift menu positions.
+  // mangaMode hides Reader Settings (issue #44: MangaReaderActivity has no font/layout
+  // settings to apply -- the item did nothing) and the generic Look Up dictionary entry
+  // (manga's Word Lookup already covers OCR'd text; unlike imageReaderMinimal, this keeps
+  // Word Lookup, Translate Page and Auto Page Turn, which manga does support).
+  // hideGenericLookup independently hides Look Up for a Japanese EPUB: free-form dictionary
+  // lookup doesn't apply to unsegmented Japanese text, where Word Lookup is the only
+  // sensible entry.
+  // verticalEnabled/furiganaEnabled seed this menu's own MenuResult (still read by the reader's
+  // apply-if-changed check) but no longer have an in-menu control to change them -- Vertical
+  // Text and Furigana moved into Reader Settings, gated there on the same condition
+  // (isJapaneseBook() || forced on) this menu used to gate its own now-removed toggle items.
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title,
                                   const int currentPage, const int totalPages, const int bookProgressPercent,
                                   const uint8_t currentOrientation, const bool hasFootnotes,
                                   const bool hasBookmarks = false, const bool hasWordLookup = false,
-                                  const bool showVerticalToggle = false, const bool verticalEnabled = false,
-                                  const bool furiganaEnabled = true, const bool hasPageText = true,
-                                  const bool imageReaderMinimal = false);
+                                  const bool verticalEnabled = false, const bool furiganaEnabled = true,
+                                  const bool hasPageText = true, const bool imageReaderMinimal = false,
+                                  const bool mangaMode = false, const bool hideGenericLookup = false);
 
   void onEnter() override;
   void onExit() override;
@@ -62,8 +73,7 @@ class EpubReaderMenuActivity final : public Activity {
   };
 
   static std::vector<MenuItem> buildMenuItems(bool hasFootnotes, bool hasBookmarks, bool hasWordLookup,
-                                              bool showVerticalToggle, bool verticalEnabled, bool furiganaEnabled,
-                                              bool imageReaderMinimal);
+                                              bool imageReaderMinimal, bool mangaMode, bool hideGenericLookup);
   void closeCancelled();
 
   std::vector<MenuItem> menuItems;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -31,6 +31,7 @@
 #include "ReaderUtils.h"
 #include "ReadingStatsStore.h"
 #include "RecentBooksStore.h"
+#include "activities/settings/SettingsActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/BookmarkFile.h"
@@ -1547,7 +1548,9 @@ void MangaReaderActivity::launchMenu() {
     }
   }
 
-  // hasFootnotes=false (no footnotes in manga), showVerticalToggle=false
+  // hasFootnotes=false (no footnotes in manga); mangaMode=true hides Look Up (Word Lookup
+  // covers OCR'd text) and routes READER_SETTINGS below to a filtered Settings screen -- see
+  // its case and SettingsActivity's mangaMode.
   startActivityForResult(
       std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, book->getTitle(), curPage, totalPages,
                                                bookProgressPercent, SETTINGS.orientation,
@@ -1599,6 +1602,28 @@ void MangaReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction
   };
 
   switch (action) {
+    case EpubReaderMenuActivity::MenuAction::READER_SETTINGS: {
+      // Filtered to what manga actually has: Rotate Panels, Reading Orientation, Customise
+      // Status Bar (SettingsActivity's mangaMode hides Text Settings and the image-rendering
+      // mode, neither of which applies to a book whose pages ARE images -- issue #44).
+      // japaneseBook=true reuses the existing "skip the folder-based dictionary picker" gate:
+      // manga has its own OCR-based Word Lookup, not the EPUB dictionary flow that configures.
+      startActivityForResult(
+          std::make_unique<SettingsActivity>(renderer, mappedInput, /*initialCategory=*/1,
+                                             /*finishOnBack=*/true, /*japaneseBook=*/true,
+                                             /*dictionaryLanguage=*/std::string{}, /*showReaderToggles=*/false,
+                                             /*verticalTextEnabled=*/false, /*furiganaEnabled=*/false,
+                                             /*mangaMode=*/true),
+          [this](const ActivityResult&) {
+            // Reading Orientation only changes via this screen now (removed from the quick
+            // menu -- see EpubReaderMenuActivity::buildMenuItems): pick up a change the same
+            // way onEnter() does, or it would silently wait for the next full open to apply.
+            ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
+            // Return to the reader MENU (where the user came from), not the page.
+            launchMenu();
+          });
+      break;
+    }
     case EpubReaderMenuActivity::MenuAction::SELECT_CHAPTER:
       if (book && book->hasToc()) {
         startActivityForResult(

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -1552,9 +1552,9 @@ void MangaReaderActivity::launchMenu() {
       std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, book->getTitle(), curPage, totalPages,
                                                bookProgressPercent, SETTINGS.orientation,
                                                /*hasFootnotes=*/false, /*hasBookmarks=*/!cachedBookmarks.empty(),
-                                               /*hasWordLookup=*/hasWordLookup, /*showVerticalToggle=*/false,
-                                               /*verticalEnabled=*/false, /*furiganaEnabled=*/true,
-                                               /*hasPageText=*/hasPageText),
+                                               /*hasWordLookup=*/hasWordLookup, /*verticalEnabled=*/false,
+                                               /*furiganaEnabled=*/true, /*hasPageText=*/hasPageText,
+                                               /*imageReaderMinimal=*/false, /*mangaMode=*/true),
       [this](const ActivityResult& result) {
         const auto& menu = std::get<MenuResult>(result.data);
         // Apply orientation change

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -227,9 +227,8 @@ void XtcReaderActivity::launchMenu() {
       std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, xtc->getTitle(), curPage, totalPages,
                                                bookProgressPercent, SETTINGS.orientation, /*hasFootnotes=*/hasChapters,
                                                /*hasBookmarks=*/!cachedBookmarks.empty(), /*hasWordLookup=*/false,
-                                               /*showVerticalToggle=*/false, /*verticalEnabled=*/false,
-                                               /*furiganaEnabled=*/true, /*hasPageText=*/false,
-                                               /*imageReaderMinimal=*/true),
+                                               /*verticalEnabled=*/false, /*furiganaEnabled=*/true,
+                                               /*hasPageText=*/false, /*imageReaderMinimal=*/true),
       [this](const ActivityResult& result) {
         if (!result.isCancelled) {
           const auto& menu = std::get<MenuResult>(result.data);

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -87,6 +87,9 @@ void SettingsActivity::rebuildSettingsLists() {
       // Settings merged into "Text Settings"
       // (they stay in the shared list for the web settings API)
       if (setting.inTextSettings) continue;
+      // Manga pages ARE images -- the Display/Placeholder/Suppress image rendering mode has
+      // nothing to render for a manga book, so it's hidden along with Text Settings below.
+      if (mangaMode && setting.nameId == StrId::STR_IMAGES) continue;
       readerSettings.push_back(std::move(setting));
     } else if (setting.category == StrId::STR_CAT_CONTROLS) {
       if (setting.valuePtr == &CrossPointSettings::pwrBtnFootnoteBack &&
@@ -117,14 +120,23 @@ void SettingsActivity::rebuildSettingsLists() {
     systemSettings.push_back(SettingInfo::Action(StrId::STR_LANGUAGE, SettingAction::Language));
   }
   if (!finishOnBack || selectedCategoryIndex == 1) {
-    readerSettings.insert(readerSettings.begin(),
-                          SettingInfo::Action(StrId::STR_TEXT_SETTINGS, SettingAction::TextSettings));
+    // Text Settings (font/margin/line-layout) has nothing to apply to manga, whose pages are
+    // pre-rendered images -- hidden along with STR_IMAGES above, leaving Rotate Panels/Reading
+    // Orientation/Customise Status Bar as the manga Reader Settings screen.
+    if (!mangaMode) {
+      readerSettings.insert(readerSettings.begin(),
+                            SettingInfo::Action(StrId::STR_TEXT_SETTINGS, SettingAction::TextSettings));
+    }
     // Vertical Text / Furigana: per-book overrides that live on the reader activity that pushed
     // this screen, not in CrossPointSettings -- so they only make sense (and only get injected)
     // when there IS such a book (finishOnBack) and the book is one they apply to
     // (showReaderToggles, the same condition the reader's quick menu used before these moved
     // here). Opening Settings from Home never shows them: there is no book to apply them to.
-    if (finishOnBack && showReaderToggles) {
+    // Also never for manga (mangaMode implies !showReaderToggles in practice, but this makes the
+    // exclusivity explicit rather than relying on the caller never combining the two) -- manga
+    // has no Japanese-vertical-text concept, and the +1/+2 insert positions below assume Text
+    // Settings just landed at index 0, which mangaMode skips.
+    if (!mangaMode && finishOnBack && showReaderToggles) {
       readerSettings.insert(readerSettings.begin() + 1,
                             SettingInfo::DynamicToggle(
                                 StrId::STR_VERTICAL_TEXT_LABEL, [this] { return verticalTextState; },
@@ -227,11 +239,14 @@ void SettingsActivity::loop() {
   if (finishOnBack) {
     if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       saveSettings();
-      // MenuResult's other fields (action/orientation/pageTurnOption) go unused here -- the
-      // reader's READER_SETTINGS handler only reads verticalOverride/furiganaOverride, the same
-      // two fields the old in-menu toggles rode back on. Left at their -1 default when this
-      // screen never showed the toggles, so the reader's ">= 0" apply-if-changed check is a
-      // no-op rather than force-applying a state the user never touched.
+      // The reader's READER_SETTINGS handler only reads verticalOverride/furiganaOverride --
+      // the same two fields the old in-menu toggles rode back on -- via std::get_if<MenuResult>,
+      // so when this screen never showed the toggles (showReaderToggles false) it's fine to set
+      // no result at all: the ActivityResult stays std::monostate, get_if returns null, and the
+      // handler skips applying anything. When it IS set, action/orientation/pageTurnOption are
+      // explicitly -1/0/0 (unused by that handler) rather than MenuResult's own defaults
+      // (action=-1, but orientation/pageTurnOption default to 0 already -- see ActivityResult.h)
+      // -- spelled out here so a value doesn't get silently relied on either way.
       if (showReaderToggles) {
         setResult(MenuResult{-1, 0, 0, static_cast<int8_t>(verticalTextState ? 1 : 0),
                              static_cast<int8_t>(furiganaState ? 1 : 0)});
@@ -400,10 +415,13 @@ void SettingsActivity::toggleCurrentSetting() {
     SETTINGS.*(setting.valuePtr) = !currentValue;
   } else if (setting.type == SettingType::TOGGLE && setting.valueGetter && setting.valueSetter) {
     // Backed by state outside CrossPointSettings (SettingInfo::DynamicToggle) -- e.g. the
-    // per-book Vertical Text / Furigana overrides. No saveSettings(): that persists the
-    // CrossPointSettings singleton to file, which this state isn't part of; the caller reads
-    // it back from this screen's finish() result instead.
+    // per-book Vertical Text / Furigana overrides. Returns immediately instead of falling
+    // through to the shared tail below: that tail's saveSettings()/rebuildSettingsLists() is
+    // for CrossPointSettings changes, and this state isn't part of that singleton -- the
+    // caller reads it back from this screen's finish() result instead. Falling through would
+    // write the settings file on every toggle for no reason.
     setting.valueSetter(setting.valueGetter() == 0 ? 1 : 0);
+    return;
   } else if (setting.type == SettingType::ENUM && setting.valuePtr != nullptr) {
     const uint8_t currentValue = SETTINGS.*(setting.valuePtr);
     if (setting.enumValues.size() > 2) {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -68,7 +68,7 @@ void SettingsActivity::rebuildSettingsLists() {
         displaySettings.reserve(settings.size());
         break;
       case 1:
-        readerSettings.reserve(settings.size() + 2);
+        readerSettings.reserve(settings.size() + 4);
         break;
       case 2:
         controlsSettings.reserve(settings.size() + 1);
@@ -119,6 +119,21 @@ void SettingsActivity::rebuildSettingsLists() {
   if (!finishOnBack || selectedCategoryIndex == 1) {
     readerSettings.insert(readerSettings.begin(),
                           SettingInfo::Action(StrId::STR_TEXT_SETTINGS, SettingAction::TextSettings));
+    // Vertical Text / Furigana: per-book overrides that live on the reader activity that pushed
+    // this screen, not in CrossPointSettings -- so they only make sense (and only get injected)
+    // when there IS such a book (finishOnBack) and the book is one they apply to
+    // (showReaderToggles, the same condition the reader's quick menu used before these moved
+    // here). Opening Settings from Home never shows them: there is no book to apply them to.
+    if (finishOnBack && showReaderToggles) {
+      readerSettings.insert(readerSettings.begin() + 1,
+                            SettingInfo::DynamicToggle(
+                                StrId::STR_VERTICAL_TEXT_LABEL, [this] { return verticalTextState; },
+                                [this](const bool v) { verticalTextState = v; }, StrId::STR_CAT_READER));
+      readerSettings.insert(readerSettings.begin() + 2,
+                            SettingInfo::DynamicToggle(
+                                StrId::STR_FURIGANA_LABEL, [this] { return furiganaState; },
+                                [this](const bool v) { furiganaState = v; }, StrId::STR_CAT_READER));
+    }
     // No STR_MANAGE_FONTS entry here: it lives at the bottom of the font list inside Text
     // Settings, where the pre-1.5.0 picker had it. Upstream moved it up when it replaced
     // FontSelectionActivity; that costs the "this font is missing -> install it" shortcut.
@@ -212,6 +227,15 @@ void SettingsActivity::loop() {
   if (finishOnBack) {
     if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       saveSettings();
+      // MenuResult's other fields (action/orientation/pageTurnOption) go unused here -- the
+      // reader's READER_SETTINGS handler only reads verticalOverride/furiganaOverride, the same
+      // two fields the old in-menu toggles rode back on. Left at their -1 default when this
+      // screen never showed the toggles, so the reader's ">= 0" apply-if-changed check is a
+      // no-op rather than force-applying a state the user never touched.
+      if (showReaderToggles) {
+        setResult(MenuResult{-1, 0, 0, static_cast<int8_t>(verticalTextState ? 1 : 0),
+                             static_cast<int8_t>(furiganaState ? 1 : 0)});
+      }
       finish();
       return;
     }
@@ -374,6 +398,12 @@ void SettingsActivity::toggleCurrentSetting() {
     // Toggle the boolean value using the member pointer
     const bool currentValue = SETTINGS.*(setting.valuePtr);
     SETTINGS.*(setting.valuePtr) = !currentValue;
+  } else if (setting.type == SettingType::TOGGLE && setting.valueGetter && setting.valueSetter) {
+    // Backed by state outside CrossPointSettings (SettingInfo::DynamicToggle) -- e.g. the
+    // per-book Vertical Text / Furigana overrides. No saveSettings(): that persists the
+    // CrossPointSettings singleton to file, which this state isn't part of; the caller reads
+    // it back from this screen's finish() result instead.
+    setting.valueSetter(setting.valueGetter() == 0 ? 1 : 0);
   } else if (setting.type == SettingType::ENUM && setting.valuePtr != nullptr) {
     const uint8_t currentValue = SETTINGS.*(setting.valuePtr);
     if (setting.enumValues.size() > 2) {
@@ -559,6 +589,8 @@ void SettingsActivity::render(RenderLock&&) {
         if (setting.type == SettingType::TOGGLE && setting.valuePtr != nullptr) {
           const bool value = SETTINGS.*(setting.valuePtr);
           valueText = value ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
+        } else if (setting.type == SettingType::TOGGLE && setting.valueGetter) {
+          valueText = setting.valueGetter() != 0 ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
         } else if (setting.type == SettingType::ENUM && setting.valuePtr != nullptr) {
           const uint8_t value = SETTINGS.*(setting.valuePtr);
           valueText = I18N.get(setting.enumValues[value]);

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -149,6 +149,22 @@ struct SettingInfo {
     s.category = category;
     return s;
   }
+
+  // For a toggle backed by state outside CrossPointSettings (e.g. a per-book override that
+  // lives on the reader activity, not the settings singleton). Reuses the existing uint8_t
+  // valueGetter/valueSetter fields -- no struct layout change -- so the TOGGLE branches in
+  // SettingsActivity that already check valueGetter/valueSetter (mirroring the DynamicEnum
+  // path) work unmodified.
+  static SettingInfo DynamicToggle(StrId nameId, std::function<bool()> getter, std::function<void(bool)> setter,
+                                   StrId category = StrId::STR_NONE_OPT) {
+    SettingInfo s;
+    s.nameId = nameId;
+    s.type = SettingType::TOGGLE;
+    s.valueGetter = [g = std::move(getter)]() -> uint8_t { return g() ? 1 : 0; };
+    s.valueSetter = [st = std::move(setter)](const uint8_t v) { st(v != 0); };
+    s.category = category;
+    return s;
+  }
 };
 
 class SettingsActivity final : public Activity {
@@ -157,6 +173,15 @@ class SettingsActivity final : public Activity {
   bool finishOnBack = false;
   bool japaneseBook = false;
   std::string dictionaryLanguage;
+  // Vertical Text / Furigana: per-book overrides that live on the pushing reader activity, not
+  // in CrossPointSettings. showReaderToggles gates whether they appear at all (mirrors the
+  // condition the reader menu used before these moved here: isJapaneseBook() || forced on).
+  // Mutated in place by their DynamicToggle setters; read back on finish() via a MenuResult (see
+  // ActivityResult.h) so the caller can apply them the same way it already applies font/margin
+  // changes made in this screen.
+  bool showReaderToggles = false;
+  bool verticalTextState = false;
+  bool furiganaState = false;
 
   int selectedCategoryIndex = 0;  // Currently selected category
   int selectedSettingIndex = 0;
@@ -188,14 +213,19 @@ class SettingsActivity final : public Activity {
   // initialCategory: category tab to open on (0=Display, 1=Reader, 2=Controls, 3=System).
   // finishOnBack: pop back to the pushing activity (e.g. the reader menu's "Reader Settings")
   // instead of replacing the stack with Home.
+  // showReaderToggles/verticalTextEnabled/furiganaEnabled: see the member comment above.
   explicit SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const int initialCategory = 0,
                             const bool finishOnBack = false, const bool japaneseBook = false,
-                            std::string dictionaryLanguage = {})
+                            std::string dictionaryLanguage = {}, const bool showReaderToggles = false,
+                            const bool verticalTextEnabled = false, const bool furiganaEnabled = false)
       : Activity("Settings", renderer, mappedInput),
         initialCategory(initialCategory),
         finishOnBack(finishOnBack),
         japaneseBook(japaneseBook),
-        dictionaryLanguage(std::move(dictionaryLanguage)) {}
+        dictionaryLanguage(std::move(dictionaryLanguage)),
+        showReaderToggles(showReaderToggles),
+        verticalTextState(verticalTextEnabled),
+        furiganaState(furiganaEnabled) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -182,6 +182,10 @@ class SettingsActivity final : public Activity {
   bool showReaderToggles = false;
   bool verticalTextState = false;
   bool furiganaState = false;
+  // Manga has no font/margin/text-layout settings (no Text Settings sub-screen) and no image
+  // rendering mode (manga pages ARE images) -- both are hidden from the Reader category for it.
+  // Rotate Panels, Reading Orientation and Customise Status Bar all still apply and stay.
+  bool mangaMode = false;
 
   int selectedCategoryIndex = 0;  // Currently selected category
   int selectedSettingIndex = 0;
@@ -214,10 +218,12 @@ class SettingsActivity final : public Activity {
   // finishOnBack: pop back to the pushing activity (e.g. the reader menu's "Reader Settings")
   // instead of replacing the stack with Home.
   // showReaderToggles/verticalTextEnabled/furiganaEnabled: see the member comment above.
+  // mangaMode: see the member comment above.
   explicit SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const int initialCategory = 0,
                             const bool finishOnBack = false, const bool japaneseBook = false,
                             std::string dictionaryLanguage = {}, const bool showReaderToggles = false,
-                            const bool verticalTextEnabled = false, const bool furiganaEnabled = false)
+                            const bool verticalTextEnabled = false, const bool furiganaEnabled = false,
+                            const bool mangaMode = false)
       : Activity("Settings", renderer, mappedInput),
         initialCategory(initialCategory),
         finishOnBack(finishOnBack),
@@ -225,7 +231,8 @@ class SettingsActivity final : public Activity {
         dictionaryLanguage(std::move(dictionaryLanguage)),
         showReaderToggles(showReaderToggles),
         verticalTextState(verticalTextEnabled),
-        furiganaState(furiganaEnabled) {}
+        furiganaState(furiganaEnabled),
+        mangaMode(mangaMode) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;


### PR DESCRIPTION
## What changed and why

Several reader quick-menu problems, fixed together since they all touch the
same menu-building/routing code:

### 1. Reader Settings did nothing in Manga (closes #44)
`MangaReaderActivity::onReaderMenuConfirm` never had a `case` for
`READER_SETTINGS` — tapping it was a silent no-op. It now opens a real
Settings screen, filtered to what manga actually has (see below), instead of
being hidden.

### 2. "Look Up" shown where it doesn't apply
Free-form dictionary lookup doesn't make sense for manga (OCR'd panel text)
or for unsegmented Japanese text — in both cases **Word Lookup** is the
correct/only lookup. "Look Up" is hidden for manga and for Japanese books
(`hideGenericLookup`, computed from `isJapaneseBook()`).

### 3. Reading Orientation and the two text-mode toggles reorganized
- **Reading Orientation** removed from the quick menu entirely — it
  duplicates the setting at **Settings → Reader → Reading Orientation**
  (`CrossPointSettings::orientation`), which is now reachable from both EPUB
  and manga (see #1), so the quick-menu popup is redundant for both.
- **Vertical Text** and **Furigana** moved out of the quick menu and into
  **Reader Settings**, so per-page actions and reading-experience settings
  aren't mixed in one list.

## Where things are now

| Item | Before | After |
|---|---|---|
| Reader Settings | Quick menu (broken in manga) | Quick menu → filtered Settings screen for both EPUB and manga |
| Look Up | Quick menu, always shown | Quick menu, **hidden for manga & Japanese books** |
| Reading Orientation | Quick menu (all readers) | Settings → Reader only, for **all** readers |
| Vertical Text / Furigana | Quick menu toggles | **Reader Settings**, shown only for books where they apply (Japanese, or vertical forced on) |

**Manga's Reader Settings** is filtered to exactly what applies: **Rotate
Panels**, **Reading Orientation**, **Customise Status Bar**. Hidden: Text
Settings (no font/margin layout for manga) and the image-rendering-mode
setting (manga pages already *are* images).

## How it's wired

Vertical Text / Furigana are **per-book** state persisted in `progress.bin`,
not part of `CrossPointSettings` — so putting them in the general Settings
screen needed new plumbing:

- `SettingInfo` gains a `DynamicToggle` builder (getter/setter closures),
  mirroring the existing `DynamicEnum` pattern used elsewhere in
  `SettingsList.h`.
- `SettingsActivity` takes `showReaderToggles`/`verticalTextEnabled`/
  `furiganaEnabled` and injects the two toggles into the Reader category only
  when relevant; on exit it reports the resulting state back via `MenuResult`
  — the same struct the quick menu used to carry these two fields on, so no
  new result type was needed.
- `SettingsActivity` also takes a `mangaMode` flag that filters the Reader
  category list down to the three items manga actually has.
- `EpubReaderActivity`/`MangaReaderActivity` apply the returned state through
  a shared `applyVerticalFuriganaOverride()` helper (EPUB) and reapply
  orientation immediately on return from Settings (both readers) —
  orientation lost its old immediate-apply from the quick-menu popup, so both
  readers now call `ReaderUtils::applyOrientation()` in the Settings result
  callback instead.
- `japaneseBook=true` is passed from manga's `READER_SETTINGS` case to reuse
  the existing "skip the folder-based dictionary picker" gate — manga has its
  own OCR-based Word Lookup, not the EPUB dictionary flow that setting
  configures.

`ROTATE_SCREEN`'s old option-popup handling in `EpubReaderMenuActivity` is
left in place (now fully unreachable, no menu path selects it) rather than
torn out, to keep the diff contained.

### Copilot review fixups (second commit)
- The `DynamicToggle` branch in `toggleCurrentSetting()` fell through to the
  shared `saveSettings()`/`rebuildSettingsLists()` tail, writing the settings
  file to flash on every Vertical Text/Furigana toggle even though nothing in
  `CrossPointSettings` changed. Returns early now, matching the `ACTION`
  branch's pattern.
- Corrected a comment claiming `MenuResult`'s unused fields default to -1;
  `orientation`/`pageTurnOption` actually default to 0, and when
  `showReaderToggles` is false no `MenuResult` is set at all (stays
  `std::monostate`).
- Removed a stale comment referencing an already-removed constructor
  parameter.

## Test plan

- [x] Manga: Reader Settings opens a filtered screen (Rotate Panels, Reading Orientation, Customise Status Bar only); rotating and panel-rotation both work correctly
- [x] Manga: Look Up hidden, Word Lookup still shown
- [x] Japanese EPUB: Look Up hidden, Word Lookup still shown; Vertical Text/Furigana appear in Reader Settings and apply correctly on return
- [x] English EPUB: Reading Orientation hidden from quick menu; changing it via Settings → Reader applies immediately on return to the book
- [x] builds compile clean, no new warnings
- [x] Verified on device for both EPUB and manga

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>