### PR TITLE
feat: track reading stats per book and per language

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,11 @@ export GEMINI_API_KEY=$(cat /path/to/gemini.key)
 python3 tools/manga_convert/convert_manga.py \
   --input /path/to/manga.cbz \
   --output-dir /path/to/sd/manga/MangaTitle/ \
+  --language ja \
   --x4
 ```
+
+**Set `--language` on every manga you convert.** It is what lets Insights break your reading time down by language, and most manga sources carry no language of their own — only EPUBs and the minority of CBZs that ship a `ComicInfo.xml` are detected automatically. A book converted without it counts as "unknown" forever: the tag is read at conversion time, so the only fix is to convert again. The [browser tool](https://eszter007.github.io/matcha-reader-tools/) does not write it yet.
 
 Panels are found with a YOLO model trained on Manga109 ([leoxs22/manga-panel-detector-yolo26n](https://huggingface.co/leoxs22/manga-panel-detector-yolo26n)); without `ultralytics` it falls back to a white-gutter heuristic. Gemini then reads each panel's text and translates it, both stored in the output so the device needs no network.
 
@@ -154,7 +157,7 @@ Panels are found with a YOLO model trained on Manga109 ([leoxs22/manga-panel-det
 | `--no-ocr` | Panel boxes only — no Gemini calls, no text or translations. |
 | `--max-pages N` | Convert the first N pages as a cheap test run. |
 | `--title` / `--author` | Override metadata. Auto-detected from EPUB/CBZ/PDF otherwise. |
-| `--language` | Book language tag (`ja`, `en`, …), used to split reading stats by language. Auto-detected from EPUB/CBZ; PDF carries none, so set it there. |
+| `--language` | Book language tag (`ja`, `en`, …) — splits your reading stats by language. Auto-detected only from an EPUB or a CBZ with `ComicInfo.xml`; set it by hand for everything else. See the note above. |
 
 `--help` lists the rest. The API key is never written into the output; pass it at runtime.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Panels are found with a YOLO model trained on Manga109 ([leoxs22/manga-panel-det
 | `--no-ocr` | Panel boxes only — no Gemini calls, no text or translations. |
 | `--max-pages N` | Convert the first N pages as a cheap test run. |
 | `--title` / `--author` | Override metadata. Auto-detected from EPUB/CBZ/PDF otherwise. |
+| `--language` | Book language tag (`ja`, `en`, …), used to split reading stats by language. Auto-detected from EPUB/CBZ; PDF carries none, so set it there. |
 
 `--help` lists the rest. The API key is never written into the output; pass it at runtime.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Every book on the card as a cover grid, at any folder depth — covers and title
 
 ### Insights
 
-Reading streak, weekly minutes, books finished, total time, and a monthly calendar of the days you read. Recorded automatically when you close a book; manga counts the same as EPUBs.
+Reading streak, weekly minutes, books finished, total time, and a monthly calendar of the days you read. Recorded automatically as you read — every few minutes, and again when you close a book, so a flat battery or a crash costs you at most the last few minutes rather than the whole session. Manga counts the same as EPUBs.
+
+Time is also recorded per book and per language, so reading can later be broken down by language (Japanese only, say). Nothing on the Insights screen shows that split yet — it is captured now so the history exists when the view lands. EPUBs supply their own language; manga takes it from `--language` at conversion time (see [Converting manga](#converting-manga)). TXT and XTC declare none and count as unknown. Days recorded before this shipped carry no language and can't be attributed retroactively.
 
 <p align="center"><img src="docs/images/screenshots/insights.png" width="260" alt="Insights screen with reading streak, stat cards, and monthly calendar"></p>
 
@@ -156,7 +158,7 @@ Panels are found with a YOLO model trained on Manga109 ([leoxs22/manga-panel-det
 
 `--help` lists the rest. The API key is never written into the output; pass it at runtime.
 
-The result is a folder of page images, panel crops, and three small binaries (`panels.idx`, `panels.dat`, `meta.bin`). Drop it anywhere on the card — the Library finds any folder containing `panels.idx`, at any depth.
+The result is a folder of page images, panel crops, and three small binaries (`panels.idx`, `panels.dat`, `meta.bin` — title, author and language). Drop it anywhere on the card — the Library finds any folder containing `panels.idx`, at any depth.
 
 ---
 

--- a/lib/MangaPanel/MangaPanel.cpp
+++ b/lib/MangaPanel/MangaPanel.cpp
@@ -496,6 +496,7 @@ void MangaBook::loadToc() {
 void MangaBook::loadMeta() {
   metaTitle.clear();
   author.clear();
+  language.clear();
 
   std::string metaPath = folderPath;
   if (metaPath.back() != '/') metaPath += '/';
@@ -526,7 +527,22 @@ void MangaBook::loadMeta() {
     author.assign(buf.get(), authorLen);
   }
 
-  LOG_DBG("MNG", "Loaded meta.bin: title=%s author=%s", metaTitle.c_str(), author.c_str());
+  // Optional language trailer (uint16 languageLen + UTF-8 tag), appended after the author
+  // without a version bump -- see convert_manga.py's meta.bin format notes. A short read here
+  // just means the file predates the trailer, which is the common case; not an error.
+  uint8_t langHdr[2];
+  if (f.read(langHdr, 2) == 2) {
+    const uint16_t languageLen = readU16(langHdr);
+    // Language tags are a handful of bytes ("ja", "zh-Hant"); anything longer is a malformed
+    // or misaligned file, so ignore it rather than allocate on its say-so.
+    char langBuf[16];
+    if (languageLen > 0 && languageLen <= sizeof(langBuf) &&
+        f.read(reinterpret_cast<uint8_t*>(langBuf), languageLen) == languageLen) {
+      language.assign(langBuf, languageLen);
+    }
+  }
+
+  LOG_DBG("MNG", "Loaded meta.bin: title=%s author=%s lang=%s", metaTitle.c_str(), author.c_str(), language.c_str());
 }
 
 }  // namespace manga

--- a/lib/MangaPanel/MangaPanel.h
+++ b/lib/MangaPanel/MangaPanel.h
@@ -53,6 +53,9 @@ class MangaBook {
   const std::string& getFolder() const { return folderPath; }
   std::string getTitle() const;
   const std::string& getAuthor() const { return author; }
+  // BCP-47/ISO-639 tag from meta.bin's optional trailer ("ja", "en", ...). Empty when the
+  // folder was converted before convert_manga.py wrote one, or the source carried no language.
+  const std::string& getLanguage() const { return language; }
 
   bool loadPagePanels(uint32_t pageIndex, std::vector<Panel>& panels) const;
   uint16_t getPageImgWidth(uint32_t pageIndex) const;
@@ -89,6 +92,7 @@ class MangaBook {
   std::string folderPath;
   std::string metaTitle;
   std::string author;
+  std::string language;
   uint32_t pageCount = 0;
   std::vector<PageInfo> pageIndex;
   std::vector<std::string> imageFiles;

--- a/src/ReadingStatsStore.cpp
+++ b/src/ReadingStatsStore.cpp
@@ -9,7 +9,10 @@
 ReadingStatsStore ReadingStatsStore::instance;
 
 static constexpr const char* STATS_PATH = "/system/reading_stats.bin";
-static constexpr uint8_t STATS_VERSION = 2;
+// v3 appends the per-book block after the finished-book paths; v4 appends the per-day-per-language
+// block after that. Each older reader stops where its own format ends and ignores what follows,
+// rather than rejecting the file -- it will, however, drop the newer blocks the next time it saves.
+static constexpr uint8_t STATS_VERSION = 4;
 
 namespace {
 int daysSinceEpoch(uint16_t y, uint8_t m, uint8_t d) {
@@ -42,6 +45,30 @@ void subtractDays(uint16_t& y, uint8_t& m, uint8_t& d, int n) {
   y = static_cast<uint16_t>(static_cast<int>(yoe) + era * 400 + (m <= 2 ? 1 : 0));
 }
 
+// "ja-JP" / "JA" / "ja_jp" all bucket as "ja". Anything longer than 3 chars (no ISO-639 code is)
+// is truncated rather than rejected, so a malformed tag still lands in a stable bucket.
+void normalizeLanguage(const std::string& in, char out[4]) {
+  size_t n = 0;
+  for (const char c : in) {
+    if (c == '-' || c == '_' || n == 3) break;
+    out[n++] = static_cast<char>((c >= 'A' && c <= 'Z') ? c - 'A' + 'a' : c);
+  }
+  for (; n < 4; n++) out[n] = '\0';
+
+  // Country codes people reach for instead of the language code. Left unmapped they would each
+  // open a second bucket for a language that already has one, splitting its totals in half.
+  static constexpr struct {
+    const char* from;
+    const char* to;
+  } ALIASES[] = {{"jp", "ja"}, {"cn", "zh"}, {"kr", "ko"}};
+  for (const auto& a : ALIASES) {
+    if (strcmp(out, a.from) == 0) {
+      strncpy(out, a.to, 4);
+      return;
+    }
+  }
+}
+
 int daysInMonth(uint16_t y, uint8_t m) {
   static constexpr int dm[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   if (m == 2 && (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0))) return 29;
@@ -61,6 +88,81 @@ void ReadingStatsStore::addMinutes(uint16_t year, uint8_t month, uint8_t day, ui
     dayCount = MAX_DAYS - 1;
   }
   days[dayCount++] = {year, month, day, minutes};
+}
+
+void ReadingStatsStore::addBookMinutes(const std::string& bookPath, const std::string& language, const uint16_t minutes,
+                                       const uint16_t year, const uint8_t month, const uint8_t day) {
+  if (bookPath.empty()) return;
+  const int32_t today = daysSinceEpoch(year, month, day);
+  // Clamped to the small-string-optimisation limit: real tags ("ja", "zh-Hant") fit easily, and
+  // this keeps each entry's language free of a heap allocation and its on-disk length in a byte.
+  const std::string lang = language.substr(0, 15);
+
+  for (auto& b : books) {
+    if (b.path != bookPath) continue;
+    b.minutesRead += minutes;
+    b.lastReadDay = today;
+    if (!lang.empty()) b.language = lang;
+    return;
+  }
+
+  if (books.size() >= MAX_BOOKS) {
+    auto oldest = std::min_element(books.begin(), books.end(), [](const BookReading& a, const BookReading& b) {
+      return a.lastReadDay < b.lastReadDay;
+    });
+    books.erase(oldest);
+  }
+  // Deliberately not reserve(MAX_BOOKS): that would commit ~11KB of DRAM the moment the first
+  // book is read. This grows one entry per new book, not in a loop.
+  books.push_back({bookPath, lang, minutes, today});
+}
+
+void ReadingStatsStore::addLanguageMinutes(const std::string& language, const uint16_t minutes, const uint16_t year,
+                                           const uint8_t month, const uint8_t day) {
+  char lang[4];
+  normalizeLanguage(language, lang);
+
+  for (auto& e : languageDays) {
+    if (e.year != year || e.month != month || e.day != day) continue;
+    if (memcmp(e.language, lang, sizeof(lang)) != 0) continue;
+    e.minutesRead = static_cast<uint16_t>(e.minutesRead + minutes);
+    return;
+  }
+
+  if (languageDays.size() >= MAX_LANG_DAYS) {
+    // Oldest calendar day first, matching how days[] evicts: the recent past is what the
+    // streak and calendar views read.
+    auto oldest =
+        std::min_element(languageDays.begin(), languageDays.end(), [](const LanguageDaily& a, const LanguageDaily& b) {
+          return daysSinceEpoch(a.year, a.month, a.day) < daysSinceEpoch(b.year, b.month, b.day);
+        });
+    languageDays.erase(oldest);
+  }
+  LanguageDaily e{year, month, day, {}, minutes};
+  memcpy(e.language, lang, sizeof(lang));
+  languageDays.push_back(e);
+}
+
+uint16_t ReadingStatsStore::getMinutesForDay(const std::string& language, const uint16_t year, const uint8_t month,
+                                             const uint8_t day) const {
+  char lang[4];
+  normalizeLanguage(language, lang);
+  for (const auto& e : languageDays) {
+    if (e.year == year && e.month == month && e.day == day && memcmp(e.language, lang, sizeof(lang)) == 0) {
+      return e.minutesRead;
+    }
+  }
+  return 0;
+}
+
+uint32_t ReadingStatsStore::getTotalMinutes(const std::string& language) const {
+  char lang[4];
+  normalizeLanguage(language, lang);
+  uint32_t total = 0;
+  for (const auto& e : languageDays) {
+    if (memcmp(e.language, lang, sizeof(lang)) == 0) total += e.minutesRead;
+  }
+  return total;
 }
 
 void ReadingStatsStore::markBookFinished(const std::string& bookPath) {
@@ -193,6 +295,31 @@ bool ReadingStatsStore::saveToFile() const {
     f.write(reinterpret_cast<const uint8_t*>(&len), 2);
     f.write(reinterpret_cast<const uint8_t*>(p.data()), len);
   }
+  // Per-book block (v3+)
+  uint16_t bookCount = static_cast<uint16_t>(books.size());
+  f.write(reinterpret_cast<const uint8_t*>(&bookCount), 2);
+  for (const auto& b : books) {
+    uint16_t pathLen = static_cast<uint16_t>(b.path.size());
+    f.write(reinterpret_cast<const uint8_t*>(&pathLen), 2);
+    f.write(reinterpret_cast<const uint8_t*>(b.path.data()), pathLen);
+    uint8_t langLen = static_cast<uint8_t>(b.language.size());
+    f.write(&langLen, 1);
+    f.write(reinterpret_cast<const uint8_t*>(b.language.data()), langLen);
+    f.write(reinterpret_cast<const uint8_t*>(&b.minutesRead), 4);
+    f.write(reinterpret_cast<const uint8_t*>(&b.lastReadDay), 4);
+  }
+  // Per-day-per-language block (v4+). Fields written individually rather than as a struct blob:
+  // LanguageDaily has trailing padding on some targets, and a padded layout would not survive a
+  // format change on the reading side.
+  uint16_t langDayCount = static_cast<uint16_t>(languageDays.size());
+  f.write(reinterpret_cast<const uint8_t*>(&langDayCount), 2);
+  for (const auto& e : languageDays) {
+    f.write(reinterpret_cast<const uint8_t*>(&e.year), 2);
+    f.write(&e.month, 1);
+    f.write(&e.day, 1);
+    f.write(reinterpret_cast<const uint8_t*>(e.language), 4);
+    f.write(reinterpret_cast<const uint8_t*>(&e.minutesRead), 2);
+  }
   f.close();
   return true;
 }
@@ -229,16 +356,70 @@ bool ReadingStatsStore::loadFromFile() {
   }
   // Read finished book paths
   finishedBookPaths.clear();
+  bool pathsIntact = false;
   uint16_t pathCount = 0;
   if (f.read(reinterpret_cast<uint8_t*>(&pathCount), 2) == 2 && pathCount <= 500) {
+    pathsIntact = true;
     for (int i = 0; i < pathCount; i++) {
       uint16_t len = 0;
-      if (f.read(reinterpret_cast<uint8_t*>(&len), 2) != 2 || len > 500) break;
+      if (f.read(reinterpret_cast<uint8_t*>(&len), 2) != 2 || len > 500) {
+        pathsIntact = false;
+        break;
+      }
       std::string p(len, '\0');
-      if (f.read(reinterpret_cast<uint8_t*>(&p[0]), len) != len) break;
+      if (f.read(reinterpret_cast<uint8_t*>(&p[0]), len) != len) {
+        pathsIntact = false;
+        break;
+      }
       finishedBookPaths.push_back(std::move(p));
     }
     booksFinished = static_cast<uint16_t>(finishedBookPaths.size());
+  }
+  // Per-book block (v3+). Only readable when the paths block above was consumed whole -- a short
+  // read there leaves the file position mid-record, so anything after it is misaligned garbage.
+  books.clear();
+  bool booksIntact = false;
+  if (version >= 3 && pathsIntact) {
+    uint16_t bookCount = 0;
+    if (f.read(reinterpret_cast<uint8_t*>(&bookCount), 2) == 2 && bookCount <= MAX_BOOKS) {
+      books.reserve(bookCount);
+      for (int i = 0; i < bookCount; i++) {
+        BookReading b;
+        uint16_t pathLen = 0;
+        if (f.read(reinterpret_cast<uint8_t*>(&pathLen), 2) != 2 || pathLen > 500) break;
+        b.path.assign(pathLen, '\0');
+        if (pathLen && f.read(reinterpret_cast<uint8_t*>(&b.path[0]), pathLen) != pathLen) break;
+        uint8_t langLen = 0;
+        if (f.read(&langLen, 1) != 1) break;
+        b.language.assign(langLen, '\0');
+        if (langLen && f.read(reinterpret_cast<uint8_t*>(&b.language[0]), langLen) != langLen) break;
+        if (f.read(reinterpret_cast<uint8_t*>(&b.minutesRead), 4) != 4) break;
+        if (f.read(reinterpret_cast<uint8_t*>(&b.lastReadDay), 4) != 4) break;
+        books.push_back(std::move(b));
+      }
+      // Only a complete block leaves the file positioned at the start of the next one; any
+      // short read above stopped mid-record.
+      booksIntact = books.size() == bookCount;
+    }
+  }
+  // Per-day-per-language block (v4+)
+  languageDays.clear();
+  if (version >= 4 && booksIntact) {
+    uint16_t langDayCount = 0;
+    if (f.read(reinterpret_cast<uint8_t*>(&langDayCount), 2) == 2 && langDayCount <= MAX_LANG_DAYS) {
+      languageDays.reserve(langDayCount);
+      for (int i = 0; i < langDayCount; i++) {
+        LanguageDaily e{};
+        if (f.read(reinterpret_cast<uint8_t*>(&e.year), 2) != 2) break;
+        if (f.read(&e.month, 1) != 1) break;
+        if (f.read(&e.day, 1) != 1) break;
+        if (f.read(reinterpret_cast<uint8_t*>(e.language), 4) != 4) break;
+        if (f.read(reinterpret_cast<uint8_t*>(&e.minutesRead), 2) != 2) break;
+        e.language[3] = '\0';         // a corrupt record must not leave an unterminated tag
+        if (e.year < 2020) continue;  // same unset-clock garbage the per-day loop drops
+        languageDays.push_back(e);
+      }
+    }
   }
   f.close();
   return true;

--- a/src/ReadingStatsStore.cpp
+++ b/src/ReadingStatsStore.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <numeric>
 
 ReadingStatsStore ReadingStatsStore::instance;
 
@@ -13,6 +14,10 @@ static constexpr const char* STATS_PATH = "/system/reading_stats.bin";
 // block after that. Each older reader stops where its own format ends and ignores what follows,
 // rather than rejecting the file -- it will, however, drop the newer blocks the next time it saves.
 static constexpr uint8_t STATS_VERSION = 4;
+// Longest language tag a per-book entry stores, on disk and in memory. Enforced on BOTH sides:
+// the writer clamps to it, and the loader rejects anything longer rather than allocating on a
+// corrupt or misaligned file's say-so.
+static constexpr size_t MAX_STORED_LANGUAGE = 15;
 
 namespace {
 int daysSinceEpoch(uint16_t y, uint8_t m, uint8_t d) {
@@ -47,9 +52,10 @@ void subtractDays(uint16_t& y, uint8_t& m, uint8_t& d, int n) {
 
 // "ja-JP" / "JA" / "ja_jp" all bucket as "ja". Anything longer than 3 chars (no ISO-639 code is)
 // is truncated rather than rejected, so a malformed tag still lands in a stable bucket.
-void normalizeLanguage(const std::string& in, char out[4]) {
+void normalizeLanguage(const char* in, char out[4]) {
   size_t n = 0;
-  for (const char c : in) {
+  for (const char* p = in; p && *p; p++) {
+    const char c = *p;
     if (c == '-' || c == '_' || n == 3) break;
     out[n++] = static_cast<char>((c >= 'A' && c <= 'Z') ? c - 'A' + 'a' : c);
   }
@@ -61,12 +67,9 @@ void normalizeLanguage(const std::string& in, char out[4]) {
     const char* from;
     const char* to;
   } ALIASES[] = {{"jp", "ja"}, {"cn", "zh"}, {"kr", "ko"}};
-  for (const auto& a : ALIASES) {
-    if (strcmp(out, a.from) == 0) {
-      strncpy(out, a.to, 4);
-      return;
-    }
-  }
+  const auto* alias =
+      std::find_if(std::begin(ALIASES), std::end(ALIASES), [&out](const auto& a) { return strcmp(out, a.from) == 0; });
+  if (alias != std::end(ALIASES)) strncpy(out, alias->to, 4);
 }
 
 int daysInMonth(uint16_t y, uint8_t m) {
@@ -90,13 +93,14 @@ void ReadingStatsStore::addMinutes(uint16_t year, uint8_t month, uint8_t day, ui
   days[dayCount++] = {year, month, day, minutes};
 }
 
-void ReadingStatsStore::addBookMinutes(const std::string& bookPath, const std::string& language, const uint16_t minutes,
+void ReadingStatsStore::addBookMinutes(const char* bookPath, const char* language, const uint16_t minutes,
                                        const uint16_t year, const uint8_t month, const uint8_t day) {
-  if (bookPath.empty()) return;
+  if (!bookPath || !*bookPath) return;
   const int32_t today = daysSinceEpoch(year, month, day);
   // Clamped to the small-string-optimisation limit: real tags ("ja", "zh-Hant") fit easily, and
   // this keeps each entry's language free of a heap allocation and its on-disk length in a byte.
-  const std::string lang = language.substr(0, 15);
+  // MAX_STORED_LANGUAGE is the same bound the loader enforces on a language read back from disk.
+  const std::string lang(language ? language : "", language ? strnlen(language, MAX_STORED_LANGUAGE) : 0);
 
   for (auto& b : books) {
     if (b.path != bookPath) continue;
@@ -117,7 +121,7 @@ void ReadingStatsStore::addBookMinutes(const std::string& bookPath, const std::s
   books.push_back({bookPath, lang, minutes, today});
 }
 
-void ReadingStatsStore::addLanguageMinutes(const std::string& language, const uint16_t minutes, const uint16_t year,
+void ReadingStatsStore::addLanguageMinutes(const char* language, const uint16_t minutes, const uint16_t year,
                                            const uint8_t month, const uint8_t day) {
   char lang[4];
   normalizeLanguage(language, lang);
@@ -143,26 +147,23 @@ void ReadingStatsStore::addLanguageMinutes(const std::string& language, const ui
   languageDays.push_back(e);
 }
 
-uint16_t ReadingStatsStore::getMinutesForDay(const std::string& language, const uint16_t year, const uint8_t month,
+uint16_t ReadingStatsStore::getMinutesForDay(const char* language, const uint16_t year, const uint8_t month,
                                              const uint8_t day) const {
   char lang[4];
   normalizeLanguage(language, lang);
-  for (const auto& e : languageDays) {
-    if (e.year == year && e.month == month && e.day == day && memcmp(e.language, lang, sizeof(lang)) == 0) {
-      return e.minutesRead;
-    }
-  }
-  return 0;
+  const auto it = std::find_if(languageDays.begin(), languageDays.end(), [&](const LanguageDaily& e) {
+    return e.year == year && e.month == month && e.day == day && memcmp(e.language, lang, sizeof(lang)) == 0;
+  });
+  return it == languageDays.end() ? 0 : it->minutesRead;
 }
 
-uint32_t ReadingStatsStore::getTotalMinutes(const std::string& language) const {
+uint32_t ReadingStatsStore::getTotalMinutes(const char* language) const {
   char lang[4];
   normalizeLanguage(language, lang);
-  uint32_t total = 0;
-  for (const auto& e : languageDays) {
-    if (memcmp(e.language, lang, sizeof(lang)) == 0) total += e.minutesRead;
-  }
-  return total;
+  return std::accumulate(languageDays.begin(), languageDays.end(), uint32_t{0},
+                         [&lang](const uint32_t sum, const LanguageDaily& e) {
+                           return memcmp(e.language, lang, sizeof(lang)) == 0 ? sum + e.minutesRead : sum;
+                         });
 }
 
 void ReadingStatsStore::markBookFinished(const std::string& bookPath) {
@@ -171,7 +172,9 @@ void ReadingStatsStore::markBookFinished(const std::string& bookPath) {
     return;
   }
   finishedBookPaths.push_back(bookPath);
-  booksFinished = static_cast<uint16_t>(finishedBookPaths.size());
+  // max(), not assignment: after a truncated load the path list can hold fewer entries than the
+  // count the file's header reported, and a finished-book tally must never count down.
+  booksFinished = std::max(booksFinished, static_cast<uint16_t>(finishedBookPaths.size()));
 }
 
 uint16_t ReadingStatsStore::getMinutesForDay(uint16_t year, uint8_t month, uint8_t day) const {
@@ -373,7 +376,10 @@ bool ReadingStatsStore::loadFromFile() {
       }
       finishedBookPaths.push_back(std::move(p));
     }
-    booksFinished = static_cast<uint16_t>(finishedBookPaths.size());
+    // Only trust the list's length once it read whole. On a truncated file the header's count is
+    // the better answer: leaving a non-zero booksFinished beside a partial list would let
+    // markBookFinished() overwrite the real total with the partial one on the next save.
+    if (pathsIntact) booksFinished = static_cast<uint16_t>(finishedBookPaths.size());
   }
   // Per-book block (v3+). Only readable when the paths block above was consumed whole -- a short
   // read there leaves the file position mid-record, so anything after it is misaligned garbage.
@@ -390,7 +396,7 @@ bool ReadingStatsStore::loadFromFile() {
         b.path.assign(pathLen, '\0');
         if (pathLen && f.read(reinterpret_cast<uint8_t*>(&b.path[0]), pathLen) != pathLen) break;
         uint8_t langLen = 0;
-        if (f.read(&langLen, 1) != 1) break;
+        if (f.read(&langLen, 1) != 1 || langLen > MAX_STORED_LANGUAGE) break;
         b.language.assign(langLen, '\0');
         if (langLen && f.read(reinterpret_cast<uint8_t*>(&b.language[0]), langLen) != langLen) break;
         if (f.read(reinterpret_cast<uint8_t*>(&b.minutesRead), 4) != 4) break;

--- a/src/ReadingStatsStore.h
+++ b/src/ReadingStatsStore.h
@@ -57,20 +57,25 @@ class ReadingStatsStore {
   static ReadingStatsStore& getInstance() { return instance; }
 
   void addMinutes(uint16_t year, uint8_t month, uint8_t day, uint16_t minutes);
-  // Same minutes, attributed to one book. Called alongside addMinutes(); an empty bookPath is
-  // ignored. A non-empty language overwrites a previously unknown one (a book converted before
-  // meta.bin carried a language tag starts blank and fills in after a re-convert).
-  void addBookMinutes(const std::string& bookPath, const std::string& language, uint16_t minutes, uint16_t year,
-                      uint8_t month, uint8_t day);
+  // Same minutes, attributed to one book. Called alongside addMinutes(); a null or empty
+  // bookPath is ignored. A non-empty language overwrites a previously unknown one (a book
+  // converted before meta.bin carried a language tag starts blank and fills in after a
+  // re-convert).
+  //
+  // const char* rather than const std::string&: the readers call this via flushReadingStats()
+  // on every loop() tick, and a std::string parameter makes each of those ticks construct a
+  // temporary -- a heap allocation per tick, on the device least able to afford the churn.
+  void addBookMinutes(const char* bookPath, const char* language, uint16_t minutes, uint16_t year, uint8_t month,
+                      uint8_t day);
   const std::vector<BookReading>& getBooks() const { return books; }
   // Same minutes again, bucketed by day and language. Unlike addBookMinutes this DOES record an
   // empty language, as its own "unknown" bucket -- dropping it would make the per-language days
   // silently disagree with the overall ones for anyone reading TXT/XTC.
-  void addLanguageMinutes(const std::string& language, uint16_t minutes, uint16_t year, uint8_t month, uint8_t day);
+  void addLanguageMinutes(const char* language, uint16_t minutes, uint16_t year, uint8_t month, uint8_t day);
   const std::vector<LanguageDaily>& getLanguageDays() const { return languageDays; }
   // language is matched the way it is stored: primary subtag, lowercase ("ja"). Empty = unknown.
-  uint16_t getMinutesForDay(const std::string& language, uint16_t year, uint8_t month, uint8_t day) const;
-  uint32_t getTotalMinutes(const std::string& language) const;
+  uint16_t getMinutesForDay(const char* language, uint16_t year, uint8_t month, uint8_t day) const;
+  uint32_t getTotalMinutes(const char* language) const;
   void markBookFinished(const std::string& bookPath);
 
   int getStreak(uint16_t todayYear, uint8_t todayMonth, uint8_t todayDay) const;

--- a/src/ReadingStatsStore.h
+++ b/src/ReadingStatsStore.h
@@ -10,19 +10,67 @@ struct DailyReading {
   uint16_t minutesRead;
 };
 
+// Per-book totals, alongside the per-day ones. Carries the book's language so reading time can
+// later be broken down by language (issue #38) -- captured now, displayed nowhere yet.
+struct BookReading {
+  std::string path;      // book file (EPUB/TXT/XTC) or manga folder -- the same identity used elsewhere
+  std::string language;  // BCP-47/ISO-639 tag, empty when the book declares none. Short enough for SSO.
+  uint32_t minutesRead = 0;
+  int32_t lastReadDay = 0;  // days since the civil epoch, for eviction and (later) recency sorting
+};
+
+// One day's minutes in one language -- what a "Japanese only" view needs (issue #38): with a
+// day granularity it yields the same streak/calendar/week/total numbers the overall stats show,
+// per language. A per-book-per-day matrix would give the same answers and more, but 150 books x
+// 365 days does not fit in DRAM, so the book dimension keeps only a running total.
+struct LanguageDaily {
+  uint16_t year;
+  uint8_t month;
+  uint8_t day;
+  // Primary subtag only, lowercased and NUL-padded: "ja-JP" and "ja" both bucket as "ja".
+  // Fixed-size to keep this POD (no allocation, written and read as a flat record). Empty
+  // first byte = language unknown (TXT/XTC, manga converted before meta.bin carried a tag).
+  char language[4];
+  uint16_t minutesRead;
+};
+
 class ReadingStatsStore {
   static ReadingStatsStore instance;
 
   static constexpr int MAX_DAYS = 365;
+  // A year of days times the handful of languages one reader actually uses. Held in a vector
+  // rather than a flat array so the common single-language case costs a few hundred bytes
+  // instead of the worst case's 5KB; oldest entries are dropped when full.
+  static constexpr size_t MAX_LANG_DAYS = 512;
+  // Bounded because each entry heap-allocates its path (~40-80 bytes) and the store is a
+  // long-lived singleton. When full, the least recently read book is dropped -- its minutes
+  // stay counted in the per-day totals, which are the numbers the UI shows today.
+  static constexpr size_t MAX_BOOKS = 150;
   DailyReading days[MAX_DAYS] = {};
   int dayCount = 0;
   uint16_t booksFinished = 0;
   std::vector<std::string> finishedBookPaths;
+  std::vector<BookReading> books;
+  std::vector<LanguageDaily> languageDays;
 
  public:
   static ReadingStatsStore& getInstance() { return instance; }
 
   void addMinutes(uint16_t year, uint8_t month, uint8_t day, uint16_t minutes);
+  // Same minutes, attributed to one book. Called alongside addMinutes(); an empty bookPath is
+  // ignored. A non-empty language overwrites a previously unknown one (a book converted before
+  // meta.bin carried a language tag starts blank and fills in after a re-convert).
+  void addBookMinutes(const std::string& bookPath, const std::string& language, uint16_t minutes, uint16_t year,
+                      uint8_t month, uint8_t day);
+  const std::vector<BookReading>& getBooks() const { return books; }
+  // Same minutes again, bucketed by day and language. Unlike addBookMinutes this DOES record an
+  // empty language, as its own "unknown" bucket -- dropping it would make the per-language days
+  // silently disagree with the overall ones for anyone reading TXT/XTC.
+  void addLanguageMinutes(const std::string& language, uint16_t minutes, uint16_t year, uint8_t month, uint8_t day);
+  const std::vector<LanguageDaily>& getLanguageDays() const { return languageDays; }
+  // language is matched the way it is stored: primary subtag, lowercase ("ja"). Empty = unknown.
+  uint16_t getMinutesForDay(const std::string& language, uint16_t year, uint8_t month, uint8_t day) const;
+  uint32_t getTotalMinutes(const std::string& language) const;
   void markBookFinished(const std::string& bookPath);
 
   int getStreak(uint16_t todayYear, uint8_t todayMonth, uint8_t todayDay) const;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -349,7 +349,8 @@ void EpubReaderActivity::onExit() {
 
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop() (see ReaderUtils::flushReadingStats).
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, epub ? epub->getPath() : std::string(),
+                                 epub ? epub->getLanguage() : std::string());
   // The extractor holds a raw pointer to this activity's epub; drop it before
   // the activity (and the shared_ptr) goes away.
   ImageBlock::setExtractor(nullptr, nullptr);
@@ -487,7 +488,8 @@ void EpubReaderActivity::loop() {
 
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, epub ? epub->getPath() : std::string(),
+                                 epub ? epub->getLanguage() : std::string());
   // A horizontal image is shown immediately in BW; refine it only after the reader
   // leaves the page idle. The render lock keeps this behind the foreground render,
   // and any input above cancels the pending refinement before it can be queued.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -349,8 +349,8 @@ void EpubReaderActivity::onExit() {
 
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop() (see ReaderUtils::flushReadingStats).
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, epub ? epub->getPath() : std::string(),
-                                 epub ? epub->getLanguage() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, epub ? epub->getPath().c_str() : nullptr,
+                                 epub ? epub->getLanguage().c_str() : nullptr);
   // The extractor holds a raw pointer to this activity's epub; drop it before
   // the activity (and the shared_ptr) goes away.
   ImageBlock::setExtractor(nullptr, nullptr);
@@ -488,8 +488,8 @@ void EpubReaderActivity::loop() {
 
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, epub ? epub->getPath() : std::string(),
-                                 epub ? epub->getLanguage() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, epub ? epub->getPath().c_str() : nullptr,
+                                 epub ? epub->getLanguage().c_str() : nullptr);
   // A horizontal image is shown immediately in BW; refine it only after the reader
   // leaves the page idle. The render lock keeps this behind the foreground render,
   // and any input above cancels the pending refinement before it can be queued.

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -144,7 +144,8 @@ void MangaReaderActivity::onExit() {
 
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop() (see ReaderUtils::flushReadingStats).
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, book ? book->getFolder() : std::string(),
+                                 book ? book->getLanguage() : std::string());
 
   // On the last page (currentPage never advances past pageCount-1 -- see
   // nextPage()) regardless of how long this particular session lasted.
@@ -337,7 +338,8 @@ void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOptio
 void MangaReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, book ? book->getFolder() : std::string(),
+                                 book ? book->getLanguage() : std::string());
 
   // Publish any finished prefetch-worker result (panelDims slot + done flags) under the loop
   // task's normal locking rules. Runs before everything else so a completed warm is visible to

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -144,8 +144,8 @@ void MangaReaderActivity::onExit() {
 
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop() (see ReaderUtils::flushReadingStats).
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, book ? book->getFolder() : std::string(),
-                                 book ? book->getLanguage() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, book ? book->getFolder().c_str() : nullptr,
+                                 book ? book->getLanguage().c_str() : nullptr);
 
   // On the last page (currentPage never advances past pageCount-1 -- see
   // nextPage()) regardless of how long this particular session lasted.
@@ -338,8 +338,8 @@ void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOptio
 void MangaReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, book ? book->getFolder() : std::string(),
-                                 book ? book->getLanguage() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, book ? book->getFolder().c_str() : nullptr,
+                                 book ? book->getLanguage().c_str() : nullptr);
 
   // Publish any finished prefetch-worker result (panelDims slot + done flags) under the loop
   // task's normal locking rules. Runs before everything else so a completed warm is visible to

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -40,12 +40,14 @@ constexpr unsigned long READING_STATS_FLUSH_MS = 5UL * 60UL * 1000UL;
 // never drop seconds.
 //
 // bookPath/language attribute the same minutes to one book, and to that day in that language,
-// as well as to the day overall (issue #38).
+// as well as to the day overall (issue #38). Both are const char* rather than std::string:
+// this runs on every loop() tick and returns early most of the time, so string parameters
+// would mean a heap allocation per tick for arguments almost always thrown away.
 // Both are optional: an empty bookPath records only the per-day total, and an empty language is
 // the normal case for books that declare none (TXT/XTC, manga converted before meta.bin carried
 // a language tag) -- it is filled in on a later flush if the book ever starts declaring one.
-inline void flushReadingStats(unsigned long& sessionStartMs, const bool force = false, const std::string& bookPath = {},
-                              const std::string& language = {}) {
+inline void flushReadingStats(unsigned long& sessionStartMs, const bool force = false, const char* bookPath = nullptr,
+                              const char* language = nullptr) {
   if (sessionStartMs == 0) return;
   const unsigned long elapsed = millis() - sessionStartMs;
   if (!force && elapsed < READING_STATS_FLUSH_MS) return;

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -9,6 +9,7 @@
 #include <components/bars/tap-zones.h>
 
 #include <ctime>
+#include <string>
 
 #include "MappedInputManager.h"
 #include "ReadingStatsStore.h"
@@ -37,7 +38,14 @@ constexpr unsigned long READING_STATS_FLUSH_MS = 5UL * 60UL * 1000UL;
 //
 // The sub-minute remainder is carried forward in sessionStartMs so repeated flushes
 // never drop seconds.
-inline void flushReadingStats(unsigned long& sessionStartMs, const bool force = false) {
+//
+// bookPath/language attribute the same minutes to one book, and to that day in that language,
+// as well as to the day overall (issue #38).
+// Both are optional: an empty bookPath records only the per-day total, and an empty language is
+// the normal case for books that declare none (TXT/XTC, manga converted before meta.bin carried
+// a language tag) -- it is filled in on a later flush if the book ever starts declaring one.
+inline void flushReadingStats(unsigned long& sessionStartMs, const bool force = false, const std::string& bookPath = {},
+                              const std::string& language = {}) {
   if (sessionStartMs == 0) return;
   const unsigned long elapsed = millis() - sessionStartMs;
   if (!force && elapsed < READING_STATS_FLUSH_MS) return;
@@ -53,6 +61,10 @@ inline void flushReadingStats(unsigned long& sessionStartMs, const bool force = 
   const bool loadOk = READING_STATS_STORE.loadFromFile();
   READING_STATS_STORE.addMinutes(static_cast<uint16_t>(t.tm_year + 1900), static_cast<uint8_t>(t.tm_mon + 1),
                                  static_cast<uint8_t>(t.tm_mday), minutes);
+  READING_STATS_STORE.addBookMinutes(bookPath, language, minutes, static_cast<uint16_t>(t.tm_year + 1900),
+                                     static_cast<uint8_t>(t.tm_mon + 1), static_cast<uint8_t>(t.tm_mday));
+  READING_STATS_STORE.addLanguageMinutes(language, minutes, static_cast<uint16_t>(t.tm_year + 1900),
+                                         static_cast<uint8_t>(t.tm_mon + 1), static_cast<uint8_t>(t.tm_mday));
   if (!READING_STATS_STORE.saveToFile()) {
     LOG_ERR("STATS", "saveToFile failed (load=%d, %u min lost from file)", loadOk, minutes);
   }

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -55,7 +55,7 @@ void TxtReaderActivity::onExit() {
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop(). TXT books never counted toward the reading streak at all
   // before this.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, txt ? txt->getPath() : std::string());
 
   // Reset orientation back to portrait for the rest of the UI
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
@@ -70,7 +70,7 @@ void TxtReaderActivity::onExit() {
 void TxtReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, txt ? txt->getPath() : std::string());
 
   if (ReaderUtils::handleBackNavigation(mappedInput, activityManager, txt ? txt->getPath().c_str() : "",
                                         {this, [](void* ctx) { static_cast<TxtReaderActivity*>(ctx)->onGoHome(); }})) {

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -55,7 +55,7 @@ void TxtReaderActivity::onExit() {
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop(). TXT books never counted toward the reading streak at all
   // before this.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, txt ? txt->getPath() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, txt ? txt->getPath().c_str() : nullptr);
 
   // Reset orientation back to portrait for the rest of the UI
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
@@ -70,7 +70,7 @@ void TxtReaderActivity::onExit() {
 void TxtReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, txt ? txt->getPath() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, txt ? txt->getPath().c_str() : nullptr);
 
   if (ReaderUtils::handleBackNavigation(mappedInput, activityManager, txt ? txt->getPath().c_str() : "",
                                         {this, [](void* ctx) { static_cast<TxtReaderActivity*>(ctx)->onGoHome(); }})) {

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -63,7 +63,7 @@ void XtcReaderActivity::onExit() {
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop(). XTC books never counted toward the reading streak at all
   // before this -- reading an XTC book all day left the day unregistered.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, xtc ? xtc->getPath() : std::string());
 
   freePageBuffer();
   APP_STATE.readerActivityLoadCount = 0;
@@ -74,7 +74,7 @@ void XtcReaderActivity::onExit() {
 void XtcReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs);
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, xtc ? xtc->getPath() : std::string());
 
   // Auto-dismiss the bookmark toast.
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -63,7 +63,7 @@ void XtcReaderActivity::onExit() {
   // Record the sub-interval tail of the session; whole minutes were already flushed
   // periodically from loop(). XTC books never counted toward the reading streak at all
   // before this -- reading an XTC book all day left the day unregistered.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, xtc ? xtc->getPath() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, xtc ? xtc->getPath().c_str() : nullptr);
 
   freePageBuffer();
   APP_STATE.readerActivityLoadCount = 0;
@@ -74,7 +74,7 @@ void XtcReaderActivity::onExit() {
 void XtcReaderActivity::loop() {
   // Crash-proof stats: flush whole minutes every few minutes so an exit path that
   // never reaches onExit() (hang/reset on sleep, battery pull) can't lose the day.
-  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, xtc ? xtc->getPath() : std::string());
+  ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/false, xtc ? xtc->getPath().c_str() : nullptr);
 
   // Auto-dismiss the bookmark toast.
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {

--- a/tools/manga_convert/convert_manga.py
+++ b/tools/manga_convert/convert_manga.py
@@ -46,8 +46,8 @@ Output (in --output-dir):
                                          reads the older flat layout, so books converted before
                                          this keep working -- re-convert to get the faster open.
     panels.idx / panels.dat             panel layout data
-    meta.bin                            book title + author (auto-extracted
-                                         from source, or set via --title/--author)
+    meta.bin                            book title + author + language (auto-extracted
+                                         from source, or set via --title/--author/--language)
 
 Binary format (meta.bin):
     Header (8 bytes):
@@ -56,6 +56,15 @@ Binary format (meta.bin):
         uint16  authorLen       UTF-8 byte length of author
     char[]  title               UTF-8 title (titleLen bytes)
     char[]  author              UTF-8 author (authorLen bytes)
+    Optional trailer (only present when a language is known):
+        uint16  languageLen     UTF-8 byte length of language tag
+        char[]  language        UTF-8 BCP-47/ISO-639 tag, e.g. "ja", "en"
+
+    The trailer is appended WITHOUT bumping the version: firmware predating it reads
+    exactly the header + title + author and never looks further, so it ignores the extra
+    bytes rather than rejecting the file. Newer firmware detects the trailer by checking
+    whether any bytes remain after the author. Any future field must follow the same
+    rule -- append only, never reorder or resize what comes before.
 
 Binary format (panels.idx):
     Header:
@@ -868,26 +877,57 @@ def write_toc(output_dir: str, entries: list[tuple], add_cover: bool = True):
 
 META_FORMAT_VERSION = 1
 META_HEADER = "<IHH"  # version(4) + titleLen(2) + authorLen(2) = 8 bytes
+META_LANGUAGE_TRAILER = "<H"  # optional, appended after author: languageLen(2) + language bytes
 
 
-def write_meta(output_dir: str, title: str, author: str) -> None:
-    """Write meta.bin: book title and author for the CrossPoint library."""
-    if not title and not author:
+# Country codes commonly typed in place of the language code. The device normalises these too,
+# but correcting here keeps meta.bin itself honest and tells the user what was written.
+LANGUAGE_ALIASES = {"jp": "ja", "cn": "zh", "kr": "ko"}
+
+
+def normalize_language(language: str) -> str:
+    """Lowercase the tag and correct common country-code mistakes ('jp' -> 'ja').
+
+    Region/script subtags are preserved ('zh-Hant' stays intact): the device buckets stats by
+    primary subtag on its own, so there is no reason to throw that detail away on disk.
+    """
+    if not language:
+        return ""
+    tag = language.strip()
+    primary, sep, rest = tag.partition("-") if "-" in tag else tag.partition("_")
+    primary = primary.lower()  # only the language subtag is case-normalised; 'zh-Hant' keeps its script
+    corrected = LANGUAGE_ALIASES.get(primary, primary) + ("-" + rest if sep and rest else "")
+    if corrected != tag:
+        print(f"  Note: language {language!r} normalised to {corrected!r}")
+    return corrected
+
+
+def write_meta(output_dir: str, title: str, author: str, language: str = "") -> None:
+    """Write meta.bin: book title, author and (optionally) language for the CrossPoint library."""
+    if not title and not author and not language:
         return
+    language = normalize_language(language)
     title_bytes = title.encode("utf-8")[:0xFFFF]
     author_bytes = author.encode("utf-8")[:0xFFFF]
+    language_bytes = language.encode("utf-8")[:0xFFFF]
     meta_path = os.path.join(output_dir, "meta.bin")
     with open(meta_path, "wb") as f:
         f.write(struct.pack(META_HEADER, META_FORMAT_VERSION, len(title_bytes), len(author_bytes)))
         f.write(title_bytes)
         f.write(author_bytes)
-    print(f"  {meta_path}: title={title!r}, author={author!r}")
+        if language_bytes:
+            f.write(struct.pack(META_LANGUAGE_TRAILER, len(language_bytes)))
+            f.write(language_bytes)
+    print(f"  {meta_path}: title={title!r}, author={author!r}, language={language!r}")
 
 
-def extract_metadata(input_path: str, work_dir: str) -> tuple[str, str]:
-    """Best-effort extraction of (title, author) from EPUB OPF, CBZ ComicInfo.xml, or PDF metadata."""
+def extract_metadata(input_path: str, work_dir: str) -> tuple[str, str, str]:
+    """Best-effort extraction of (title, author, language) from EPUB OPF, CBZ ComicInfo.xml, or PDF metadata.
+
+    PDF has no standard language field, so it yields an empty language -- use --language there.
+    """
     p = Path(input_path)
-    title, author = "", ""
+    title, author, language = "", "", ""
 
     if p.suffix.lower() == ".epub":
         try:
@@ -902,6 +942,9 @@ def extract_metadata(input_path: str, work_dir: str) -> tuple[str, str]:
                     a = re.search(r'<dc:creator[^>]*>([^<]+)</dc:creator>', opf)
                     if a:
                         author = a.group(1).strip()
+                    lang = re.search(r'<dc:language[^>]*>([^<]+)</dc:language>', opf)
+                    if lang:
+                        language = lang.group(1).strip()
         except Exception:
             pass
 
@@ -917,6 +960,9 @@ def extract_metadata(input_path: str, work_dir: str) -> tuple[str, str]:
                     a = re.search(r'<Writer>([^<]+)</Writer>', xml)
                     if a:
                         author = a.group(1).strip()
+                    lang = re.search(r'<LanguageISO>([^<]+)</LanguageISO>', xml)
+                    if lang:
+                        language = lang.group(1).strip()
         except Exception:
             pass
 
@@ -930,7 +976,7 @@ def extract_metadata(input_path: str, work_dir: str) -> tuple[str, str]:
         except Exception:
             pass
 
-    return title, author
+    return title, author, language
 
 
 def parse_toc_file(toc_file: str) -> list[tuple]:
@@ -1141,6 +1187,12 @@ def main():
     parser.add_argument("--title", help="Book title written to meta.bin (overrides value auto-detected from source)")
     parser.add_argument("--author", help="Book author written to meta.bin (overrides value auto-detected from source)")
     parser.add_argument(
+        "--language",
+        help="Book language tag written to meta.bin, e.g. 'ja' or 'en' (overrides the value auto-detected from "
+             "an EPUB's <dc:language> or a CBZ's ComicInfo <LanguageISO>). Used to break reading stats down by "
+             "language; PDF sources carry no language field, so set it here for those.",
+    )
+    parser.add_argument(
         "--mono",
         action="store_true",
         help="Write pages and panel crops as 1-bit (black/white) Floyd-Steinberg-dithered BMP instead of JPEG. "
@@ -1208,12 +1260,13 @@ def main():
 
         os.makedirs(args.output_dir, exist_ok=True)
 
-        # Extract and write book metadata (title + author).
-        auto_title, auto_author = extract_metadata(args.input, work_dir)
+        # Extract and write book metadata (title + author + language).
+        auto_title, auto_author, auto_language = extract_metadata(args.input, work_dir)
         meta_title = args.title if args.title else auto_title
         meta_author = args.author if args.author else auto_author
-        if meta_title or meta_author:
-            write_meta(args.output_dir, meta_title, meta_author)
+        meta_language = args.language if args.language else auto_language
+        if meta_title or meta_author or meta_language:
+            write_meta(args.output_dir, meta_title, meta_author, meta_language)
 
         idx_records = []
         dat_chunks = []


### PR DESCRIPTION
Groundwork for #38 (Japanese-only reading stats). **Capture only — nothing new is displayed yet.** The overall stats read the same per-day totals they always have; the same minutes are now simply recorded three ways instead of one.

## `meta.bin`: optional language trailer, no version bump

`uint16 languageLen + UTF-8 tag`, appended after the author. Deliberately **not** a version bump: `MangaBook::loadMeta()` reads exactly the header, title and author and never looks further, so firmware predating this ignores the extra bytes rather than rejecting the file. Cards can therefore be re-converted before devices are updated.

`convert_manga.py` gains `--language`, auto-detected from an EPUB's `<dc:language>` or a CBZ's ComicInfo `<LanguageISO>` (PDF carries no language field, so set it by hand there).

## `reading_stats.bin` → v4

Same append-only rule the v2 `booksFinished` field established — each older reader stops where its own format ends:

| | |
|---|---|
| v3 | per-book totals (path, language, minutes, lastReadDay) |
| v4 | per-day-per-language minutes |

Per book is a **running total, not a daily series**: a 150-book × 365-day matrix does not fit in DRAM. Per *day* per *language* does, and is what a Japanese-only view actually needs — it yields the same streak/calendar/week/total numbers the overall stats show, filtered. Both tables are bounded (150 books, 512 language-days) and evict the least recently read entry.

## Language bucketing

Primary subtag, lowercased, with the country codes people reach for corrected (`jp`→`ja`, `cn`→`zh`, `kr`→`ko`) so one language cannot end up split across two buckets. `zh-Hant` keeps its script subtag on disk; only the stats key is reduced.

Books that declare no language (TXT/XTC) get an explicit **unknown** bucket rather than being dropped — otherwise the per-language days would silently fail to add up to the overall ones.

## Verification

Run in the emulator against a real v2 stats file:

- Migrated **v2 → v4 in place**: all 6 days, 3 finished books and their paths preserved, no trailing bytes.
- A converted Japanese book recorded as `lang='ja'` at the day, book and language level; firmware log confirms `Loaded meta.bin: … lang=ja`.
- A pre-trailer parser reads the same title/author from the new `meta.bin` as before — existing devices are unaffected.
- `pio run -e default` and `-e private` both build clean; clang-format applied.

One known limitation worth stating: minutes recorded *before* this ships carry no language, so a future "Japanese" tab will under-report against "All" for historical days. That attribution cannot be recovered retroactively.

## Not in this PR

The UI changes in `ReadingStatsActivity` — deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)