### PR TITLE
feat: Reduce margins and char spacing in tategaki

### DIFF
--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -240,7 +240,7 @@ int VerticalParsedText::charAdvancePx() const {
   renderer_.ensureSdCardFontReady(fontId_, "\xe6\xbc\xa2", 0x01);
   const int cjkAdvance =
       renderer_.getTextAdvanceX(fontId_, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));  // 漢
-  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 6;
+  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 10;
   return renderer_.getLineHeight(fontId_);
 }
 
@@ -531,7 +531,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   const int columnAdvancePx = cellPx + columnGapPx_;
   const int ascender = renderer_.getFontAscenderSize(fontId_);
   const int globalDownNudge = std::max(1, (cellPx * 3) / 8);
-  const int bottomReservedPx = std::max(cellPx * 2, ascender + globalDownNudge + cellPx);
+  const int bottomReservedPx = std::max(cellPx, ascender + globalDownNudge + cellPx / 2);  // reduced: *2 and full cellPx left excessive bottom margin
   const int usableHeightPx = std::max(cellPx, static_cast<int>(viewportHeight_) - bottomReservedPx);
   const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, usableHeightPx / cellPx));
   const int usableWidthPx = std::max(cellPx, static_cast<int>(viewportWidth_) - rightPaddingPx_);

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1254,13 +1254,14 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   VerticalParsedText layout(renderer, fontId, viewportWidth, viewportHeight);
   layout.preallocateStream();
   const int lineH = renderer.getLineHeight(fontId);
-  // Tight/Normal/Wide use one, two, or four sixths of a line between columns.
+  // Tight/Normal/Wide column gap. /12 gives tighter spacing matching printed books;
+  // ruby adds one extra twelfth for the annotation column.
   const int clampedLineSpacing = std::clamp<int>(lineSpacing, 0, 2);
-  const int gapSixths = clampedLineSpacing == 2 ? 4 : clampedLineSpacing + 1;
-  layout.setColumnGapPx(std::max(4, lineH * gapSixths / 6));
+  const int gapTwelfths = clampedLineSpacing == 2 ? 4 : clampedLineSpacing + 1;
+  layout.setColumnGapPx(std::max(2, lineH * gapTwelfths / 12 + 4));
   if (hasRuby) {
-    layout.setColumnGapPx(std::max(4, lineH * (gapSixths + 2) / 6));
-    layout.setRightPaddingPx((lineH / 2) < 2 ? 2 : (lineH / 2));
+    layout.setColumnGapPx(std::max(2, lineH * (gapTwelfths + 1) / 12 + 4));
+    layout.setRightPaddingPx((lineH / 4) < 2 ? 2 : (lineH / 4));  // reduced: /2 was ~2x the furigana area size
   }
 
   LayoutPageSink sink(layout, out, pageOffsets_, *epub, renderer, chapterDir, imageBasePath, viewportWidth,

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -32,7 +32,7 @@ int computeCellPx(GfxRenderer& renderer, int fontId) {
   // nudge lands wrong for that frame (seen live: cell flapping 42 -> 33 on NotoSansJP).
   renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
   const int cjkAdvance = renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));
-  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 6;
+  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 10;
   return renderer.getLineHeight(fontId);
 }
 
@@ -79,9 +79,8 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
         // check, book 2). Keep in sync with GfxRenderer::verticalPunctInkBox().
         dy += std::max(1, (cellPx * 7) / 8);
       } else if (shiftType == 4) {
-        // Dashes/chōonpu sat visibly low in their cell (device photo, kyokasho) -- a
-        // quarter cell less down-shift than the ellipsis dot stack.
-        dy += std::max(1, (cellPx * 3) / 8);
+        // Dashes/chōonpu: reduced down-shift to match tighter cell spacing.
+          dy -= std::max(1, cellPx / 22);
       }
       renderer.drawCharVerticalRotatedInCell(fontId, dx, dy, cellPx, g.codepoint, shiftType, black,
                                              static_cast<EpdFontFamily::Style>(g.style));

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2438,9 +2438,12 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     // right of the em box, so pull them left onto the column axis. Angle brackets 〉》 are
     // symmetric chevrons -- the same pull pushed them visibly LEFT of the column (device
     // photo, 〈夏〉); leave them ink-centered.
-    const bool isSquareBracket = (cp == 0x300D || cp == 0x300F || cp == 0x3011 || cp == 0x3015);
-    if (isSquareBracket) {
-      drawX = cellLeftX + (cellSize - rotatedW) / 2 - cellSize / 3;
+    const bool isTortoiseBracket = (cp == 0x3011 || cp == 0x3015);
+    const bool isCornerBracket = (cp == 0x300D || cp == 0x300F);
+    if (isTortoiseBracket) {
+      drawX = cellLeftX + (cellSize - rotatedW) / 2;
+    } else if (isCornerBracket) {
+      drawX = cellLeftX + (cellSize - rotatedW) / 2 - cellSize / 4;
     }
     // +cellSize/4: the closing bracket read high against the Japanese character it closes
     // (device check, tuned in two steps). After an embedded Latin word the distance is set by
@@ -2462,7 +2465,11 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     // and character spacing around it follows automatically.
     const int openingBias = std::max(1, (cellSize * 3) / 8 + extraNudge + baselineExcess);
     drawY = cellTopY + cellSize + openingBias;
-    if (!inkCentered) drawX += cellSize / 4;
+    if (cp == 0x300C || cp == 0x300E) {
+      drawX += cellSize / 4;
+    } else if (!inkCentered) {
+      drawX += 0;
+    }
   }
 
   int minX = cellLeftX;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3267,6 +3267,9 @@ void EpubReaderActivity::renderVerticalPageBody(const VerticalPage& vpage, const
   renderer.getOrientedViewableTRBL(&marginTop, &marginRight, &marginBottom, &marginLeft);
   marginTop += SETTINGS.screenMargin;
   marginLeft += SETTINGS.screenMargin;
+  // Vertical mode uses tighter margins than horizontal: reduce top and left.
+  marginTop -= 35;
+  marginLeft -= 18;
   VerticalTextBlock block(vpage);
   if (useFurigana()) {
     block.render(renderer, effectiveReaderFontId(), SETTINGS.getRubyFontId(), marginLeft, marginTop, true);


### PR DESCRIPTION
## Summary

Reduce margins and char spacing in tategaki
    
    Reduces top and left margins in tategaki mode.
    
    Also reduces line spacing in tight width, and character spacing generally.

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

Brings tategaki layout in line with typical Japanese trade print.

## Additional Context

<img width="3072" height="4080" alt="PXL_20260806_042127384 RAW-01 COVER" src="https://github.com/user-attachments/assets/f79dcaf0-264e-407e-8060-2f1037a44452" />
<img width="3072" height="4080" alt="PXL_20260806_042139534 RAW-01 COVER" src="https://github.com/user-attachments/assets/72fa19f8-944a-4bf0-be82-24b111c614f4" />


* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

There may be a bug in the position of the text 「起動中…」 on boot and the position of the text 「索引作成」 when building the index.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_. Qwen 3.6 was used locally to identify where to make edits, and then I tested and adjusted those edits manually.
