### PR TITLE
feat: derive vertical text placement from metrics and JLREQ

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -92,6 +92,10 @@ void FontDecompressor::freeHotGroup() {
   free(hotGlyphBuf);
   hotGlyphBuf = nullptr;
   hotGlyphBufCapacity = 0;
+  // The release itself is the biggest heap improvement there is; never let a stale latch
+  // suppress the first retry after it.
+  hotGroupFailNeeded = 0;
+  hotGroupFailMaxAlloc = 0;
 }
 
 bool FontDecompressor::ensureCapacity(uint8_t*& buf, uint32_t& capacity, uint32_t needed) {
@@ -244,14 +248,29 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
     stats.cacheMisses++;
     const EpdFontGroup& group = fontData->groups[groupIndex];
 
+    // Skip an allocation that already failed on a heap no larger than this one. Checked BEFORE
+    // ensureCapacity, which frees the existing buffer first: without the latch a doomed retry also
+    // destroys a hot group that later glyphs would have hit, turning one shortage into a cascade.
+    if (hotGroupFailNeeded != 0 && group.uncompressedSize >= hotGroupFailNeeded &&
+        ESP.getMaxAllocHeap() <= hotGroupFailMaxAlloc) {
+      starvedGlyphs++;
+      stats.getBitmapTimeUs += micros() - tStart;
+      return nullptr;
+    }
+
     // ensureCapacity may free the buffer, so the cached-group identity dies with it either way.
     hotGroupFont = nullptr;
     hotGroupIndex = UINT16_MAX;
     if (!ensureCapacity(hotGroup, hotGroupCapacity, group.uncompressedSize)) {
-      LOG_ERR("FDC", "Failed to allocate %u bytes for hot group %u", group.uncompressedSize, groupIndex);
+      hotGroupFailNeeded = group.uncompressedSize;
+      hotGroupFailMaxAlloc = ESP.getMaxAllocHeap();
+      starvedGlyphs++;
+      LOG_ERR("FDC", "Failed to allocate %u bytes for hot group %u (backing off until heap > %u)",
+              group.uncompressedSize, groupIndex, hotGroupFailMaxAlloc);
       stats.getBitmapTimeUs += micros() - tStart;
       return nullptr;
     }
+    hotGroupFailNeeded = 0;  // a success proves the heap recovered
 
     if (!decompressGroup(fontData, groupIndex, hotGroup, group.uncompressedSize)) {
       free(hotGroup);

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -50,6 +50,12 @@ class FontDecompressor {
   void resetStats();
   const Stats& getStats() const { return stats; }
 
+  // Monotonic count of glyphs that could not be served because the heap had no room for their
+  // group. Sampled either side of a long build so the caller can tell that its measurements ran
+  // blind -- see VerticalSection's stale-stamp path. Never reset by clearCache(), so a sample
+  // pair is always comparable.
+  uint32_t getStarvedGlyphCount() const { return starvedGlyphs; }
+
  private:
   Stats stats;
   InflateReader inflateReader;
@@ -90,6 +96,17 @@ class FontDecompressor {
   // Valid until the next getBitmap() call. Same ownership/OOM contract as hotGroup.
   uint8_t* hotGlyphBuf = nullptr;
   uint32_t hotGlyphBufCapacity = 0;
+
+  // Back-off latch for a failed hot-group allocation. Without it, a heap too tight for one group
+  // is re-probed once per glyph: a device log of a vertical chapter build showed 203 consecutive
+  // "Failed to allocate 16357 bytes" over 6.8 seconds, each one a free()+malloc()+LOG_ERR that
+  // could not have succeeded. The state is RAM-only and self-clearing -- a retry is allowed the
+  // moment the largest block grows past what was available when we failed, or a smaller group is
+  // asked for -- so a transient shortage is never recorded as a permanent "this font is
+  // unavailable". Cleared outright whenever the buffers are released.
+  uint32_t hotGroupFailNeeded = 0;    // size that failed; 0 = no latch
+  uint32_t hotGroupFailMaxAlloc = 0;  // largest block at the time of that failure
+  uint32_t starvedGlyphs = 0;         // glyphs returned as nullptr for want of a group buffer
 
   // Grow (never shrink) an owned buffer to at least `needed` bytes; false on OOM, buffer freed.
   static bool ensureCapacity(uint8_t*& buf, uint32_t& capacity, uint32_t needed);

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -97,13 +97,13 @@ class FontDecompressor {
   uint8_t* hotGlyphBuf = nullptr;
   uint32_t hotGlyphBufCapacity = 0;
 
-  // Back-off latch for a failed hot-group allocation. Without it, a heap too tight for one group
-  // is re-probed once per glyph: a device log of a vertical chapter build showed 203 consecutive
-  // "Failed to allocate 16357 bytes" over 6.8 seconds, each one a free()+malloc()+LOG_ERR that
-  // could not have succeeded. The state is RAM-only and self-clearing -- a retry is allowed the
-  // moment the largest block grows past what was available when we failed, or a smaller group is
-  // asked for -- so a transient shortage is never recorded as a permanent "this font is
-  // unavailable". Cleared outright whenever the buffers are released.
+  // Back-off latch for a failed hot-group allocation. Without it a heap too tight for one group is
+  // re-probed once per glyph -- each probe a free()+malloc()+LOG_ERR that cannot succeed, measured at
+  // 203 consecutive failures over 6.8s during one chapter build.
+  //
+  // RAM-only and self-clearing: a retry is allowed as soon as the largest block exceeds what was
+  // available at the failure, or a smaller group is requested, and freeHotGroup() clears it outright.
+  // A transient shortage must never be recorded as a permanent "font unavailable".
   uint32_t hotGroupFailNeeded = 0;    // size that failed; 0 = no latch
   uint32_t hotGroupFailMaxAlloc = 0;  // largest block at the time of that failure
   uint32_t starvedGlyphs = 0;         // glyphs returned as nullptr for want of a group buffer

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -1556,11 +1556,15 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           idx++;
           continue;
         }
-        // JLREQ 3.1.4: 。/、 and a closing bracket after it SHARE one em -- the mark takes the
-        // first half, the bracket the second. The mark is already set tight (commaTighten), so
-        // the half it left free is exactly where the bracket belongs. No new cell is needed, and
-        // neither character has to leave the column its sentence ended in.
-        if (Kinsoku::verticalShiftType(prev.codepoint) == 1 && Kinsoku::verticalShiftType(pc.codepoint) == 2 &&
+        // JLREQ 3.1.4: two adjacent half-em marks SHARE one em -- the first takes the first half,
+        // the second the second. That covers 。」 and 、」 as well as 』」 and 」」, since a closing
+        // bracket is itself a half-em glyph set in the first half of its cell (and 。/、 are set
+        // tight for the same reason). The half the first mark left free is exactly where the
+        // second belongs: no new cell, and neither character leaves the column its sentence
+        // ended in. Only the FIRST of the pair may already be placed -- a full-em character
+        // before the bracket (？」) genuinely needs 1.5 em and falls through to oidashi.
+        const int prevHalfEm = Kinsoku::verticalShiftType(prev.codepoint);
+        if ((prevHalfEm == 1 || prevHalfEm == 2) && Kinsoku::verticalShiftType(pc.codepoint) == 2 &&
             Kinsoku::needsVerticalRotation(pc.codepoint)) {
           VerticalGlyph g;
           g.codepoint = pc.codepoint;
@@ -1575,6 +1579,17 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.style = pc.style;
           g.emphasis = pc.emphasis;
           pushGlyph(page, g, pc.rubyText);
+          idx++;
+          continue;
+        }
+
+        // Burasage (ぶら下げ): 。/、 hang past the end of a full column rather than evict the
+        // character before them. They are half-em marks whose ink sits in the top half of the
+        // cell, so the overhang is small and falls in the bottom margin -- the same margin ruby
+        // uses beside the text (JLREQ Fig 2.37). Without this, oidashi pulled the preceding
+        // character along and left a column holding just those two.
+        if (Kinsoku::verticalShiftType(pc.codepoint) == 1 && prev.row + 1 == rowsPerColumn) {
+          placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
           idx++;
           continue;
         }

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -291,10 +291,11 @@ int punctEmHalf(const uint32_t cp) {
   }
 }
 
-bool isAsciiDigit(const uint32_t cp) {
-  return (cp >= '0' && cp <= '9') ||      // ASCII digits: U+0030-U+0039
-         (cp >= 0xFF10 && cp <= 0xFF19);  // Fullwidth digits: U+FF10-U+FF19
-}
+// Digits that are set SIDEWAYS in vertical text -- as a tate-chu-yoko pair, or as a rotated run.
+// Halfwidth ASCII only. Fullwidth digits (U+FF10-U+FF19) are East Asian Wide: they are ideographic
+// -width characters and stand upright in tategaki, one per cell, exactly like kanji. Gathering them
+// into a rotated run laid １９３８年 on its side across four cells.
+bool isAsciiDigit(const uint32_t cp) { return cp >= '0' && cp <= '9'; }
 
 bool isAsciiAlnum(const uint32_t cp) {
   return (cp >= '0' && cp <= '9') || (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -246,6 +246,8 @@ bool measureGlyphInk(const GfxRenderer& renderer, const int fontId, const uint32
   return true;
 }
 
+namespace {
+
 // Ink boxes for the handful of codepoints placed by quadrant. A miss is NOT stored: a probe
 // against a not-yet-resident SD font fails transiently, and caching that would place every
 // later occurrence by the fallback for the rest of the chapter.
@@ -272,6 +274,116 @@ struct InkMemo {
     count++;
   }
 };
+
+// Which half of its em a punctuation glyph's ink occupies: 0 none (full em), 1 first half,
+// 2 second half, 3 centred. JLREQ 3.1.4 states pair spacing in terms of these halves.
+int punctEmHalf(const uint32_t cp) {
+  if (cp == 0x30FB || cp == 0x00B7) return 3;  // ・
+  switch (Kinsoku::verticalShiftType(cp)) {
+    case 1:
+      return 1;  // 、。，．
+    case 2:
+      return 1;  // closing brackets
+    case 3:
+      return 2;  // opening brackets
+    default:
+      return 0;
+  }
+}
+
+bool isAsciiDigit(const uint32_t cp) {
+  return (cp >= '0' && cp <= '9') ||      // ASCII digits: U+0030-U+0039
+         (cp >= 0xFF10 && cp <= 0xFF19);  // Fullwidth digits: U+FF10-U+FF19
+}
+
+bool isAsciiAlnum(const uint32_t cp) {
+  return (cp >= '0' && cp <= '9') || (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');
+}
+
+// Exclamation/question marks that books put in tate-chu-yoko pairs (!? / !!). Halfwidth only:
+// fullwidth ！？ already render upright as normal CJK cells.
+bool isBangOrQuestion(const uint32_t cp) { return cp == '!' || cp == '?'; }
+
+void trimSpaces(std::string& s) {
+  const size_t b = s.find_first_not_of(' ');
+  if (b == std::string::npos) {
+    s.clear();
+    return;
+  }
+  const size_t e = s.find_last_not_of(' ');
+  s.assign(s, b, e - b + 1);
+}
+
+// The page grid for one layout pass: fixed once the font metrics and viewport are known, so the
+// placement rules can be read (and moved out of the loop) without carrying a dozen captures.
+struct ColumnGeometry {
+  int cellPx = 1;            // one em, the kihon-hanmen cell
+  int inkGapPx = 0;          // gap a normal adjacent pair leaves between ink boxes
+  int baselineInCellPx = 0;  // baseline measured down from the cell top
+  int ascenderPx = 0;
+  int columnAdvancePx = 1;  // cell + 行間
+  int usableWidthPx = 1;
+  uint16_t rowsPerColumn = 1;
+  uint16_t columnsPerPage = 1;
+
+  // Columns are anchored to the right edge and march leftwards.
+  int columnLeftX(const uint16_t col) const { return usableWidthPx - cellPx - static_cast<int>(col) * columnAdvancePx; }
+};
+
+// Upper-RIGHT quadrant placement, from the glyph's own ink box: 。、 are drawn with their ink at
+// the bottom-left of the em, so how far it must travel is font-specific. False when metrics are
+// unavailable, which every caller has a fallback for.
+//
+// centreInHalf distinguishes the two users:
+//   。、        - ink centred in a half-em box at the cell's head
+//   small kana - letter face against the TOP edge of its box
+bool quadrantTopRight(const GfxRenderer& renderer, const int fontId, InkMemo& memo, const ColumnGeometry& geom,
+                      const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
+                      const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) {
+  GlyphInk ink;
+  if (!memo.lookup(cp, style, &ink)) {
+    if (!measureGlyphInk(renderer, fontId, cp, style, &ink)) return false;
+    memo.store(cp, style, ink);
+  }
+  if (ink.width <= 0 || ink.height <= 0) return false;
+  // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
+  const int inkTopInCell = centreInHalf ? std::max(0, (geom.cellPx / 2 - ink.height) / 2) : 0;
+  *gxOut = geom.columnLeftX(col) + geom.cellPx - ink.left - ink.width;
+  *gyOut = std::max(0, rowIdx * geom.cellPx + inkTopInCell + ink.top - geom.baselineInCellPx);
+  if (inkHeightOut) *inkHeightOut = inkTopInCell + ink.height;
+  return true;
+}
+
+// getRenderAdvanceX ends at the pen, not at the ink: the last glyph's right side bearing is
+// blank. Counting it made every run reserve up to a whole extra cell.
+int runInkWidth(const GfxRenderer& renderer, const int fontId, const std::string& s, const int advanceWidth,
+                const EpdFontFamily::Style style) {
+  if (s.empty()) return advanceWidth;
+  size_t lastStart = s.size() - 1;
+  while (lastStart > 0 && (static_cast<unsigned char>(s[lastStart]) & 0xC0) == 0x80) lastStart--;
+  const std::string lastChar = s.substr(lastStart);
+  const auto c0 = static_cast<unsigned char>(lastChar[0]);
+  uint32_t lastCp = c0;
+  if (c0 >= 0xC0 && lastChar.size() >= 2) {
+    lastCp = static_cast<uint32_t>(c0 & 0x1F) << 6 | (static_cast<unsigned char>(lastChar[1]) & 0x3F);
+  }
+  GlyphInk ink;
+  if (!measureGlyphInk(renderer, fontId, lastCp, static_cast<uint8_t>(style), &ink) || ink.width <= 0) {
+    return advanceWidth;
+  }
+  const int lastAdvance = renderer.getRenderAdvanceX(fontId, lastChar.c_str(), style);
+  return advanceWidth - std::max(0, lastAdvance - (ink.left + ink.width));
+}
+
+// Rows a rotated run occupies: enough that the next character's ink clears the run's, no more.
+uint16_t rotatedRunRows(const int cellPx, const int startY, const int inkWidthPx, const uint16_t rowArg,
+                        const int nextInkOffset) {
+  const int intrusion = (nextInkOffset >= 0) ? nextInkOffset : 0;
+  const int endRow = static_cast<int>(std::ceil(static_cast<double>(startY + inkWidthPx - intrusion) / cellPx));
+  return static_cast<uint16_t>(std::max(1, endRow - static_cast<int>(rowArg)));
+}
+
+}  // namespace
 
 int verticalCellPx(const GfxRenderer& renderer, const int fontId, bool* measured) {
   // SD fonts measure through their advance table; make sure the reference glyph is in it. A cold
@@ -533,6 +645,413 @@ int verticalCellBaselineOffset(const GfxRenderer& renderer, const int fontId, co
   return (cellPx - ink.height) / 2 + ink.top;
 }
 
+// Members are REFERENCES to layoutPages' own locals and share their names, so a rule moved in
+// here reads exactly as it did in the loop; only the owner's members pick up an `o.` prefix.
+struct VerticalParsedText::LayoutCursor {
+  VerticalParsedText& o;
+  const ColumnGeometry& geom;
+  InkMemo& inkMemo;
+  VerticalPage& page;
+  std::vector<VerticalPage>& pages;
+  uint16_t& column;
+  uint16_t& row;
+  int& columnYShift;
+  uint16_t& shiftColumn;
+  const size_t glyphsPerPage;
+  void* const ctx;
+  const PageReadyCallback onPageReady;
+
+  // Can one more glyph be appended without a reallocation that the heap cannot serve?
+  bool pageVectorCanTakeMore() const {
+    constexpr size_t GROWTH_STEP = 16;  // = growForOnePush's LINEAR_GROWTH_STEP for glyphs
+    if (page.glyphs.size() + GROWTH_STEP <= page.glyphs.capacity()) return true;
+    const size_t growBytes = (page.glyphs.capacity() + GROWTH_STEP) * sizeof(VerticalGlyph);
+    return ESP.getMaxAllocHeap() >= growBytes;
+  }
+
+  void reservePageGlyphs(VerticalPage& p) const {
+    const size_t requestBytes = glyphsPerPage * sizeof(VerticalGlyph);
+    if (heapCanAfford(requestBytes, MIN_FREE_HEAP_FOR_RESERVE)) {
+      p.glyphs.reserve(glyphsPerPage);
+      return;
+    }
+    // Partial fallback: reserve the largest fitting fraction of the page instead of nothing.
+    // Starting from capacity 0 makes the vector double 1-2-4-...-256, and every doubling's
+    // grow-copy (old + new buffer coexisting) is a fresh chance to land on a heap dip -- on
+    // the X3's tighter heap that fired the emergency page split constantly, which the reader
+    // sees as pages breaking at random fill levels. This runs right after the previous page
+    // was flushed and freed (the heap's local best), so one medium block now prevents most of
+    // the risky growth steps later at the dips.
+    for (size_t fraction = 2; fraction <= 8; fraction *= 2) {
+      const size_t partial = glyphsPerPage / fraction;
+      if (partial < 32) break;
+      if (heapCanAfford(partial * sizeof(VerticalGlyph), MIN_FREE_HEAP_FOR_RESERVE)) {
+        p.glyphs.reserve(partial);
+        LOG_DBG("VPT", "Partial page glyphs reserve: %u/%u elements (maxAlloc=%u)", static_cast<unsigned>(partial),
+                static_cast<unsigned>(glyphsPerPage), ESP.getMaxAllocHeap());
+        return;
+      }
+    }
+    LOG_ERR("VPT", "Skipping page glyphs reserve (%u bytes doesn't fit, free=%u); growing incrementally",
+            static_cast<unsigned>(requestBytes), ESP.getMaxAllocHeap());
+  }
+
+  // Row where a fresh column starts: 0 normally; inside a styled block, the block's start offset
+  // (start-Xem), plus the hanging indent (h-indent-Xem) when the column continues a wrapped
+  // paragraph line rather than beginning a new paragraph.
+  // Appends a glyph, applying this column's slide and the heap growth ladder. False = dropped.
+  bool pushGlyph(VerticalPage& pg, VerticalGlyph g, const std::string& text = std::string()) {
+    std::vector<VerticalGlyph>& glyphs = pg.glyphs;
+    // Intern before the push: on a dropped glyph the orphaned pool entry is a few wasted
+    // bytes, while interning after would need the glyph's index to patch -- not worth it.
+    if (!text.empty()) g.textId = pg.internText(text);
+    if (g.column != shiftColumn) {
+      columnYShift = 0;
+      shiftColumn = g.column;
+    } else if (columnYShift != 0) {
+      // Positive slides the column tail up (cell-rounding leftover after a run), negative
+      // slides it down (ink that leaves its own cell, e.g. the low ellipsis dot stack).
+      g.y = static_cast<uint16_t>(std::max(0, static_cast<int>(g.y) - columnYShift));
+    }
+    // Tiers, most protective first. The 4K tier: device evidence (450+ page chapter) showed
+    // maxAlloc dips bottoming at 14324 while the linear request sat at ~9216 -- the 8K margin
+    // missed by 12 bytes, dropped glyphs, and the stale mark re-indexed the chapter on every
+    // open. The 0 tier: at that point the margin protects only allocations that fail gracefully
+    // and retry (font advance tables, staging buffers, the next page's reserve), while a dropped
+    // glyph is a character permanently missing from the page.
+    static constexpr uint32_t MARGINS[] = {SMALL_ALLOC_MARGIN, 4 * 1024, 0};
+    constexpr size_t LINEAR_GROWTH_STEP = 16;  // elements; keeps a stalled page's retries cheap
+    if (growForOnePush(glyphs, MARGINS, LINEAR_GROWTH_STEP)) {
+      glyphs.push_back(g);
+      return true;
+    }
+    LOG_ERR("VPT", "Low heap (%u bytes); dropping glyph", ESP.getMaxAllocHeap());
+    o.everDroppedForHeap_ = true;
+    return false;
+  }
+
+  // JLREQ 3.1.4 pair spacing: two adjacent punctuation halves close up.
+  void applyPunctPairSpacing(const uint32_t cp, const uint16_t columnArg) {
+    if (page.glyphs.empty()) return;
+    const VerticalGlyph& prev = page.glyphs.back();
+    if (prev.column != columnArg || prev.codepoint == 0) return;
+    const int prevHalf = punctEmHalf(prev.codepoint);
+    const int thisHalf = punctEmHalf(cp);
+    if (prevHalf == 0 || thisHalf == 0) return;
+
+    // Every pair in the figures closes up by a half em: 、「 and 」「 from a full em to a half
+    // (figures 3, 4); 。」, ）。, 「『, ）」 from a half em to solid (1, 2, 5, 6); 」・「 from three
+    // quarters to a quarter each side of the dot (7).
+    int reduction = geom.cellPx / 2;
+
+    // 。and 、 already end a half em after their own ink (commaTighten), so that half is gone:
+    // an opening bracket wants exactly it (figure 3), a closing bracket or another 。/、 is set
+    // solid (1, 2), a middle dot keeps a quarter.
+    if (Kinsoku::verticalShiftType(prev.codepoint) == 1) {
+      if (thisHalf == 2) return;
+      reduction = (thisHalf == 3) ? geom.cellPx / 4 : geom.cellPx / 2;
+    }
+    columnYShift += reduction;
+    shiftColumn = columnArg;
+  }
+
+  // Resolving one costs an ensureSdCardFontReady() -- a potential SD round-trip -- and a
+  // chapter hits this once per embedded word, number and ellipsis, often for the same few
+  // characters (は、。 dominate). A tiny direct-mapped cache keeps the repeat lookups off the
+  // card without holding a map. Deliberately small: this runs on the render task, and the
+  // project's stack budget for locals is 256 bytes total -- 16 entries is 96 bytes.
+  struct InkOffsetCacheEntry {
+    uint32_t key = 0;  // codepoint | style << 24; 0 = empty (never a real key, cp 0 is unused)
+    int16_t offset = 0;
+  };
+  static constexpr size_t INK_CACHE_SLOTS = 16;
+  InkOffsetCacheEntry inkOffsetCache[INK_CACHE_SLOTS];
+
+  // Where a rotated run may start in this column: on the grid unless the preceding glyph's
+  // ink actually reaches into the cell.
+  int rotatedRunStartY(const uint16_t columnArg, const int topYArg) const {
+    if (page.glyphs.empty()) return topYArg;
+    const VerticalGlyph& pg = page.glyphs.back();
+    if (pg.column != columnArg) return topYArg;
+    // Start on the grid; the only reason to push further is a predecessor whose ink actually
+    // reaches into this cell, which is measured below.
+    int startY = topYArg;
+    if (pg.renderKind == VerticalGlyph::RotatedPunct) {
+      // Brackets are placed from their cell box and hang roughly a full cell lower than that
+      // box (「 opens the character in the NEXT cell), so a run that only stepped one cell
+      // started inside the bracket's ink (device photo, 「Furz」).
+      int inkTop = 0, inkHeight = 0;
+      if (o.renderer_.verticalPunctInkBox(o.fontId_, pg.codepoint, static_cast<EpdFontFamily::Style>(pg.style),
+                                          static_cast<int>(pg.y), geom.cellPx, Kinsoku::verticalShiftType(pg.codepoint),
+                                          &inkTop, &inkHeight)) {
+        startY = std::max(startY, inkTop + inkHeight + geom.inkGapPx);
+      }
+    } else if (pg.renderKind == VerticalGlyph::Upright && pg.codepoint != 0) {
+      GlyphInk ink;
+      if (measureGlyphInk(o.renderer_, o.fontId_, pg.codepoint, pg.style, &ink) && ink.height > 0) {
+        // pg.y already carries this column's slide-up; startY is computed on the raw grid and
+        // gets the same slide applied at push time, so compare in raw space.
+        const int pgRawY = static_cast<int>(pg.y) + ((pg.column == shiftColumn) ? columnYShift : 0);
+        startY = std::max(startY, pgRawY + geom.baselineInCellPx - ink.top + ink.height);
+      }
+    }
+    return startY;
+  }
+
+  // How far into its cell the next glyph's ink starts, or -1 when there is no next glyph in
+  // this paragraph.
+  int nextGlyphInkOffset(const size_t nextIdx, const uint32_t paragraphIndex) {
+    if (nextIdx >= o.stream_.size() || o.stream_[nextIdx].paragraphIndex != paragraphIndex) return -1;
+    const auto& next = o.stream_[nextIdx];
+    const uint32_t key = (next.codepoint & 0x00FFFFFFu) | (static_cast<uint32_t>(next.style & 3) << 24);
+    auto& slot = inkOffsetCache[key % INK_CACHE_SLOTS];
+    if (slot.key == key) return slot.offset;
+
+    const auto nextStyle = static_cast<EpdFontFamily::Style>(next.style);
+    int offset = -1;
+    if (Kinsoku::needsVerticalRotation(next.codepoint)) {
+      int inkTop = 0, inkHeight = 0;
+      if (o.renderer_.verticalPunctInkBox(o.fontId_, next.codepoint, nextStyle, 0, geom.cellPx,
+                                          Kinsoku::verticalShiftType(next.codepoint), &inkTop, &inkHeight)) {
+        offset = inkTop;
+      }
+    } else {
+      // Metrics for a glyph the SD font has not paged in yet come back empty, which silently
+      // disabled the tail allowance; page the one character in first.
+      char nextChar[5] = {};
+      utf8EncodeCodepoint(next.codepoint, nextChar);
+      o.renderer_.ensureSdCardFontReady(o.fontId_, nextChar, static_cast<uint8_t>(1u << (next.style & 3)));
+      GlyphInk ink;
+      if (measureGlyphInk(o.renderer_, o.fontId_, next.codepoint, next.style, &ink) && ink.height > 0) {
+        offset = geom.baselineInCellPx - ink.top;
+      }
+    }
+    // A miss is worth caching too -- it is the expensive case, and a glyph the font lacks
+    // stays missing for the rest of the chapter.
+    slot = {key, static_cast<int16_t>(offset)};
+    return offset;
+  }
+
+  // Take up the cell-rounding leftover after a run: the rest of the column slides up by it, so
+  // the next character follows at normal spacing instead of after a partly empty cell.
+  void takeUpRunSlack(const int startY, const int inkWidthPx, const uint16_t rowAfter, const uint16_t columnArg,
+                      const int nextInkOffset) {
+    if (nextInkOffset < 0 || rowAfter >= geom.rowsPerColumn) return;
+    const int nextGridInkTop = rowAfter * geom.cellPx + nextInkOffset;
+    const int slack = nextGridInkTop - (startY + inkWidthPx) - geom.inkGapPx;
+    if (slack > 0) {
+      columnYShift += slack;
+      shiftColumn = columnArg;
+    }
+  }
+
+  // Close the page when the columns run out: emit it, and open a fresh one.
+  void finalizePageIfNeeded() {
+    if (column >= geom.columnsPerPage) {
+      // A box spanning the page boundary gets one rect per page: close it at this page's last
+      // column and continue from column 0 on the next page.
+      if (o.inBox_) {
+        o.appendBoxRectToPage(page, o.boxStartCol_, static_cast<uint16_t>(geom.columnsPerPage - 1),
+                              /*openLeft=*/true, /*openRight=*/o.boxContinuedFromPrevPage_);
+        if (o.activeBlock_.alignCenter) {
+          o.centerBlockColumns(page, o.boxStartCol_, static_cast<uint16_t>(geom.columnsPerPage - 1));
+        }
+        o.boxStartCol_ = 0;
+        o.boxContinuedFromPrevPage_ = true;
+      }
+      pages.push_back(std::move(page));
+      o.anyPageEverProduced_ = true;
+      // Stream out everything except the single most-recently-completed page: the oikomi
+      // pull-back check below only ever looks at pages.back() (the page immediately before the
+      // one currently being started), so once THIS page is pushed, any earlier page in `pages`
+      // can never be touched again and is safe to write out and free now.
+      if (onPageReady) {
+        while (pages.size() > 1) {
+          onPageReady(ctx, std::move(pages.front()));
+          pages.erase(pages.begin());
+        }
+      }
+      page = VerticalPage{};
+      page.columnCount = geom.columnsPerPage;
+      page.rowsPerColumn = geom.rowsPerColumn;
+      reservePageGlyphs(page);
+      column = 0;
+      row = 0;
+    }
+  }
+
+  // Place one upright character in a given cell, applying the JLREQ quadrant/half-em rules.
+  void placeUprightAt(const PendingChar& pc, uint16_t col, uint16_t rowIdx) {
+    applyPunctPairSpacing(pc.codepoint, col);
+    VerticalGlyph g;
+    g.codepoint = pc.codepoint;
+    g.column = col;
+    g.row = rowIdx;
+    g.paragraphIndex = pc.paragraphIndex;
+    g.byteOffset = pc.byteOffset;
+    g.style = pc.style;
+    g.emphasis = pc.emphasis;
+
+    if (Kinsoku::needsVerticalRotation(pc.codepoint)) {
+      // Bracket / dash / chōonpu: keep one-cell layout, but mark as rotated
+      // punctuation so the renderer can center it by glyph metrics and apply
+      // opening/closing bracket flow-direction bias.
+      g.x = static_cast<uint16_t>(geom.columnLeftX(col));
+      g.y = static_cast<uint16_t>(rowIdx * geom.cellPx);
+      g.renderKind = VerticalGlyph::RotatedPunct;
+      // JLREQ: an opening bracket at the LINE HEAD is set flush to it (tentsuki), the half em
+      // before it deleted. "Line head" is the first glyph of THIS column, not row 0 -- a styled
+      // block (CSS indent, hanging indent) opens its column further down, and dialogue paragraphs
+      // are typically indented. Checked before the push, when the bracket is not yet the last.
+      const bool atLineHead = page.glyphs.empty() || page.glyphs.back().column != col;
+      const bool flushOpeningBracket = atLineHead && Kinsoku::verticalShiftType(pc.codepoint) == 3;
+      if (flushOpeningBracket) g.lineHeadFlush = 1;
+      pushGlyph(page, g, pc.rubyText);
+      if (flushOpeningBracket) {
+        // The half em it no longer needs comes off the rest of the column.
+        columnYShift += geom.cellPx / 2;
+        shiftColumn = col;
+      }
+      return;
+    }
+
+    if (Kinsoku::isSmallKana(pc.codepoint)) {
+      // Small kana (っゃゅょ ィ ョ) sit upper-right, letter face against the TOP edge of the box.
+      int qx = 0, qy = 0;
+      if (quadrantTopRight(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
+                           /*centreInHalf=*/false, &qx, &qy)) {
+        g.x = static_cast<uint16_t>(qx);
+        g.y = static_cast<uint16_t>(qy);
+      } else {
+        g.x = static_cast<uint16_t>(geom.columnLeftX(col) + std::max(1, geom.cellPx / 8));
+        g.y = static_cast<uint16_t>(rowIdx * geom.cellPx);
+      }
+      g.renderKind = VerticalGlyph::Upright;
+      pushGlyph(page, g, pc.rubyText);
+      return;
+    }
+
+    int gx = geom.columnLeftX(col);
+    int gy = rowIdx * geom.cellPx;
+    if (pc.codepoint >= '0' && pc.codepoint <= '9') {
+      GlyphInk ink;
+      if (measureGlyphInk(o.renderer_, o.fontId_, pc.codepoint, pc.style, &ink)) {
+        gx = geom.columnLeftX(col) + (geom.cellPx - ink.width) / 2 - ink.left;
+      }
+    }
+    int commaTighten = 0;
+    if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
+      // Comma/period: bottom-left of the em -> upper-right of the cell.
+      int qx = 0, qy = 0, inkH = 0;
+      if (quadrantTopRight(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
+                           /*centreInHalf=*/true, &qx, &qy, &inkH)) {
+        gx = qx;
+        gy = qy;
+        // Not a whole square: the mark takes its own ink height plus a half em, then the next
+        // character follows. The remainder of the cell comes off the rest of the column.
+        commaTighten = std::max(0, geom.cellPx - (inkH + geom.cellPx / 2));
+      } else {
+        gx += geom.cellPx / 2;
+        gy = std::max(0, gy - geom.cellPx / 2);
+      }
+    }
+    g.x = static_cast<uint16_t>(gx);
+    g.y = static_cast<uint16_t>(gy);
+    g.renderKind = VerticalGlyph::Upright;
+    pushGlyph(page, g, pc.rubyText);
+    if (commaTighten > 0) {
+      columnYShift += commaTighten;
+      shiftColumn = col;
+    }
+  }
+
+  // Place a two-character tate-chu-yoko run (a 2-digit number, or a !?/!! pair) upright in one
+  // cell, ink-centred on the column, and advance row/column past it.
+  void placeTcyPairAt(size_t i0) {
+    std::string runUtf8;
+    utf8AppendCodepoint(o.stream_[i0].codepoint, runUtf8);
+    utf8AppendCodepoint(o.stream_[i0 + 1].codepoint, runUtf8);
+    // Measure with the pair's ACTUAL style -- rendered with g.style, and bold digits are
+    // wider, so an unstyled measurement mis-centers the pair in its cell.
+    const auto tcyStyle = static_cast<EpdFontFamily::Style>(o.stream_[i0].style);
+    const auto tcyStyleBit = static_cast<uint8_t>(1u << (o.stream_[i0].style & 3));
+    o.renderer_.ensureSdCardFontReady(o.fontId_, runUtf8.c_str(), tcyStyleBit);
+    const int runWidthPx = o.renderer_.getRenderAdvanceX(o.fontId_, runUtf8.c_str(), tcyStyle);
+
+    // Center the run on its INK box, not its advance width. drawText puts ink at
+    // pen + firstGlyph.left, and digit advances carry trailing whitespace, so advance-based
+    // centering sat the run visibly right of the column's kanji (device photo, 「築26年」).
+    // Mirrors the single-digit ink centering in placeUprightAt.
+    int runX = geom.columnLeftX(column) + std::max(0, (geom.cellPx - runWidthPx) / 2);
+    {
+      const uint32_t cpFirst = o.stream_[i0].codepoint;
+      const uint32_t cpLast = o.stream_[i0 + 1].codepoint;
+      int l1 = 0, w1 = 0, t1 = 0, h1 = 0, lN = 0, wN = 0, tN = 0, hN = 0;
+      if (o.renderer_.getGlyphMetrics(o.fontId_, cpFirst, tcyStyle, &l1, &w1, &t1, &h1) &&
+          o.renderer_.getGlyphMetrics(o.fontId_, cpLast, tcyStyle, &lN, &wN, &tN, &hN)) {
+        std::string lastUtf8;
+        utf8AppendCodepoint(cpLast, lastUtf8);
+        const int lastAdvance = o.renderer_.getRenderAdvanceX(o.fontId_, lastUtf8.c_str(), tcyStyle);
+        // Ink spans pen+l1 .. pen+(runWidthPx-lastAdvance)+lN+wN.
+        const int inkWidth = (runWidthPx - lastAdvance + lN + wN) - l1;
+        if (inkWidth > 0 && inkWidth <= geom.cellPx) {
+          // Align the pair's ink center with the ink center of the column's CJK glyphs rather
+          // than the geometric cell center: CJK glyphs carry uneven side bearings, so pure cell
+          // centering reads shifted next to them. The previous fixed nudge of
+          // -max(4, geom.cellPx/4) was tuned on one photo/font (Kyokasho, 「築26年」) and
+          // over-corrected elsewhere -- device photo: 「10年」 sat a quarter cell LEFT of the
+          // column in Mincho. Measure the 中 reference glyph's ink center at this size/style
+          // and use its delta from the cell center. A well-formed full-width glyph cannot be
+          // off-centre by more than its own side bearing, so that bounds the delta and a metrics
+          // outlier can't fling the pair off-axis.
+          // Falls back to plain ink centering when metrics are unavailable.
+          int cjkDelta = 0;
+          int kl = 0, kw = 0, kt = 0, kh = 0;
+          // String literal, no allocation -- this sits in the pagination path (review finding:
+          // the earlier runUtf8 + 中 concatenation allocated per pair).
+          o.renderer_.ensureSdCardFontReady(o.fontId_, "\xe4\xb8\xad", tcyStyleBit);
+          if (o.renderer_.getGlyphMetrics(o.fontId_, 0x4E2D /* 中 */, tcyStyle, &kl, &kw, &kt, &kh) && kw > 0) {
+            cjkDelta = (kl + kw / 2) - geom.cellPx / 2;
+            const int clampPx = std::max(1, (geom.cellPx - kw) / 2);
+            if (cjkDelta > clampPx) cjkDelta = clampPx;
+            if (cjkDelta < -clampPx) cjkDelta = -clampPx;
+          }
+          runX = geom.columnLeftX(column) + (geom.cellPx - inkWidth) / 2 - l1 + cjkDelta;
+        }
+      }
+    }
+
+    VerticalGlyph g;
+    g.codepoint = 0;
+    g.column = column;
+    g.row = row;
+    g.x = static_cast<uint16_t>(std::max(0, runX));
+    g.y = static_cast<uint16_t>(row * geom.cellPx);
+    g.paragraphIndex = o.stream_[i0].paragraphIndex;
+    g.byteOffset = o.stream_[i0].byteOffset;
+    g.style = o.stream_[i0].style;
+    g.renderKind = VerticalGlyph::UprightRun;
+    pushGlyph(page, g, runUtf8);
+
+    row++;
+    if (row >= geom.rowsPerColumn) {
+      column++;
+      row = 0;
+      finalizePageIfNeeded();
+      row = columnStartRow(false);
+    }
+  }
+
+  void placeUpright(const PendingChar& pc) { placeUprightAt(pc, column, row); }
+
+  uint16_t columnStartRow(const bool paragraphStart) const {
+    if (!o.inBox_) return 0;
+    const int startRows = static_cast<int>(o.activeBlock_.startEm + 0.5f);
+    const int hangRows = paragraphStart ? 0 : static_cast<int>(o.activeBlock_.hangEm + 0.5f);
+    return static_cast<uint16_t>(std::min<int>(geom.rowsPerColumn - 1, std::max(0, startRows + hangRows)));
+  }
+};
+
 std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCallback onPageReady, bool isFinalFlush) {
   std::vector<VerticalPage> pages;
   // A break recorded at exactly stream-end (a trailing '\n' in this batch's last run) can never
@@ -585,10 +1104,23 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // N columns occupy N*advance - gap, not N*advance: the last one needs no trailing 行間, so
   // dividing the width by the advance drops a column whenever the remainder is a cell or more.
   const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, (usableWidthPx + columnGapPx_) / columnAdvancePx));
-  // Whatever is still left over stays on the LEFT, where tategaki's margin belongs -- the text
-  // starts at the right edge. It must not be spread into the gaps: 行間 is set in quarter ems by
-  // the line-spacing setting (and by whether furigana needs room in it), so widening it here
-  // overrides the rule that chose it -- measurably, a 21px gap became 25px against a 29px em.
+  // The width that does not divide evenly into whole columns is left where it falls: on the LEFT,
+  // because tategaki starts at the right margin and marches leftwards. It must not be spread into
+  // the gaps -- 行間 is set in quarter ems by the line-spacing setting (and by whether furigana
+  // needs room in it), so widening it here overrides the rule that chose it; measurably, a 21px
+  // gap became 25px against a 29px em. Nor split between the margins: that pushes the first
+  // column off the right edge the text is supposed to start at.
+
+  // One bundle for the helpers that were lambdas purely to reach these values.
+  const ColumnGeometry geom{.cellPx = cellPx,
+                            .inkGapPx = inkGapPx,
+                            .baselineInCellPx = baselineInCellPx,
+                            .ascenderPx = ascender,
+                            .columnAdvancePx = columnAdvancePx,
+                            .usableWidthPx = usableWidthPx,
+                            .rowsPerColumn = rowsPerColumn,
+                            .columnsPerPage = columnsPerPage};
+  InkMemo inkMemo;
 
   // Index into paragraphBreaksBeforeIndex_ of the *next* paragraph start,
   // so we know when we've crossed into a new paragraph and should force a
@@ -645,32 +1177,6 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // process on failure under -fno-exceptions -- confirmed via a real device crash inside this
   // exact reserve, immediately after the *previous* page was pushed (which can itself burst
   // memory use during its own relocation). Check the request against free heap every time.
-  auto reservePageGlyphs = [&](VerticalPage& p) {
-    const size_t requestBytes = glyphsPerPage * sizeof(VerticalGlyph);
-    if (heapCanAfford(requestBytes, MIN_FREE_HEAP_FOR_RESERVE)) {
-      p.glyphs.reserve(glyphsPerPage);
-      return;
-    }
-    // Partial fallback: reserve the largest fitting fraction of the page instead of nothing.
-    // Starting from capacity 0 makes the vector double 1-2-4-...-256, and every doubling's
-    // grow-copy (old + new buffer coexisting) is a fresh chance to land on a heap dip -- on
-    // the X3's tighter heap that fired the emergency page split constantly, which the reader
-    // sees as pages breaking at random fill levels. This runs right after the previous page
-    // was flushed and freed (the heap's local best), so one medium block now prevents most of
-    // the risky growth steps later at the dips.
-    for (size_t fraction = 2; fraction <= 8; fraction *= 2) {
-      const size_t partial = glyphsPerPage / fraction;
-      if (partial < 32) break;
-      if (heapCanAfford(partial * sizeof(VerticalGlyph), MIN_FREE_HEAP_FOR_RESERVE)) {
-        p.glyphs.reserve(partial);
-        LOG_DBG("VPT", "Partial page glyphs reserve: %u/%u elements (maxAlloc=%u)", static_cast<unsigned>(partial),
-                static_cast<unsigned>(glyphsPerPage), ESP.getMaxAllocHeap());
-        return;
-      }
-    }
-    LOG_ERR("VPT", "Skipping page glyphs reserve (%u bytes doesn't fit, free=%u); growing incrementally",
-            static_cast<unsigned>(requestBytes), ESP.getMaxAllocHeap());
-  };
 
   // Skipping the reserve above is only safe if every individual push_back is ALSO guarded --
   // "grows incrementally" isn't automatically safe on a heap this tight, and a real device crash
@@ -704,36 +1210,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   int columnYShift = 0;
   uint16_t shiftColumn = UINT16_MAX;
 
-  auto pushGlyph = [this, &columnYShift, &shiftColumn](VerticalPage& pg, VerticalGlyph g,
-                                                       const std::string& text = std::string()) {
-    std::vector<VerticalGlyph>& glyphs = pg.glyphs;
-    // Intern before the push: on a dropped glyph the orphaned pool entry is a few wasted
-    // bytes, while interning after would need the glyph's index to patch -- not worth it.
-    if (!text.empty()) g.textId = pg.internText(text);
-    if (g.column != shiftColumn) {
-      columnYShift = 0;
-      shiftColumn = g.column;
-    } else if (columnYShift != 0) {
-      // Positive slides the column tail up (cell-rounding leftover after a run), negative
-      // slides it down (ink that leaves its own cell, e.g. the low ellipsis dot stack).
-      g.y = static_cast<uint16_t>(std::max(0, static_cast<int>(g.y) - columnYShift));
-    }
-    // Tiers, most protective first. The 4K tier: device evidence (450+ page chapter) showed
-    // maxAlloc dips bottoming at 14324 while the linear request sat at ~9216 -- the 8K margin
-    // missed by 12 bytes, dropped glyphs, and the stale mark re-indexed the chapter on every
-    // open. The 0 tier: at that point the margin protects only allocations that fail gracefully
-    // and retry (font advance tables, staging buffers, the next page's reserve), while a dropped
-    // glyph is a character permanently missing from the page.
-    static constexpr uint32_t MARGINS[] = {SMALL_ALLOC_MARGIN, 4 * 1024, 0};
-    constexpr size_t LINEAR_GROWTH_STEP = 16;  // elements; keeps a stalled page's retries cheap
-    if (growForOnePush(glyphs, MARGINS, LINEAR_GROWTH_STEP)) {
-      glyphs.push_back(g);
-      return true;
-    }
-    LOG_ERR("VPT", "Low heap (%u bytes); dropping glyph", ESP.getMaxAllocHeap());
-    everDroppedForHeap_ = true;
-    return false;
-  };
+  LayoutCursor cur{*this,       geom,         inkMemo,     pendingPage_,  pages, pendingColumn_,
+                   pendingRow_, columnYShift, shiftColumn, glyphsPerPage, ctx,   onPageReady};
 
   // First call ever (or first since the last isFinalFlush=true call): start a fresh page. A
   // resumed call (pendingPageValid_ already true) picks up exactly where the previous non-final
@@ -743,7 +1221,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     pendingPage_ = VerticalPage{};
     pendingPage_.columnCount = columnsPerPage;
     pendingPage_.rowsPerColumn = rowsPerColumn;
-    reservePageGlyphs(pendingPage_);
+    cur.reservePageGlyphs(pendingPage_);
     pendingColumn_ = 0;
     pendingRow_ = 0;
     pendingPageValid_ = true;
@@ -752,295 +1230,17 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   uint16_t& column = pendingColumn_;
   uint16_t& row = pendingRow_;
 
-  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - col * columnAdvancePx; };
-
-  // Row where a fresh column starts: 0 normally; inside a styled block, the block's start
-  // offset (start-Xem), plus the hanging indent (h-indent-Xem) when the column continues a
-  // wrapped paragraph line rather than beginning a new paragraph.
-  auto columnStartRow = [&](const bool paragraphStart) -> uint16_t {
-    if (!inBox_) return 0;
-    const int startRows = static_cast<int>(activeBlock_.startEm + 0.5f);
-    const int hangRows = paragraphStart ? 0 : static_cast<int>(activeBlock_.hangEm + 0.5f);
-    return static_cast<uint16_t>(std::min<int>(rowsPerColumn - 1, std::max(0, startRows + hangRows)));
-  };
-
-  auto finalizePageIfNeeded = [&]() {
-    if (column >= columnsPerPage) {
-      // A box spanning the page boundary gets one rect per page: close it at this page's last
-      // column and continue from column 0 on the next page.
-      if (inBox_) {
-        appendBoxRectToPage(page, boxStartCol_, static_cast<uint16_t>(columnsPerPage - 1),
-                            /*openLeft=*/true, /*openRight=*/boxContinuedFromPrevPage_);
-        if (activeBlock_.alignCenter) {
-          centerBlockColumns(page, boxStartCol_, static_cast<uint16_t>(columnsPerPage - 1));
-        }
-        boxStartCol_ = 0;
-        boxContinuedFromPrevPage_ = true;
-      }
-      pages.push_back(std::move(page));
-      anyPageEverProduced_ = true;
-      // Stream out everything except the single most-recently-completed page: the oikomi
-      // pull-back check below only ever looks at pages.back() (the page immediately before the
-      // one currently being started), so once THIS page is pushed, any earlier page in `pages`
-      // can never be touched again and is safe to write out and free now.
-      if (onPageReady) {
-        while (pages.size() > 1) {
-          onPageReady(ctx, std::move(pages.front()));
-          pages.erase(pages.begin());
-        }
-      }
-      page = VerticalPage{};
-      page.columnCount = columnsPerPage;
-      page.rowsPerColumn = rowsPerColumn;
-      reservePageGlyphs(page);
-      column = 0;
-      row = 0;
-    }
-  };
-
   // JLREQ 3.1.4, consecutive brackets / commas / full stops / middle dots. Each is a half-em
   // glyph occupying one half of its em, which is what decides the white between two neighbours:
   //
   //   first half (top, in vertical)  - closing brackets, 、。，．
   //   second half (bottom)           - opening brackets
   //   centre                         - middle dot ・
-  auto punctEmHalf = [](const uint32_t cp) -> int {  // 0 none, 1 first half, 2 second half, 3 centre
-    if (cp == 0x30FB || cp == 0x00B7) return 3;      // ・
-    switch (Kinsoku::verticalShiftType(cp)) {
-      case 1:
-        return 1;  // 、。，．
-      case 2:
-        return 1;  // closing brackets
-      case 3:
-        return 2;  // opening brackets
-      default:
-        return 0;
-    }
-  };
-  auto applyPunctPairSpacing = [&](const uint32_t cp, const uint16_t columnArg) {
-    if (page.glyphs.empty()) return;
-    const VerticalGlyph& prev = page.glyphs.back();
-    if (prev.column != columnArg || prev.codepoint == 0) return;
-    const int prevHalf = punctEmHalf(prev.codepoint);
-    const int thisHalf = punctEmHalf(cp);
-    if (prevHalf == 0 || thisHalf == 0) return;
 
-    // Every pair in the figures closes up by a half em: 、「 and 」「 from a full em to a half
-    // (figures 3, 4); 。」, ）。, 「『, ）」 from a half em to solid (1, 2, 5, 6); 」・「 from three
-    // quarters to a quarter each side of the dot (7).
-    int reduction = cellPx / 2;
-
-    // 。and 、 already end a half em after their own ink (commaTighten), so that half is gone:
-    // an opening bracket wants exactly it (figure 3), a closing bracket or another 。/、 is set
-    // solid (1, 2), a middle dot keeps a quarter.
-    if (Kinsoku::verticalShiftType(prev.codepoint) == 1) {
-      if (thisHalf == 2) return;
-      reduction = (thisHalf == 3) ? cellPx / 4 : cellPx / 2;
-    }
-    columnYShift += reduction;
-    shiftColumn = columnArg;
-  };
-
-  InkMemo inkMemo;
-
-  // Upper-RIGHT quadrant placement, from the glyph's own ink box: these marks are drawn with
-  // their ink at the bottom-left of the em, so how far it must travel is font-specific. Returns
-  // false when metrics are unavailable.
-  //
-  // centreInHalf distinguishes the two users:
-  //   。、        - half-width advance, so the ink is centred in a half-em box at the cell's head
-  //   small kana - letter face against the top edge of its box
-  auto quadrantTopRight = [&](const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
-                              const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) -> bool {
-    // Only 。、 and the small kana reach here -- about fifteen codepoints per style for a whole
-    // chapter, each otherwise re-probed for every occurrence. A probe pages the glyph in from the
-    // SD font and evicts another from its small on-demand table, so the repeat cost is SD reads,
-    // not arithmetic.
-    GlyphInk ink;
-    if (!inkMemo.lookup(cp, style, &ink)) {
-      if (!measureGlyphInk(renderer_, fontId_, cp, style, &ink)) return false;
-      inkMemo.store(cp, style, ink);
-    }
-    if (ink.width <= 0 || ink.height <= 0) return false;
-    // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
-    const int inkTopInCell = centreInHalf ? std::max(0, (cellPx / 2 - ink.height) / 2) : 0;
-    *gxOut = columnLeftX(col) + cellPx - ink.left - ink.width;
-    *gyOut = std::max(0, rowIdx * cellPx + inkTopInCell + ink.top - baselineInCellPx);
-    if (inkHeightOut) *inkHeightOut = inkTopInCell + ink.height;
-    return true;
-  };
-
-  auto placeUprightAt = [&](const PendingChar& pc, uint16_t col, uint16_t rowIdx) {
-    applyPunctPairSpacing(pc.codepoint, col);
-    VerticalGlyph g;
-    g.codepoint = pc.codepoint;
-    g.column = col;
-    g.row = rowIdx;
-    g.paragraphIndex = pc.paragraphIndex;
-    g.byteOffset = pc.byteOffset;
-    g.style = pc.style;
-    g.emphasis = pc.emphasis;
-
-    if (Kinsoku::needsVerticalRotation(pc.codepoint)) {
-      // Bracket / dash / chōonpu: keep one-cell layout, but mark as rotated
-      // punctuation so the renderer can center it by glyph metrics and apply
-      // opening/closing bracket flow-direction bias.
-      g.x = static_cast<uint16_t>(columnLeftX(col));
-      g.y = static_cast<uint16_t>(rowIdx * cellPx);
-      g.renderKind = VerticalGlyph::RotatedPunct;
-      // JLREQ: an opening bracket at the LINE HEAD is set flush to it (tentsuki), the half em
-      // before it deleted. "Line head" is the first glyph of THIS column, not row 0 -- a styled
-      // block (CSS indent, hanging indent) opens its column further down, and dialogue paragraphs
-      // are typically indented. Checked before the push, when the bracket is not yet the last.
-      const bool atLineHead = page.glyphs.empty() || page.glyphs.back().column != col;
-      const bool flushOpeningBracket = atLineHead && Kinsoku::verticalShiftType(pc.codepoint) == 3;
-      if (flushOpeningBracket) g.lineHeadFlush = 1;
-      pushGlyph(page, g, pc.rubyText);
-      if (flushOpeningBracket) {
-        // The half em it no longer needs comes off the rest of the column.
-        columnYShift += cellPx / 2;
-        shiftColumn = col;
-      }
-      return;
-    }
-
-    if (Kinsoku::isSmallKana(pc.codepoint)) {
-      // Small kana (っゃゅょ ィ ョ) sit upper-right, letter face against the TOP edge of the box.
-      int qx = 0, qy = 0;
-      if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/false, &qx, &qy)) {
-        g.x = static_cast<uint16_t>(qx);
-        g.y = static_cast<uint16_t>(qy);
-      } else {
-        g.x = static_cast<uint16_t>(columnLeftX(col) + std::max(1, cellPx / 8));
-        g.y = static_cast<uint16_t>(rowIdx * cellPx);
-      }
-      g.renderKind = VerticalGlyph::Upright;
-      pushGlyph(page, g, pc.rubyText);
-      return;
-    }
-
-    int gx = columnLeftX(col);
-    int gy = rowIdx * cellPx;
-    if (pc.codepoint >= '0' && pc.codepoint <= '9') {
-      GlyphInk ink;
-      if (measureGlyphInk(renderer_, fontId_, pc.codepoint, pc.style, &ink)) {
-        gx = columnLeftX(col) + (cellPx - ink.width) / 2 - ink.left;
-      }
-    }
-    int commaTighten = 0;
-    if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
-      // Comma/period: bottom-left of the em -> upper-right of the cell.
-      int qx = 0, qy = 0, inkH = 0;
-      if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/true, &qx, &qy, &inkH)) {
-        gx = qx;
-        gy = qy;
-        // Not a whole square: the mark takes its own ink height plus a half em, then the next
-        // character follows. The remainder of the cell comes off the rest of the column.
-        commaTighten = std::max(0, cellPx - (inkH + cellPx / 2));
-      } else {
-        gx += cellPx / 2;
-        gy = std::max(0, gy - cellPx / 2);
-      }
-    }
-    g.x = static_cast<uint16_t>(gx);
-    g.y = static_cast<uint16_t>(gy);
-    g.renderKind = VerticalGlyph::Upright;
-    pushGlyph(page, g, pc.rubyText);
-    if (commaTighten > 0) {
-      columnYShift += commaTighten;
-      shiftColumn = col;
-    }
-  };
-
-  auto placeUpright = [&](const PendingChar& pc) { placeUprightAt(pc, column, row); };
-  auto isAsciiDigit = [](uint32_t cp) {
-    return (cp >= '0' && cp <= '9') ||      // ASCII digits: U+0030-U+0039
-           (cp >= 0xFF10 && cp <= 0xFF19);  // Fullwidth digits: U+FF10-U+FF19
-  };
-  auto isAsciiAlnum = [](uint32_t cp) {
-    return (cp >= '0' && cp <= '9') || (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');
-  };
-  // Exclamation/question marks that books put in tate-chu-yoko pairs (!? / !!).
-  // Halfwidth only: fullwidth ！？ already render upright as normal CJK cells.
-  auto isBangOrQuestion = [](uint32_t cp) { return cp == '!' || cp == '?'; };
   // Place a two-character tate-chu-yoko run (a 2-digit number like 26, or a
   // !?/!! pair) upright in a single cell, ink-centered on the column, and
   // advance row/column past it. Shared by the digit and punctuation-pair
   // branches in the loop below.
-  auto placeTcyPairAt = [&](size_t i0) {
-    std::string runUtf8;
-    utf8AppendCodepoint(stream_[i0].codepoint, runUtf8);
-    utf8AppendCodepoint(stream_[i0 + 1].codepoint, runUtf8);
-    // Measure with the pair's ACTUAL style -- rendered with g.style, and bold digits are
-    // wider, so an unstyled measurement mis-centers the pair in its cell.
-    const auto tcyStyle = static_cast<EpdFontFamily::Style>(stream_[i0].style);
-    const auto tcyStyleBit = static_cast<uint8_t>(1u << (stream_[i0].style & 3));
-    renderer_.ensureSdCardFontReady(fontId_, runUtf8.c_str(), tcyStyleBit);
-    const int runWidthPx = renderer_.getRenderAdvanceX(fontId_, runUtf8.c_str(), tcyStyle);
-
-    // Center the run on its INK box, not its advance width. drawText puts ink at
-    // pen + firstGlyph.left, and digit advances carry trailing whitespace, so advance-based
-    // centering sat the run visibly right of the column's kanji (device photo, 「築26年」).
-    // Mirrors the single-digit ink centering in placeUprightAt.
-    int runX = columnLeftX(column) + std::max(0, (cellPx - runWidthPx) / 2);
-    {
-      const uint32_t cpFirst = stream_[i0].codepoint;
-      const uint32_t cpLast = stream_[i0 + 1].codepoint;
-      int l1 = 0, w1 = 0, t1 = 0, h1 = 0, lN = 0, wN = 0, tN = 0, hN = 0;
-      if (renderer_.getGlyphMetrics(fontId_, cpFirst, tcyStyle, &l1, &w1, &t1, &h1) &&
-          renderer_.getGlyphMetrics(fontId_, cpLast, tcyStyle, &lN, &wN, &tN, &hN)) {
-        std::string lastUtf8;
-        utf8AppendCodepoint(cpLast, lastUtf8);
-        const int lastAdvance = renderer_.getRenderAdvanceX(fontId_, lastUtf8.c_str(), tcyStyle);
-        // Ink spans pen+l1 .. pen+(runWidthPx-lastAdvance)+lN+wN.
-        const int inkWidth = (runWidthPx - lastAdvance + lN + wN) - l1;
-        if (inkWidth > 0 && inkWidth <= cellPx) {
-          // Align the pair's ink center with the ink center of the column's CJK glyphs rather
-          // than the geometric cell center: CJK glyphs carry uneven side bearings, so pure cell
-          // centering reads shifted next to them. The previous fixed nudge of
-          // -max(4, cellPx/4) was tuned on one photo/font (Kyokasho, 「築26年」) and
-          // over-corrected elsewhere -- device photo: 「10年」 sat a quarter cell LEFT of the
-          // column in Mincho. Measure the 中 reference glyph's ink center at this size/style
-          // and use its delta from the cell center. A well-formed full-width glyph cannot be
-          // off-centre by more than its own side bearing, so that bounds the delta and a metrics
-          // outlier can't fling the pair off-axis.
-          // Falls back to plain ink centering when metrics are unavailable.
-          int cjkDelta = 0;
-          int kl = 0, kw = 0, kt = 0, kh = 0;
-          // String literal, no allocation -- this sits in the pagination path (review finding:
-          // the earlier runUtf8 + 中 concatenation allocated per pair).
-          renderer_.ensureSdCardFontReady(fontId_, "\xe4\xb8\xad", tcyStyleBit);
-          if (renderer_.getGlyphMetrics(fontId_, 0x4E2D /* 中 */, tcyStyle, &kl, &kw, &kt, &kh) && kw > 0) {
-            cjkDelta = (kl + kw / 2) - cellPx / 2;
-            const int clampPx = std::max(1, (cellPx - kw) / 2);
-            if (cjkDelta > clampPx) cjkDelta = clampPx;
-            if (cjkDelta < -clampPx) cjkDelta = -clampPx;
-          }
-          runX = columnLeftX(column) + (cellPx - inkWidth) / 2 - l1 + cjkDelta;
-        }
-      }
-    }
-
-    VerticalGlyph g;
-    g.codepoint = 0;
-    g.column = column;
-    g.row = row;
-    g.x = static_cast<uint16_t>(std::max(0, runX));
-    g.y = static_cast<uint16_t>(row * cellPx);
-    g.paragraphIndex = stream_[i0].paragraphIndex;
-    g.byteOffset = stream_[i0].byteOffset;
-    g.style = stream_[i0].style;
-    g.renderKind = VerticalGlyph::UprightRun;
-    pushGlyph(page, g, runUtf8);
-
-    row++;
-    if (row >= rowsPerColumn) {
-      column++;
-      row = 0;
-      finalizePageIfNeeded();
-      row = columnStartRow(false);
-    }
-  };
 
   // Whether the current page's glyph vector can take one more PendingChar's worth of glyphs
   // without an impossible copy-and-grow (old and new buffer must coexist during a vector
@@ -1051,12 +1251,6 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // early break fires only when the very next growth attempt would otherwise start
   // dropping -- not sooner. A bigger headroom here inflated the page count with premature
   // breaks (device evidence: breaks at 81-148 glyphs against dips the +16 step survived).
-  auto pageVectorCanTakeMore = [&]() -> bool {
-    constexpr size_t GROWTH_STEP = 16;  // = pushGlyph's LINEAR_GROWTH_STEP
-    if (page.glyphs.size() + GROWTH_STEP <= page.glyphs.capacity()) return true;
-    const size_t growBytes = (page.glyphs.capacity() + GROWTH_STEP) * sizeof(VerticalGlyph);
-    return ESP.getMaxAllocHeap() >= growBytes;
-  };
 
   // Shared placement geometry for every sideways run -- embedded Latin words AND multi-digit
   // numbers. drawText() takes the em-box TOP, so an upright glyph's ink starts (ascender -
@@ -1065,122 +1259,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   //
   // Where the run's ink may start: just under the previous glyph's measured ink, or flush with
   // the cell top when nothing precedes it in this column.
-  auto rotatedRunStartY = [&](const uint16_t columnArg, const int topYArg) -> int {
-    if (page.glyphs.empty()) return topYArg;
-    const VerticalGlyph& pg = page.glyphs.back();
-    if (pg.column != columnArg) return topYArg;
-    // Start on the grid; the only reason to push further is a predecessor whose ink actually
-    // reaches into this cell, which is measured below.
-    int startY = topYArg;
-    if (pg.renderKind == VerticalGlyph::RotatedPunct) {
-      // Brackets are placed from their cell box and hang roughly a full cell lower than that
-      // box (「 opens the character in the NEXT cell), so a run that only stepped one cell
-      // started inside the bracket's ink (device photo, 「Furz」).
-      int inkTop = 0, inkHeight = 0;
-      if (renderer_.verticalPunctInkBox(fontId_, pg.codepoint, static_cast<EpdFontFamily::Style>(pg.style),
-                                        static_cast<int>(pg.y), cellPx, Kinsoku::verticalShiftType(pg.codepoint),
-                                        &inkTop, &inkHeight)) {
-        startY = std::max(startY, inkTop + inkHeight + inkGapPx);
-      }
-    } else if (pg.renderKind == VerticalGlyph::Upright && pg.codepoint != 0) {
-      GlyphInk ink;
-      if (measureGlyphInk(renderer_, fontId_, pg.codepoint, pg.style, &ink) && ink.height > 0) {
-        // pg.y already carries this column's slide-up; startY is computed on the raw grid and
-        // gets the same slide applied at push time, so compare in raw space.
-        const int pgRawY = static_cast<int>(pg.y) + ((pg.column == shiftColumn) ? columnYShift : 0);
-        startY = std::max(startY, pgRawY + baselineInCellPx - ink.top + ink.height);
-      }
-    }
-    return startY;
-  };
 
   // How far the character AFTER the run may be intruded upon: its ink only starts that far
   // below its own cell top. Reports the ink offset inside the cell, or -1 when unknown.
   //
-  // Resolving one costs an ensureSdCardFontReady() -- a potential SD round-trip -- and a
-  // chapter hits this once per embedded word, number and ellipsis, often for the same few
-  // characters (は、。 dominate). A tiny direct-mapped cache keeps the repeat lookups off the
-  // card without holding a map. Deliberately small: this runs on the render task, and the
-  // project's stack budget for locals is 256 bytes total -- 16 entries is 96 bytes.
-  struct InkOffsetCacheEntry {
-    uint32_t key = 0;  // codepoint | style << 24; 0 = empty (never a real key, cp 0 is unused)
-    int16_t offset = 0;
-  };
-  static constexpr size_t INK_CACHE_SLOTS = 16;
-  InkOffsetCacheEntry inkOffsetCache[INK_CACHE_SLOTS];
-
-  auto nextGlyphInkOffset = [&](const size_t nextIdx, const uint32_t paragraphIndex) -> int {
-    if (nextIdx >= stream_.size() || stream_[nextIdx].paragraphIndex != paragraphIndex) return -1;
-    const auto& next = stream_[nextIdx];
-    const uint32_t key = (next.codepoint & 0x00FFFFFFu) | (static_cast<uint32_t>(next.style & 3) << 24);
-    auto& slot = inkOffsetCache[key % INK_CACHE_SLOTS];
-    if (slot.key == key) return slot.offset;
-
-    const auto nextStyle = static_cast<EpdFontFamily::Style>(next.style);
-    int offset = -1;
-    if (Kinsoku::needsVerticalRotation(next.codepoint)) {
-      int inkTop = 0, inkHeight = 0;
-      if (renderer_.verticalPunctInkBox(fontId_, next.codepoint, nextStyle, 0, cellPx,
-                                        Kinsoku::verticalShiftType(next.codepoint), &inkTop, &inkHeight)) {
-        offset = inkTop;
-      }
-    } else {
-      // Metrics for a glyph the SD font has not paged in yet come back empty, which silently
-      // disabled the tail allowance; page the one character in first.
-      char nextChar[5] = {};
-      utf8EncodeCodepoint(next.codepoint, nextChar);
-      renderer_.ensureSdCardFontReady(fontId_, nextChar, static_cast<uint8_t>(1u << (next.style & 3)));
-      GlyphInk ink;
-      if (measureGlyphInk(renderer_, fontId_, next.codepoint, next.style, &ink) && ink.height > 0) {
-        offset = baselineInCellPx - ink.top;
-      }
-    }
-    // A miss is worth caching too -- it is the expensive case, and a glyph the font lacks
-    // stays missing for the rest of the chapter.
-    slot = {key, static_cast<int16_t>(offset)};
-    return offset;
-  };
-
-  // Rows the run occupies: enough that the next character's ink clears the run's, no more.
-  auto rotatedRunRows = [&](const int startY, const int inkWidthPx, const uint16_t rowArg,
-                            const int nextInkOffset) -> uint16_t {
-    const int intrusion = (nextInkOffset >= 0) ? nextInkOffset : 0;
-    const int endRow = static_cast<int>(std::ceil(static_cast<double>(startY + inkWidthPx - intrusion) / cellPx));
-    return static_cast<uint16_t>(std::max(1, endRow - static_cast<int>(rowArg)));
-  };
-
-  // getRenderAdvanceX ends at the pen, not at the ink: the last glyph's right side bearing is
-  // blank. Counting it made every run reserve up to a whole extra cell.
-  auto runInkWidth = [&](const std::string& s, const int advanceWidth, const EpdFontFamily::Style style) -> int {
-    if (s.empty()) return advanceWidth;
-    size_t lastStart = s.size() - 1;
-    while (lastStart > 0 && (static_cast<unsigned char>(s[lastStart]) & 0xC0) == 0x80) lastStart--;
-    const std::string lastChar = s.substr(lastStart);
-    const auto c0 = static_cast<unsigned char>(lastChar[0]);
-    uint32_t lastCp = c0;
-    if (c0 >= 0xC0 && lastChar.size() >= 2) {
-      lastCp = static_cast<uint32_t>(c0 & 0x1F) << 6 | (static_cast<unsigned char>(lastChar[1]) & 0x3F);
-    }
-    GlyphInk ink;
-    if (!measureGlyphInk(renderer_, fontId_, lastCp, static_cast<uint8_t>(style), &ink) || ink.width <= 0) {
-      return advanceWidth;
-    }
-    const int lastAdvance = renderer_.getRenderAdvanceX(fontId_, lastChar.c_str(), style);
-    return advanceWidth - std::max(0, lastAdvance - (ink.left + ink.width));
-  };
 
   // Take up the cell-rounding leftover after a run: the rest of the column slides up by it, so
   // the next character follows at normal spacing instead of after a partly empty cell.
-  auto takeUpRunSlack = [&](const int startY, const int inkWidthPx, const uint16_t rowAfter, const uint16_t columnArg,
-                            const int nextInkOffset) {
-    if (nextInkOffset < 0 || rowAfter >= rowsPerColumn) return;
-    const int nextGridInkTop = rowAfter * cellPx + nextInkOffset;
-    const int slack = nextGridInkTop - (startY + inkWidthPx) - inkGapPx;
-    if (slack > 0) {
-      columnYShift += slack;
-      shiftColumn = columnArg;
-    }
-  };
 
   size_t idx = 0;
   size_t suppressKinsokuUntilIdx = 0;  // watchdog escape hatch: place plainly up to here
@@ -1206,13 +1291,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     // fresh one (whose vector starts small and grows in fragment-sized steps) -- an early
     // page break the reader barely notices, instead of the silent character loss that
     // followed once pushGlyph's growth ladder was exhausted mid-page.
-    if (column < columnsPerPage && !page.glyphs.empty() && !pageVectorCanTakeMore()) {
+    if (column < columnsPerPage && !page.glyphs.empty() && !cur.pageVectorCanTakeMore()) {
       LOG_INF("VPT", "Page glyph buffer cannot grow (%u glyphs, maxAlloc=%u); early page break",
               static_cast<unsigned>(page.glyphs.size()), ESP.getMaxAllocHeap());
       everSplitForHeap_ = true;
       column = columnsPerPage;
-      finalizePageIfNeeded();
-      row = columnStartRow(false);
+      cur.finalizePageIfNeeded();
+      row = cur.columnStartRow(false);
     }
 
     const PendingChar& pc = stream_[idx];
@@ -1240,13 +1325,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         if (row != 0) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
+          cur.finalizePageIfNeeded();
         }
         // m-after-Xem approximation: one blank column of extra separation.
         if (wantAfterGap && column != 0) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
+          cur.finalizePageIfNeeded();
         }
       }
       nextBoxEndIdx++;
@@ -1259,9 +1344,9 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       if (row != 0 || column == 0) {
         column++;
         row = 0;
-        finalizePageIfNeeded();
+        cur.finalizePageIfNeeded();
       }
-      row = columnStartRow(true);
+      row = cur.columnStartRow(true);
       nextParagraphBreakIdx++;
     }
 
@@ -1280,18 +1365,18 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         if (row != 0) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
+          cur.finalizePageIfNeeded();
         }
         // m-before-Xem approximation: one blank column of extra separation.
         if (params.beforeEm >= 0.75f && column != 0) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
+          cur.finalizePageIfNeeded();
         }
         activeBlock_ = params;
         inBox_ = true;
         boxStartCol_ = column;
-        row = columnStartRow(true);
+        row = cur.columnStartRow(true);
         LOG_DBG("VPT", "block active at col=%u row=%u start=%.1f hang=%.1f edges=0x%X", column, row,
                 activeBlock_.startEm, activeBlock_.hangEm, activeBlock_.borderEdges);
       }
@@ -1315,7 +1400,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       }
       const bool nextAlnum = markEnd < stream_.size() && isAsciiAlnum(stream_[markEnd].codepoint);
       if (markEnd - idx == 2 && !prevAlnum && !nextAlnum) {
-        placeTcyPairAt(idx);
+        cur.placeTcyPairAt(idx);
         idx = markEnd;
         continue;
       }
@@ -1330,7 +1415,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       const size_t digitCount = digitEnd - idx;
 
       if (digitCount == 2) {
-        placeTcyPairAt(idx);
+        cur.placeTcyPairAt(idx);
         idx = digitEnd;
         continue;
       }
@@ -1352,53 +1437,53 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // real ink, reserve only what the digits' ink needs. The old fixed 9/10-cell drop was
         // a blunt guard against 4-digit years overprinting the following character (1914年)
         // and left most of a cell empty behind the number (device photo, SCP－1305 だ。).
-        const int digitInkWidth = runInkWidth(runUtf8, runWidthPx, runStyle);
-        const int nextInkOffset = nextGlyphInkOffset(digitEnd, pc.paragraphIndex);
-        int startY = rotatedRunStartY(column, row * cellPx);
-        uint16_t rowsNeeded = rotatedRunRows(startY, digitInkWidth, row, nextInkOffset);
+        const int digitInkWidth = runInkWidth(renderer_, fontId_, runUtf8, runWidthPx, runStyle);
+        const int nextInkOffset = cur.nextGlyphInkOffset(digitEnd, pc.paragraphIndex);
+        int startY = cur.rotatedRunStartY(column, row * cellPx);
+        uint16_t rowsNeeded = rotatedRunRows(cellPx, startY, digitInkWidth, row, nextInkOffset);
 
         if (row != 0 && row + rowsNeeded > rowsPerColumn) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
-          row = columnStartRow(false);
-          startY = rotatedRunStartY(column, row * cellPx);
-          rowsNeeded = rotatedRunRows(startY, digitInkWidth, row, nextInkOffset);
+          cur.finalizePageIfNeeded();
+          row = cur.columnStartRow(false);
+          startY = cur.rotatedRunStartY(column, row * cellPx);
+          rowsNeeded = rotatedRunRows(cellPx, startY, digitInkWidth, row, nextInkOffset);
         }
 
         VerticalGlyph g;
         g.codepoint = 0;
         g.column = column;
         g.row = row;
-        g.x = static_cast<uint16_t>(columnLeftX(column) + cellPx - ascender);
+        g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
         g.y = static_cast<uint16_t>(startY);
         g.paragraphIndex = pc.paragraphIndex;
         g.byteOffset = pc.byteOffset;
         g.style = pc.style;
         g.renderKind = VerticalGlyph::RotatedRun;
-        pushGlyph(page, g, runUtf8);
+        cur.pushGlyph(page, g, runUtf8);
 
         const uint16_t digitColumn = column;
         row = static_cast<uint16_t>(row + rowsNeeded);
-        takeUpRunSlack(startY, digitInkWidth, row, digitColumn, nextInkOffset);
+        cur.takeUpRunSlack(startY, digitInkWidth, row, digitColumn, nextInkOffset);
         if (row >= rowsPerColumn) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
-          row = columnStartRow(false);
+          cur.finalizePageIfNeeded();
+          row = cur.columnStartRow(false);
         }
         idx = digitEnd;
         continue;
       }
 
       // Single digit (digitCount == 1): place centered upright
-      placeUprightAt(pc, column, row);
+      cur.placeUprightAt(pc, column, row);
       row++;
       if (row >= rowsPerColumn) {
         column++;
         row = 0;
-        finalizePageIfNeeded();
-        row = columnStartRow(false);
+        cur.finalizePageIfNeeded();
+        row = cur.columnStartRow(false);
       }
       idx++;
       continue;
@@ -1429,16 +1514,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // dead cell after it (device photo, Vita Sexualis). The measured start position plus
       // the cell raster already provide the visual separation, so trim boundary spaces and
       // keep only the inner ones (word gaps and break points).
-      const auto trimSpaces = [](std::string& s) {
-        const size_t b = s.find_first_not_of(' ');
-        if (b == std::string::npos) {
-          s.clear();
-          return;
-        }
-        const size_t e = s.find_last_not_of(' ');
-        s.assign(s, b, e - b + 1);
-      };
-      const int nextInkOffset = nextGlyphInkOffset(runEnd, pc.paragraphIndex);
+      const int nextInkOffset = cur.nextGlyphInkOffset(runEnd, pc.paragraphIndex);
       std::string remaining = runUtf8;
       const bool hadLeadingSpace = !runUtf8.empty() && runUtf8[0] == ' ';
       trimSpaces(remaining);
@@ -1450,21 +1526,21 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // tategaki: give it a full empty cell so the word starts one character below the
       // preceding glyph instead of sharing its cell (device photo: S printed onto the と).
       // Skipped at a fresh column start -- line-leading spaces collapse, as in kinsoku.
-      if (hadLeadingSpace && row > columnStartRow(false)) {
+      if (hadLeadingSpace && row > cur.columnStartRow(false)) {
         row++;
         if (row >= rowsPerColumn) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
-          row = columnStartRow(false);
+          cur.finalizePageIfNeeded();
+          row = cur.columnStartRow(false);
         }
       }
 
       while (!remaining.empty()) {
         const int remWidthPx = renderer_.getRenderAdvanceX(fontId_, remaining.c_str(), runStyle);
-        const int startY = rotatedRunStartY(column, row * cellPx);
-        const uint16_t remRows =
-            rotatedRunRows(startY, runInkWidth(remaining, remWidthPx, runStyle), row, nextInkOffset);
+        const int startY = cur.rotatedRunStartY(column, row * cellPx);
+        const uint16_t remRows = rotatedRunRows(
+            cellPx, startY, runInkWidth(renderer_, fontId_, remaining, remWidthPx, runStyle), row, nextInkOffset);
         const uint16_t availRows = rowsPerColumn - row;
 
         if (remRows <= availRows) {
@@ -1473,20 +1549,21 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.codepoint = 0;
           g.column = column;
           g.row = row;
-          g.x = static_cast<uint16_t>(columnLeftX(column) + cellPx - ascender);
+          g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
           g.y = static_cast<uint16_t>(startY);
           g.paragraphIndex = pc.paragraphIndex;
           g.byteOffset = pc.byteOffset;
           g.style = pc.style;
           g.renderKind = VerticalGlyph::RotatedRun;
-          pushGlyph(page, g, remaining);
+          cur.pushGlyph(page, g, remaining);
           row = static_cast<uint16_t>(row + remRows);
-          takeUpRunSlack(startY, runInkWidth(remaining, remWidthPx, runStyle), row, g.column, nextInkOffset);
+          cur.takeUpRunSlack(startY, runInkWidth(renderer_, fontId_, remaining, remWidthPx, runStyle), row, g.column,
+                             nextInkOffset);
           if (row >= rowsPerColumn) {
             column++;
             row = 0;
-            finalizePageIfNeeded();
-            row = columnStartRow(false);
+            cur.finalizePageIfNeeded();
+            row = cur.columnStartRow(false);
           }
           break;
         }
@@ -1498,8 +1575,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
              sp = (sp == 0) ? std::string::npos : remaining.rfind(' ', sp - 1)) {
           std::string prefix = remaining.substr(0, sp);
           const int prefixPx = renderer_.getRenderAdvanceX(fontId_, prefix.c_str(), runStyle);
-          const uint16_t prefixRows =
-              rotatedRunRows(startY, runInkWidth(prefix, prefixPx, runStyle), row, nextInkOffset);
+          const uint16_t prefixRows = rotatedRunRows(
+              cellPx, startY, runInkWidth(renderer_, fontId_, prefix, prefixPx, runStyle), row, nextInkOffset);
           if (prefixRows <= availRows) {
             breakAt = sp;
             break;
@@ -1509,19 +1586,19 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         if (breakAt == std::string::npos) {
           // No space-break fits. Retry from a fresh column ONLY when the current position is
           // deeper than where a fresh column would start; otherwise force-place. The comparison
-          // MUST be against columnStartRow(false), not 0: inside a styled block (start-Xem, e.g.
+          // MUST be against cur.columnStartRow(false), not 0: inside a styled block (start-Xem, e.g.
           // Aozora/EBPAJ div.mtN margins, defined up to 22em+) fresh columns begin at a non-zero
           // row, and comparing against 0 made this branch loop forever -- every retry re-seeded
           // row = startRows != 0, the force-place arm below was unreachable, and the layout
           // marched through columns/pages without consuming a single byte ("Indexing" never
           // finished; host-reproduced with a mtN block whose start offset left fewer rows than a
-          // short embedded Latin word needs). After one retry row == columnStartRow(false), so
+          // short embedded Latin word needs). After one retry row == cur.columnStartRow(false), so
           // the force-place arm is guaranteed on the next pass -- termination is structural.
-          if (row > columnStartRow(false)) {
+          if (row > cur.columnStartRow(false)) {
             column++;
             row = 0;
-            finalizePageIfNeeded();
-            row = columnStartRow(false);
+            cur.finalizePageIfNeeded();
+            row = cur.columnStartRow(false);
           } else {
             // At (or above) a fresh column's start row and still doesn't fit — force-place the
             // whole thing at the CURRENT row to guarantee progress. It may overrun the column
@@ -1530,19 +1607,19 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
             g.codepoint = 0;
             g.column = column;
             g.row = row;
-            g.x = static_cast<uint16_t>(columnLeftX(column) + cellPx - ascender);
+            g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
             g.y = static_cast<uint16_t>(startY);
             g.paragraphIndex = pc.paragraphIndex;
             g.byteOffset = pc.byteOffset;
             g.style = pc.style;
             g.renderKind = VerticalGlyph::RotatedRun;
-            pushGlyph(page, g, remaining);
+            cur.pushGlyph(page, g, remaining);
             row = static_cast<uint16_t>(std::min<int>(row + remRows, rowsPerColumn));
             if (row >= rowsPerColumn) {
               column++;
               row = 0;
-              finalizePageIfNeeded();
-              row = columnStartRow(false);
+              cur.finalizePageIfNeeded();
+              row = cur.columnStartRow(false);
             }
             break;
           }
@@ -1560,26 +1637,27 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           continue;
         }
         const int chunkPx = renderer_.getRenderAdvanceX(fontId_, chunk.c_str(), runStyle);
-        const uint16_t chunkRows = rotatedRunRows(startY, runInkWidth(chunk, chunkPx, runStyle), row, nextInkOffset);
+        const uint16_t chunkRows = rotatedRunRows(
+            cellPx, startY, runInkWidth(renderer_, fontId_, chunk, chunkPx, runStyle), row, nextInkOffset);
 
         VerticalGlyph g;
         g.codepoint = 0;
         g.column = column;
         g.row = row;
-        g.x = static_cast<uint16_t>(columnLeftX(column) + cellPx - ascender);
+        g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
         g.y = static_cast<uint16_t>(startY);
         g.paragraphIndex = pc.paragraphIndex;
         g.byteOffset = pc.byteOffset;
         g.style = pc.style;
         g.renderKind = VerticalGlyph::RotatedRun;
-        pushGlyph(page, g, chunk);
+        cur.pushGlyph(page, g, chunk);
 
         row = static_cast<uint16_t>(row + chunkRows);
         if (row >= rowsPerColumn) {
           column++;
           row = 0;
-          finalizePageIfNeeded();
-          row = columnStartRow(false);
+          cur.finalizePageIfNeeded();
+          row = cur.columnStartRow(false);
         }
 
         // Skip the space and continue with the rest.
@@ -1605,7 +1683,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // Oikomi (追い込み) only while the previous column has a row spare -- otherwise it writes
         // past the bottom of the grid, over the status bar.
         if (prev.row + 1 < rowsPerColumn) {
-          placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
+          cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
           idx++;
           continue;
         }
@@ -1623,7 +1701,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.codepoint = pc.codepoint;
           g.column = prev.column;
           g.row = prev.row;
-          g.x = static_cast<uint16_t>(columnLeftX(prev.column));
+          g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column));
           // Raw grid position: pushGlyph applies this column's slide, as every other path expects.
           g.y = static_cast<uint16_t>(prev.row * cellPx + cellPx / 2);
           g.renderKind = VerticalGlyph::RotatedPunct;
@@ -1631,7 +1709,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.byteOffset = pc.byteOffset;
           g.style = pc.style;
           g.emphasis = pc.emphasis;
-          pushGlyph(page, g, pc.rubyText);
+          cur.pushGlyph(page, g, pc.rubyText);
           idx++;
           continue;
         }
@@ -1642,7 +1720,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // uses beside the text (JLREQ Fig 2.37). Without this, oidashi pulled the preceding
         // character along and left a column holding just those two.
         if (Kinsoku::verticalShiftType(pc.codepoint) == 1 && prev.row + 1 == rowsPerColumn) {
-          placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
+          cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
           idx++;
           continue;
         }
@@ -1661,7 +1739,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         if (idx > 0 && row + 1 < rowsPerColumn && prev.byteOffset == stream_[idx - 1].byteOffset &&
             prev.paragraphIndex == stream_[idx - 1].paragraphIndex) {
           page.glyphs.pop_back();
-          placeUprightAt(stream_[idx - 1], column, row);
+          cur.placeUprightAt(stream_[idx - 1], column, row);
           row++;
           // Fall through: this character is placed normally, now one row below its partner.
         }
@@ -1684,11 +1762,12 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.codepoint = pc.codepoint;
           g.column = prev.column;
           g.row = static_cast<uint16_t>(prev.row + 1);
-          int gx = columnLeftX(prev.column);
+          int gx = geom.columnLeftX(prev.column);
           int gy = g.row * cellPx;
           if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
             int qx = 0, qy = 0;
-            if (quadrantTopRight(pc.codepoint, pc.style, prev.column, g.row, /*centreInHalf=*/true, &qx, &qy)) {
+            if (quadrantTopRight(renderer_, fontId_, inkMemo, geom, pc.codepoint, pc.style, prev.column, g.row,
+                                 /*centreInHalf=*/true, &qx, &qy)) {
               gx = qx;
               gy = qy;
             } else {
@@ -1700,13 +1779,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.y = static_cast<uint16_t>(gy);
           g.renderKind = VerticalGlyph::Upright;
           if (Kinsoku::needsVerticalRotation(pc.codepoint)) {
-            g.x = static_cast<uint16_t>(columnLeftX(prev.column) + cellPx - ascender);
+            g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column) + cellPx - ascender);
             g.y = static_cast<uint16_t>(g.row * cellPx);
             g.renderKind = VerticalGlyph::RotatedPunct;
           }
           g.paragraphIndex = pc.paragraphIndex;
           g.byteOffset = pc.byteOffset;
-          pushGlyph(prevPage, g, pc.rubyText);
+          cur.pushGlyph(prevPage, g, pc.rubyText);
           idx++;
           continue;
         }
@@ -1719,11 +1798,11 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // column instead of letting it end the current one.
       column++;
       row = 0;
-      finalizePageIfNeeded();
-      row = columnStartRow(false);
+      cur.finalizePageIfNeeded();
+      row = cur.columnStartRow(false);
     }
 
-    placeUpright(pc);
+    cur.placeUpright(pc);
     const uint16_t placedRow = row;
     row++;
     // The ellipsis dot stack is drawn low enough to leave its own cell (it has to, or it
@@ -1736,7 +1815,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         (pc.codepoint == 0x2026 || pc.codepoint == 0x2025) &&
         (idx + 1 >= stream_.size() || (stream_[idx + 1].codepoint != 0x2026 && stream_[idx + 1].codepoint != 0x2025));
     if (endsEllipsisGroup && row < rowsPerColumn) {
-      const int nextInkOffset = nextGlyphInkOffset(idx + 1, pc.paragraphIndex);
+      const int nextInkOffset = cur.nextGlyphInkOffset(idx + 1, pc.paragraphIndex);
       int inkTop = 0, inkHeight = 0;
       if (nextInkOffset >= 0 &&
           renderer_.verticalPunctInkBox(fontId_, pc.codepoint, static_cast<EpdFontFamily::Style>(pc.style),
@@ -1754,8 +1833,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     if (row >= rowsPerColumn) {
       column++;
       row = 0;
-      finalizePageIfNeeded();
-      row = columnStartRow(false);
+      cur.finalizePageIfNeeded();
+      row = cur.columnStartRow(false);
     }
     idx++;
   }

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -460,6 +460,20 @@ bool VerticalParsedText::canPushStreamChar() {
 }
 
 void VerticalParsedText::addParagraph(const std::string& utf8Text) {
+  // Characters held back from the previous batch (a rotated run that ran to its end). They belong
+  // to the paragraph that was in flight then, so they go in BEFORE this batch records its own
+  // break -- the rest of the word is about to follow them and the two must gather as one run.
+  if (!carriedRunTail_.empty()) {
+    const uint32_t carryIndex =
+        paragraphBreaksBeforeIndex_.empty() ? 0 : static_cast<uint32_t>(paragraphBreaksBeforeIndex_.size() - 1);
+    for (auto& carried : carriedRunTail_) {
+      if (!canPushStreamChar()) break;
+      carried.paragraphIndex = carryIndex;
+      stream_.push_back(std::move(carried));
+    }
+    carriedRunTail_.clear();
+  }
+
   const uint32_t paragraphIndex = static_cast<uint32_t>(paragraphBreaksBeforeIndex_.size());
   paragraphBreaksBeforeIndex_.push_back(stream_.size());
 
@@ -513,6 +527,20 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
   if (pendingTrailingBreak_) {
     recordParagraphBreakAt(stream_.size());
     pendingTrailingBreak_ = false;
+  }
+
+  // Characters held back from the previous batch (a rotated run that ran to its end). They belong
+  // to the paragraph that was in flight then, so they go in BEFORE this batch records its own
+  // break -- the rest of the word is about to follow them and the two must gather as one run.
+  if (!carriedRunTail_.empty()) {
+    const uint32_t carryIndex =
+        paragraphBreaksBeforeIndex_.empty() ? 0 : static_cast<uint32_t>(paragraphBreaksBeforeIndex_.size() - 1);
+    for (auto& carried : carriedRunTail_) {
+      if (!canPushStreamChar()) break;
+      carried.paragraphIndex = carryIndex;
+      stream_.push_back(std::move(carried));
+    }
+    carriedRunTail_.clear();
   }
 
   // A continuation chunk belongs to the paragraph already in flight: no break is recorded and
@@ -1155,6 +1183,16 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       !stream_.empty()) {
     pendingTrailingBreak_ = true;
   }
+  // A carry with no following batch (the sink finalizes without adding more text) would be lost.
+  // The stream is empty here, so there are no recorded break indices to shift.
+  if (!carriedRunTail_.empty() && stream_.empty()) {
+    for (auto& carried : carriedRunTail_) {
+      if (!canPushStreamChar()) break;
+      stream_.push_back(std::move(carried));
+    }
+    carriedRunTail_.clear();
+  }
+
   // Nothing new to lay out AND nothing left over from a previous non-final call to finalize.
   if (stream_.empty() && !(isFinalFlush && pendingPageValid_)) return pages;
 
@@ -1586,6 +1624,18 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         utf8AppendCodepoint(stream_[runEnd].codepoint, runUtf8);
         runEnd++;
         if (runEnd - idx > 64) break;
+      }
+
+      // A run that reaches the END of a non-final batch is not this batch's to place: the rest of
+      // the word is in the next one, and the gatherer only ever looks within one batch, so placing
+      // it now renders "authority" as "au", a blank cell, then "thority". Hold its characters back
+      // instead -- the next batch prepends them and gathers the whole word. isFinalFlush means
+      // nothing follows, so there the run really is complete.
+      if (!isFinalFlush && runEnd == stream_.size()) {
+        carriedRunTail_.assign(std::make_move_iterator(stream_.begin() + static_cast<long>(idx)),
+                               std::make_move_iterator(stream_.end()));
+        idx = runEnd;
+        continue;
       }
 
       // Split the run into chunks that fit in columns, breaking at spaces.

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -11,21 +11,15 @@
 #include "Kinsoku.h"
 
 namespace {
-// A reserve() big enough to satisfy this margin should always succeed even under pressure --
-// below it, skip reserving and let the vector grow incrementally (smaller, more-likely-to-succeed
-// allocations) rather than attempt one large upfront allocation that's more likely to fail outright.
+// Headroom required ON TOP of a reserve() before it is attempted. Below it, skip the reserve and
+// let the vector grow incrementally: many small allocations are likelier to succeed than one large
+// one.
 //
-// Was 32KB, then 16KB -- both confirmed on a real device to be actively counterproductive for
-// large legitimate requests. At 32KB: a furigana-dense paragraph's bulk stream_ reserve needed
-// 38600 bytes with 65524 available (comfortably enough) but was skipped because 38600+32768
-// exceeded 65524. At 16KB: the per-page glyphs reserve (13824 bytes) was refused with 29684 free
-// because 13824+16384 overshot by 524 bytes. Each refusal forces incremental doubling growth --
-// hundreds to 1000+ separate reallocations for the same data -- which fragments the heap far
-// worse (a measured ~22KB net loss) than the single bulk reserve it was "protecting" against.
-// The getMaxAllocHeap() check already guarantees the reserve() itself succeeds; this constant is
-// only cushion for OTHER allocations during the build, and while a chapter build runs the rest of
-// the app is quiescent (largest concurrent needs: SD write buffers and log lines, low KBs). 4KB
-// lets the real page buffer win over fragmenting incremental growth.
+// Keep this small. The margin is cushion for OTHER allocations during a build (SD write buffers,
+// log lines -- low KBs; the rest of the app is quiescent), not for the reserve itself, which the
+// getMaxAllocHeap() check already guarantees. A margin large enough to refuse a legitimate bulk
+// reserve is worse than none: incremental doubling then costs hundreds of reallocations for the
+// same data and fragments the heap ~22KB beyond the single allocation it withheld.
 constexpr uint32_t MIN_FREE_HEAP_FOR_RESERVE = 4 * 1024;
 
 // Cushion left for the rest of the app when growing a vector one element at a time, as opposed
@@ -421,14 +415,11 @@ void VerticalParsedText::recordParagraphBreakAt(const size_t idx) {
 }
 
 void VerticalParsedText::reserveStreamFor(size_t utf8Bytes) {
-  // CJK prose is ~3 UTF-8 bytes per codepoint, so bytes/3 (+ slack for embedded ASCII) closely
-  // estimates the PendingChar slots this text needs. An earlier version of this reserve used the
-  // raw byte count as the slot count -- a 3x over-request at 32 bytes per slot (~96 bytes reserved
-  // per actual character), which crashed a real device. The affordability check below is on the
-  // REQUEST size, not just current free heap: reserve() is one contiguous allocation that aborts
-  // the process on failure under -fno-exceptions, so a request that doesn't comfortably fit is
-  // skipped entirely -- incremental push_back growth (guarded by canPushStreamChar) is the
-  // lower-risk path once memory is tight.
+  // CJK prose is ~3 UTF-8 bytes per codepoint, so bytes/3 (+ slack for embedded ASCII) sizes the
+  // PendingChar slots. Not the raw byte count: at 32 bytes per slot that over-requests 3x.
+  // The affordability check is on the REQUEST size, not free heap. reserve() is one contiguous
+  // allocation and aborts under -fno-exceptions, so a request that does not comfortably fit is
+  // skipped in favour of incremental growth (guarded by canPushStreamChar).
   const size_t slots = utf8Bytes / 3 + 8;
   const size_t needed = stream_.size() + slots;
   if (needed <= stream_.capacity()) return;
@@ -503,14 +494,9 @@ void VerticalParsedText::addParagraph(const std::string& utf8Text) {
       i += consumed;
       continue;
     }
-    // Note: a plain space is deliberately NOT skipped here even though CJK prose
-    // itself never uses inter-word spaces, because Kinsoku::
-    // isRotatedRunCharacter() now treats ' ' as part of a Latin run --
-    // dropping it here would merge multi-word embedded English phrases
-    // ("CrossPoint Reader") into one unreadable token
-    // ("CrossPointReader"). A stray space between two CJK characters
-    // (rare, but it happens in some EPUB markup) just renders as a
-    // harmless near-invisible 1-character rotated "run".
+    // Keep plain spaces. Kinsoku::isRotatedRunCharacter() counts ' ' as part of a Latin run, so
+    // dropping it here merges embedded English into one token ("CrossPointReader"). A stray space
+    // between two CJK characters renders as a near-invisible 1-character rotated run.
     if (cp == '\t') {
       i += consumed;
       continue;
@@ -749,12 +735,13 @@ struct VerticalParsedText::LayoutCursor {
       // slides it down (ink that leaves its own cell, e.g. the low ellipsis dot stack).
       g.y = static_cast<uint16_t>(std::max(0, static_cast<int>(g.y) - columnYShift));
     }
-    // Tiers, most protective first. The 4K tier: device evidence (450+ page chapter) showed
-    // maxAlloc dips bottoming at 14324 while the linear request sat at ~9216 -- the 8K margin
-    // missed by 12 bytes, dropped glyphs, and the stale mark re-indexed the chapter on every
-    // open. The 0 tier: at that point the margin protects only allocations that fail gracefully
-    // and retry (font advance tables, staging buffers, the next page's reserve), while a dropped
-    // glyph is a character permanently missing from the page.
+    // Tiers, most protective first.
+    //   4K: a ~9216-byte linear request must still pass when maxAlloc dips to ~14324, as it does
+    //       on a 450+ page chapter. An 8K margin misses, drops glyphs, and marks the section
+    //       stale so it re-indexes on every open.
+    //   0:  below this the margin protects only allocations that fail gracefully and retry (font
+    //       advance tables, staging buffers, the next page's reserve), whereas a dropped glyph is
+    //       content permanently missing from the page.
     static constexpr uint32_t MARGINS[] = {SMALL_ALLOC_MARGIN, 4 * 1024, 0};
     constexpr size_t LINEAR_GROWTH_STEP = 16;  // elements; keeps a stalled page's retries cheap
     if (growForOnePush(glyphs, MARGINS, LINEAR_GROWTH_STEP)) {
@@ -902,20 +889,19 @@ struct VerticalParsedText::LayoutCursor {
     return static_cast<uint16_t>(std::clamp(rows, 1, static_cast<int>(UINT16_MAX)));
   }
 
-  // JLREQ 3.8, the other half of line adjustment: spreading. A column that reclaimed slack inside
-  // itself -- a rotated run's cell rounding, the slide that keeps the low ellipsis stack out of the
-  // next character -- ends short of the text area's foot by LESS than one cell. Measured on this
-  // book: 17px of a 29px cell, on nearly half of all columns, which is what made the column feet
-  // look ragged. Nothing can be pulled in to fill it (oikomi already ran, and the next character is
-  // an ordinary full-em one needing a whole cell), so the space goes back to the column's own
-  // inter-character gaps and the column ends flush.
+  // JLREQ 3.8 spreading, the counterpart to oikomi below. A column that reclaimed slack inside
+  // itself (a rotated run's cell rounding; the slide that keeps a low ellipsis stack clear of the
+  // next character) ends short of the text area's foot by LESS than one cell. Nothing can be
+  // pulled in to fill it -- oikomi has already run and the next character needs a whole em -- so
+  // the leftover is returned to the column's own inter-character gaps and the column ends flush.
   //
-  // Progressive, like the squeeze: each row moves by its share, so the gaps grow by leftover/lastRow
-  // -- under a pixel each here -- and the reclaimed correction inside the column survives.
+  // Progressive, like the squeeze: each row moves by its share (leftover/lastRow), so corrections
+  // already applied inside the column survive.
   //
-  // Left alone: a column that ends where its PARAGRAPH ended (shortfall of a cell or more -- not a
-  // fitting problem, and stretching it would space a two-character line down the whole page), and
-  // one whose last glyph HANGS past the foot (burasage, negative leftover).
+  // Two cases are deliberately left ragged:
+  //   - the column ends where its PARAGRAPH ended (shortfall >= one cell). Not a fitting problem;
+  //     stretching it would space a two-character line down the whole page.
+  //   - the last glyph HANGS past the foot (burasage), i.e. leftover is negative.
   void spreadColumnToFoot(VerticalPage& pg, const uint16_t col) {
     int lastRow = -1;
     int lastY = 0;
@@ -1421,35 +1407,27 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // exact reserve, immediately after the *previous* page was pushed (which can itself burst
   // memory use during its own relocation). Check the request against free heap every time.
 
-  // Skipping the reserve above is only safe if every individual push_back is ALSO guarded --
-  // "grows incrementally" isn't automatically safe on a heap this tight, and a real device crash
-  // confirmed exactly that: the skipped-reserve fallback still aborted inside the first
-  // push_back's own reallocation. Only checks free heap when a reallocation is actually imminent
-  // (size == capacity), so this is cheap in the (now common, thanks to reservePageGlyphs) case
-  // where headroom already covers the push. Drops the glyph (visually a rare missing character in
-  // an extreme low-memory tail case) rather than crash the whole device.
+  // Guards one push_back when the bulk reserve was skipped. Skipping the reserve is only safe if
+  // each push is guarded too: incremental growth still reallocates, and that reallocation aborts
+  // under -fno-exceptions. Dropping one glyph is preferable to killing the firmware.
   //
-  // The check must be against the ACTUAL next allocation size, not a flat margin: vector growth
-  // roughly doubles capacity each time, so the very first push from empty needs ~1 element
-  // (~50 bytes) while a push near a nearly-full page needs nearly as much as the original bulk
-  // reserve. A real device crash confirmed the failure mode of getting this wrong: using
-  // MIN_FREE_HEAP_FOR_RESERVE (32KB) as a flat per-glyph margin meant that once free heap sat
-  // anywhere below 32KB -- which is otherwise completely survivable for a ~50-byte push -- every
-  // single glyph was dropped, silently blanking entire pages.
-  // Exponential (x2) growth here is a trap once the heap is tight: if one doubling attempt fails,
-  // capacity stays put, so *every* subsequent push_back needs that exact same (large, ever-doubling)
-  // contiguous block and fails identically -- silently dropping every remaining glyph on the page,
-  // not just the one that triggered it. This is what produced the "sparse page" bug reports: a
-  // single transient dip below the doubled-capacity requirement blanked the rest of the page.
-  // Falling back to a small LINEAR growth step once doubling would be too big keeps each retry's
-  // request small and roughly constant, so a later push (after some other allocation frees up) has
-  // a real chance to succeed instead of being permanently walled off behind the same big ask.
-  // An embedded Latin word reserves whole cells, so the leftover of that rounding (up to a
-  // full cell) landed as dead space before the next character. Instead of moving that one
-  // character -- which only pushes the hole one position further along (device photo:
-  // "Lombroso なんぞ", gap between な and ん) -- the whole rest of the column slides up by
-  // the same amount. Spacing stays even, nothing collides, and only this column's tail sits
-  // slightly higher than its neighbours.
+  // Three rules, each load-bearing:
+  //
+  //   1. Check only when a reallocation is imminent (size == capacity). Otherwise free.
+  //
+  //   2. Test the ACTUAL next allocation size, never a flat margin. Growth roughly doubles, so a
+  //      push from empty needs ~50 bytes while a push near a full page needs nearly the whole bulk
+  //      reserve. A flat 32KB margin drops every glyph whenever free heap is below 32KB -- easily
+  //      survivable for a 50-byte push -- and silently blanks whole pages.
+  //
+  //   3. Fall back to LINEAR growth once doubling would be too large. With x2 growth a single
+  //      failed doubling leaves capacity unchanged, so every later push requests the same large
+  //      block and fails identically, dropping the rest of the page after one transient dip. A
+  //      small constant step keeps each retry cheap enough to succeed once memory frees up.
+  // An embedded Latin run reserves whole cells, leaving up to a cell of dead space after it.
+  // The whole remainder of the column slides up by that amount, not just the next character --
+  // moving one character only relocates the gap. Spacing stays even and this column's tail sits
+  // slightly higher than its neighbours'.
   int columnYShift = 0;
   uint16_t shiftColumn = UINT16_MAX;
 
@@ -1485,15 +1463,14 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // advance row/column past it. Shared by the digit and punctuation-pair
   // branches in the loop below.
 
-  // Whether the current page's glyph vector can take one more PendingChar's worth of glyphs
-  // without an impossible copy-and-grow (old and new buffer must coexist during a vector
-  // reallocation -- on the observed dense-ruby pages that is a 10-12KB block at exactly the
-  // layout's low-heap dip). HEADROOM covers the worst single-character expansion: a sliced
-  // rotated Latin run plus ruby.
-  // Mirrors pushGlyph's LAST growth fallback exactly (+16 elements, zero margin) so the
-  // early break fires only when the very next growth attempt would otherwise start
-  // dropping -- not sooner. A bigger headroom here inflated the page count with premature
-  // breaks (device evidence: breaks at 81-148 glyphs against dips the +16 step survived).
+  // Whether this page's glyph vector can take one more PendingChar without a copy-and-grow it
+  // cannot afford (both buffers coexist during a reallocation: 10-12KB on dense-ruby pages, at the
+  // layout's low-heap dip). HEADROOM covers the worst single-character expansion, a sliced rotated
+  // Latin run plus ruby.
+  //
+  // Must mirror pushGlyph's LAST growth fallback exactly (+16 elements, zero margin), so the page
+  // breaks early only when the next growth attempt would genuinely drop glyphs. A larger headroom
+  // breaks pages that would have survived and inflates the page count.
 
   // Shared placement geometry for every sideways run -- embedded Latin words AND multi-digit
   // numbers. drawText() takes the em-box TOP, so an upright glyph's ink starts (ascender -
@@ -1542,12 +1519,10 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     // Force a fresh column at the start of every paragraph after the
     // first, the same way horizontal layout starts a new line per
     // paragraph.
-    // Tracks whether a forced paragraph break just fired for THIS position, so the kinsoku
-    // line-start pull-back below can be suppressed: a paragraph the author starts with
-    // prohibited punctuation (……でも) must keep its fresh column -- oikomi would otherwise
-    // drag its opening characters back into the previous paragraph's column, visually merging
-    // the two (confirmed with the full-pipeline host repro). Kinsoku governs WRAPPED line
-    // starts, not author-intended paragraph openings.
+    // Suppresses the kinsoku pull-back below when a paragraph break just fired at this position.
+    // Kinsoku governs WRAPPED line starts, not author-intended paragraph openings: a paragraph
+    // beginning with prohibited punctuation (……でも) must keep its fresh column, or oikomi drags
+    // its opening characters back into the previous paragraph's column and merges the two.
     // Box END before the paragraph break: the box's content ended with the previous glyph, so
     // its rect closes at the CURRENT column -- the break below then advances to a fresh one.
     while (nextBoxEndIdx < boxEndsBeforeIndex_.size() && idx == boxEndsBeforeIndex_[nextBoxEndIdx]) {
@@ -1829,16 +1804,15 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         }
 
         if (breakAt == std::string::npos) {
-          // No space-break fits. Retry from a fresh column ONLY when the current position is
-          // deeper than where a fresh column would start; otherwise force-place. The comparison
-          // MUST be against cur.columnStartRow(false), not 0: inside a styled block (start-Xem, e.g.
-          // Aozora/EBPAJ div.mtN margins, defined up to 22em+) fresh columns begin at a non-zero
-          // row, and comparing against 0 made this branch loop forever -- every retry re-seeded
-          // row = startRows != 0, the force-place arm below was unreachable, and the layout
-          // marched through columns/pages without consuming a single byte ("Indexing" never
-          // finished; host-reproduced with a mtN block whose start offset left fewer rows than a
-          // short embedded Latin word needs). After one retry row == cur.columnStartRow(false), so
-          // the force-place arm is guaranteed on the next pass -- termination is structural.
+          // No space-break fits. Retry from a fresh column only if the current row is deeper than
+          // where a fresh column starts; otherwise force-place.
+          //
+          // Compare against cur.columnStartRow(false), NEVER 0. Inside a styled block (start-Xem
+          // margins such as Aozora/EBPAJ div.mtN, seen up to 22em) fresh columns begin at a
+          // non-zero row, so comparing with 0 makes every retry re-seed the same row, leaves the
+          // force-place arm unreachable, and loops forever without consuming input. With the
+          // correct comparison, one retry leaves row == columnStartRow(false) and force-place is
+          // guaranteed on the next pass: termination is structural.
           if (row > cur.columnStartRow(false)) {
             column++;
             row = 0;

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -582,15 +582,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   const int baselineInCellPx = baselineNow;
   const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, static_cast<int>(viewportHeight_) / cellPx));
   const int usableWidthPx = std::max(cellPx, static_cast<int>(viewportWidth_) - rightPaddingPx_);
-  const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, usableWidthPx / columnAdvancePx));
-  // Columns are anchored to the right edge and march leftwards, so the width that does not divide
-  // evenly into columns would pile up as dead space on the LEFT. Split it between the two margins
-  // instead of adding it to the gaps: the gap is 行間, set in quarter ems by the line-spacing
-  // setting (and by whether furigana needs room in it), so widening it here overrides the very
-  // rule that chose it -- measurably, a 21px gap became 25px against a 29px em.
-  // (x stays >= 0: the leftmost column sits at leftover - leftover/2.)
-  const int leftoverPx = std::max(0, usableWidthPx - cellPx - (columnsPerPage - 1) * columnAdvancePx);
-  const int blockShiftPx = leftoverPx / 2;
+  // N columns occupy N*advance - gap, not N*advance: the last one needs no trailing 行間, so
+  // dividing the width by the advance drops a column whenever the remainder is a cell or more.
+  const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, (usableWidthPx + columnGapPx_) / columnAdvancePx));
+  // Whatever is still left over stays on the LEFT, where tategaki's margin belongs -- the text
+  // starts at the right edge. It must not be spread into the gaps: 行間 is set in quarter ems by
+  // the line-spacing setting (and by whether furigana needs room in it), so widening it here
+  // overrides the rule that chose it -- measurably, a 21px gap became 25px against a 29px em.
 
   // Index into paragraphBreaksBeforeIndex_ of the *next* paragraph start,
   // so we know when we've crossed into a new paragraph and should force a
@@ -606,9 +604,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // function and must still be able to close an open box on the final page.
   boxGeomCellPx_ = cellPx;
   boxGeomColumnAdvancePx_ = columnAdvancePx;
-  // Fold the block shift in here: appendBoxRectToPage's colLeft is columnLeftX with the shift
-  // already applied, so the two must not drift apart.
-  boxGeomUsableWidthPx_ = usableWidthPx - blockShiftPx;
+  boxGeomUsableWidthPx_ = usableWidthPx;
   boxGeomRowsPerColumn_ = rowsPerColumn;
 
   // Re-record box markers carried across a batch boundary (see reset()) at index 0.
@@ -756,7 +752,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   uint16_t& column = pendingColumn_;
   uint16_t& row = pendingRow_;
 
-  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - blockShiftPx - col * columnAdvancePx; };
+  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - col * columnAdvancePx; };
 
   // Row where a fresh column starts: 0 normally; inside a styled block, the block's start
   // offset (start-Xem), plus the hanging indent (h-indent-Xem) when the column continues a

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -543,37 +543,23 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   if (stream_.empty() && !(isFinalFlush && pendingPageValid_)) return pages;
 
   // Coordinate convention, uniform for every RenderKind: VerticalGlyph::y is the TOP of the
-  // glyph's cell, never a baseline. Baselines are a property of drawing, not of layout, and the
-  // two used to be mixed per kind -- upright glyphs stored cellTop + ascender while the rotated
-  // kinds stored cellTop. Since GfxRenderer::drawText takes a TOP and adds the ascender itself,
-  // the upright ones were drawn a full ascender low, and the constants that compensated for it
-  // (a 3/8-cell "down nudge", a two-cell bottom reserve, `2 * ascender - gt` here) then had to be
-  // tuned by eye against that error. With one convention the ink positions come out of measured
-  // metrics instead: see verticalCellBaselineOffset.
+  // glyph's cell, never a baseline -- baselines belong to drawing, which converts per draw call
+  // (see VerticalTextBlock::drawGlyphs). Ink offsets come from verticalCellBaselineOffset().
   const int cellPx = std::max(1, charAdvancePx());
   const int columnAdvancePx = cellPx + columnGapPx_;
   const int ascender = renderer_.getFontAscenderSize(fontId_);
-  // Rows come straight out of the text area's height: as many whole cells as fit.
-  //
-  // The last row's ink hangs a few px below its own cell (baselineInCell + descender exceeds the
-  // cell by ~2px at a 33px cell), and that overhang is left to the margin below the text area,
-  // exactly as ruby is left to the margin beside it (JLREQ Fig 2.37). Reserving it inside the
-  // text area instead used to cost a whole character per column whenever the height divided
-  // evenly: 759px of viewport at a 33px cell is exactly 23 rows, but subtracting a 2px reserve
-  // rounded that down to 22 and left ~31px of dead space at every column's foot.
-  //
-  // The margin below is the reader's screenMargin plus the status bar (see EpubReaderActivity),
-  // so there is room for a few px of ink; the previous formula's own reserve was smaller than
-  // that margin anyway.
+  // As many whole cells as the text area's height allows. The last row's ink hangs a few px past
+  // its cell; that goes in the margin below (screenMargin + status bar), just as ruby goes in the
+  // margin beside the text (JLREQ Fig 2.37). Reserving it here instead costs a whole character
+  // per column whenever the height divides evenly.
   const int baselineInCellPx = verticalCellBaselineOffset(renderer_, fontId_, cellPx);
   const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, static_cast<int>(viewportHeight_) / cellPx));
   const int usableWidthPx = std::max(cellPx, static_cast<int>(viewportWidth_) - rightPaddingPx_);
   const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, usableWidthPx / columnAdvancePx));
-  // Columns are anchored to the right edge and march leftwards, so whatever width does not divide
-  // evenly into columns piled up as dead space on the LEFT -- up to a full column plus a gap, and
-  // wider than the margin the reader actually set. Spread that remainder across the gaps instead:
-  // the leftmost column then lands on the left margin, both sides match the setting, and the
-  // columns stay evenly spaced. (x stays >= 0: (N-1) * (advance + leftover/(N-1)) <= usable - cell.)
+  // Columns are anchored to the right edge and march leftwards, so the width that does not divide
+  // evenly into columns would pile up as dead space on the LEFT. Spread it across the gaps: the
+  // leftmost column lands on the left margin and the columns stay evenly spaced.
+  // (x stays >= 0: (N-1) * (advance + leftover/(N-1)) <= usable - cell.)
   const int leftoverPx = std::max(0, usableWidthPx - cellPx - (columnsPerPage - 1) * columnAdvancePx);
   const int spreadColumnAdvancePx =
       columnsPerPage > 1 ? columnAdvancePx + leftoverPx / (columnsPerPage - 1) : columnAdvancePx;
@@ -824,19 +810,12 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
   };
 
-  // JLREQ 3.1.4, consecutive brackets / commas / full stops / middle dots. Each of these marks
-  // is a half-em glyph occupying one half of its full-em cell, so which halves two neighbours use
-  // decides how much white ends up between their ink:
+  // JLREQ 3.1.4, consecutive brackets / commas / full stops / middle dots. Each is a half-em
+  // glyph occupying one half of its em, which is what decides the white between two neighbours:
   //
   //   first half (top, in vertical)  - closing brackets, 、。，．
   //   second half (bottom)           - opening brackets
   //   centre                         - middle dot ・
-  //
-  // Set solid, a first-half mark followed by a second-half one leaves a WHOLE em of white (the
-  // first's empty tail plus the second's empty head), which the spec reduces to a half em. Every
-  // other combination already lands on its target when set solid, so this one test reproduces the
-  // whole table: 、「 and 」「 close up (figures 3, 4), 」・「 closes up on both sides of the dot
-  // (figure 7), while 。」, ）。, 「『 and ）」 are left alone (figures 1, 2, 5, 6).
   auto punctEmHalf = [](const uint32_t cp) -> int {  // 0 none, 1 first half, 2 second half, 3 centre
     if (cp == 0x30FB || cp == 0x00B7) return 3;      // ・
     switch (Kinsoku::verticalShiftType(cp)) {
@@ -858,16 +837,14 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     const int thisHalf = punctEmHalf(cp);
     if (prevHalf == 0 || thisHalf == 0) return;
 
-    // Every pair in the figures closes up by a half em: 、「 and 」「 go from a full em of white
-    // down to a half (figures 3, 4); 。」, ）。, 「『 and ）」 go from a half em to solid (1, 2, 5,
-    // 6); and 」・「 goes from three quarters to a quarter on each side of the dot (7).
+    // Every pair in the figures closes up by a half em: 、「 and 」「 from a full em to a half
+    // (figures 3, 4); 。」, ）。, 「『, ）」 from a half em to solid (1, 2, 5, 6); 」・「 from three
+    // quarters to a quarter each side of the dot (7).
     int reduction = cellPx / 2;
 
-    // 。and 、 are the exception, because they no longer occupy a whole cell: they end a half em
-    // after their own ink (see commaTighten), so that half em is already gone.
-    //   - an OPENING bracket after them wants exactly that half em -- leave it (figure 3);
-    //   - a CLOSING bracket or another 。/、 is set solid, so take it (figures 1, 2);
-    //   - a middle dot keeps a quarter, so take half of it.
+    // 。and 、 already end a half em after their own ink (commaTighten), so that half is gone:
+    // an opening bracket wants exactly it (figure 3), a closing bracket or another 。/、 is set
+    // solid (1, 2), a middle dot keeps a quarter.
     if (Kinsoku::verticalShiftType(prev.codepoint) == 1) {
       if (thisHalf == 2) return;
       reduction = (thisHalf == 3) ? cellPx / 4 : cellPx / 2;
@@ -876,18 +853,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     shiftColumn = columnArg;
   };
 
-  // 。and 、 occupy the upper-RIGHT quadrant of their cell in vertical writing. Place them by
-  // their own ink box -- flush to the cell's right edge and to its top -- rather than by shifting
-  // the glyph half a cell, which only approximated it and drifted with the font: these glyphs
-  // are drawn with their ink at the bottom-left of the em, so how far it has to travel depends
-  // entirely on that font's bearings. Returns false when metrics are unavailable.
+  // Upper-RIGHT quadrant placement, from the glyph's own ink box: these marks are drawn with
+  // their ink at the bottom-left of the em, so how far it must travel is font-specific. Returns
+  // false when metrics are unavailable.
   //
-  // centreInHalf picks between the two shapes this is used for:
-  //   。、  - "character advance of full stops and commas is half-width, 1/2 em space after", so
-  //           the mark lives in a HALF-em box at the head of the cell and its ink is centred in
-  //           that box. Pinning the ink to the very top of a full cell instead left about 3/4 em
-  //           of white before the next character.
-  //   small kana - the reference figures put the letter face against the top edge of its box.
+  // centreInHalf distinguishes the two users:
+  //   。、        - half-width advance, so the ink is centred in a half-em box at the cell's head
+  //   small kana - letter face against the top edge of its box
   auto quadrantTopRight = [&](const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
                               const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) -> bool {
     int gl = 0, gw = 0, gt = 0, gh = 0;
@@ -921,15 +893,10 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       g.x = static_cast<uint16_t>(columnLeftX(col));
       g.y = static_cast<uint16_t>(rowIdx * cellPx);
       g.renderKind = VerticalGlyph::RotatedPunct;
-      // JLREQ: an opening bracket at the LINE HEAD has the half em before it removed -- it is set
-      // flush to the head (tentsuki). Its ink normally occupies the second half of its em so it
-      // sits against the character it opens, which at a line head left a visible half-em hole
-      // above it and started every quoted line lower than its neighbours.
-      //
-      // "Line head" means the first glyph of THIS column, not row 0: a styled block (a CSS indent
-      // or hanging indent) opens its column further down, and dialogue paragraphs -- the ones that
-      // actually begin with 「 -- are typically indented, so a row-0 test missed every one of them.
-      // Checked BEFORE the glyph is pushed, since afterwards the bracket is itself the last glyph.
+      // JLREQ: an opening bracket at the LINE HEAD is set flush to it (tentsuki), the half em
+      // before it deleted. "Line head" is the first glyph of THIS column, not row 0 -- a styled
+      // block (CSS indent, hanging indent) opens its column further down, and dialogue paragraphs
+      // are typically indented. Checked before the push, when the bracket is not yet the last.
       const bool atLineHead = page.glyphs.empty() || page.glyphs.back().column != col;
       const bool flushOpeningBracket = atLineHead && Kinsoku::verticalShiftType(pc.codepoint) == 3;
       if (flushOpeningBracket) g.lineHeadFlush = 1;
@@ -943,11 +910,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
 
     if (Kinsoku::isSmallKana(pc.codepoint)) {
-      // Small kana (っゃゅょ, ィ ョ ...) sit in the upper-right of their cell in vertical writing --
-      // the reference figures show the letter face against the TOP edge of its box, not centred in
-      // it. Same measured placement as 。and 、: flush to the cell's right edge and to its top,
-      // from the glyph's own ink box rather than an eighth-of-a-cell bias, since how far the ink
-      // has to travel depends entirely on the font's bearings.
+      // Small kana (っゃゅょ ィ ョ) sit upper-right, letter face against the TOP edge of the box.
       int qx = 0, qy = 0;
       if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/false, &qx, &qy)) {
         g.x = static_cast<uint16_t>(qx);
@@ -977,9 +940,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/true, &qx, &qy, &inkH)) {
         gx = qx;
         gy = qy;
-        // These marks do not deserve a whole square: they take the height of their own ink plus a
-        // half em of space, and the next character follows. Whatever is left of the cell after
-        // that comes off the rest of the column, so a comma no longer reads as a full blank cell.
+        // Not a whole square: the mark takes its own ink height plus a half em, then the next
+        // character follows. The remainder of the cell comes off the rest of the column.
         commaTighten = std::max(0, cellPx - (inkH + cellPx / 2));
       } else {
         gx += cellPx / 2;
@@ -1125,9 +1087,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     const VerticalGlyph& pg = page.glyphs.back();
     if (pg.column != columnArg) return topYArg;
     // Start on the grid; the only reason to push further is a predecessor whose ink actually
-    // reaches into this cell, and that is measured below. The old unconditional quarter-cell
-    // (min 5px) gap was tuned when upright ink was drawn an ascender low, and now just leaves a
-    // visible hole before an embedded Latin word.
+    // reaches into this cell, which is measured below.
     int startY = topYArg;
     if (pg.renderKind == VerticalGlyph::RotatedPunct) {
       // Brackets are placed from their cell box and hang roughly a full cell lower than that
@@ -1640,22 +1600,17 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     if (startingNewColumn && !paraBreakJustFired && Kinsoku::isLineStartProhibited(pc.codepoint)) {
       if (!page.glyphs.empty()) {
         const VerticalGlyph& prev = page.glyphs.back();
-        // Oikomi (追い込み) only while the previous column still has a row spare. Nothing used to
-        // check that, so a small kana or 。 arriving at a FULL column was written one row past the
-        // bottom -- printing over the status bar (device photo: 「…とっく」's small っ).
+        // Oikomi (追い込み) only while the previous column has a row spare -- otherwise it writes
+        // past the bottom of the grid, over the status bar.
         if (prev.row + 1 < rowsPerColumn) {
           placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
           idx++;
           continue;
         }
-        // Oidashi (追い出し): no room to pull it back, so send the character BEFORE it forward
-        // instead and let the pair start this column together. Rewinding one step re-places that
-        // character here through the normal path; this character then follows it and no longer
-        // starts a column, so the rule is satisfied without overrunning the grid.
-        //
-        // Only safe when the previous glyph is this batch's previous stream entry -- with
-        // streamed layout the page can carry glyphs from an earlier batch, and those are not
-        // ours to re-place. Falls back to leaving the character where it is otherwise.
+        // Oidashi (追い出し): send the character BEFORE it forward instead, so the pair starts
+        // this column together. Rewinding one step re-places it through the normal path.
+        // Only safe when that glyph is this batch's previous stream entry -- streamed layout can
+        // leave glyphs from an earlier batch on the page, which are not ours to re-place.
         if (idx > 0 && prev.byteOffset == stream_[idx - 1].byteOffset &&
             prev.paragraphIndex == stream_[idx - 1].paragraphIndex) {
           page.glyphs.pop_back();
@@ -1673,8 +1628,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // and heap is tight, skip the pull-back (the character starts the next page/column
         // normally instead) rather than risk it -- a minor formatting nicety, not correctness.
         const bool hasHeadroom = prevPage.glyphs.size() < prevPage.glyphs.capacity();
-        // Same bound as the in-page pull-back: only while that column has a row spare, or the
-        // character lands past the bottom of the previous page and over its status bar.
+        // Same bound as the in-page pull-back: only while that column has a row spare.
         const bool prevColumnHasRoom = !prevPage.glyphs.empty() && prevPage.glyphs.back().row + 1 < rowsPerColumn;
         if (prevColumnHasRoom && (hasHeadroom || ESP.getMaxAllocHeap() >= MIN_FREE_HEAP_FOR_RESERVE)) {
           const VerticalGlyph& prev = prevPage.glyphs.back();

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -901,6 +901,38 @@ struct VerticalParsedText::LayoutCursor {
     return static_cast<uint16_t>(std::clamp(rows, 1, static_cast<int>(UINT16_MAX)));
   }
 
+  // JLREQ 3.8, the other half of line adjustment: spreading. A column that reclaimed slack inside
+  // itself -- a rotated run's cell rounding, the slide that keeps the low ellipsis stack out of the
+  // next character -- ends short of the text area's foot by LESS than one cell. Measured on this
+  // book: 17px of a 29px cell, on nearly half of all columns, which is what made the column feet
+  // look ragged. Nothing can be pulled in to fill it (oikomi already ran, and the next character is
+  // an ordinary full-em one needing a whole cell), so the space goes back to the column's own
+  // inter-character gaps and the column ends flush.
+  //
+  // Progressive, like the squeeze: each row moves by its share, so the gaps grow by leftover/lastRow
+  // -- under a pixel each here -- and the reclaimed correction inside the column survives.
+  //
+  // Left alone: a column that ends where its PARAGRAPH ended (shortfall of a cell or more -- not a
+  // fitting problem, and stretching it would space a two-character line down the whole page), and
+  // one whose last glyph HANGS past the foot (burasage, negative leftover).
+  void spreadColumnToFoot(VerticalPage& pg, const uint16_t col) {
+    int lastRow = -1;
+    int lastY = 0;
+    for (const auto& g : pg.glyphs) {
+      if (g.column == col && g.row > lastRow) {
+        lastRow = g.row;
+        lastY = g.y;
+      }
+    }
+    if (lastRow < 1) return;  // nothing to spread across
+    const int leftover = static_cast<int>(o.viewportHeight_) - (lastY + geom.cellPx);
+    if (leftover <= 0 || leftover >= geom.cellPx) return;
+    for (auto& g : pg.glyphs) {
+      if (g.column != col) continue;
+      g.y = static_cast<uint16_t>(static_cast<int>(g.y) + leftover * static_cast<int>(g.row) / lastRow);
+    }
+  }
+
   // JLREQ 3.8 line adjustment, 追い込み (oikomi): recover one cell in column `col` so a character
   // that may not start a line can join it instead of being pushed to the next column.
   //
@@ -1033,6 +1065,7 @@ struct VerticalParsedText::LayoutCursor {
         o.boxStartCol_ = 0;
         o.boxContinuedFromPrevPage_ = true;
       }
+      for (uint16_t c = 0; c < geom.columnsPerPage; c++) spreadColumnToFoot(page, c);
       pages.push_back(std::move(page));
       o.anyPageEverProduced_ = true;
       // Stream out everything except the single most-recently-completed page: the oikomi
@@ -2047,6 +2080,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   }
 
   if (isFinalFlush) {
+    for (uint16_t c = 0; c < columnsPerPage; c++) cur.spreadColumnToFoot(page, c);
     if (!page.glyphs.empty() || !anyPageEverProduced_) {
       pages.push_back(std::move(page));
       anyPageEverProduced_ = true;

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -512,6 +512,21 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
   }
 }
 
+int verticalCellBaselineOffset(const GfxRenderer& renderer, const int fontId, const int cellPx) {
+  const int ascender = renderer.getFontAscenderSize(fontId);
+  // String literal, no allocation -- this is called from the pagination path.
+  renderer.ensureSdCardFontReady(fontId, "\xe4\xb8\xad", 0x01);
+  int left = 0, width = 0, top = 0, height = 0;
+  if (!renderer.getGlyphMetrics(fontId, 0x4E2D /* 中 */, static_cast<EpdFontFamily::Style>(0), &left, &width, &top,
+                                &height) ||
+      height <= 0 || height > cellPx * 2) {
+    return ascender;
+  }
+  // getGlyphMetrics reports `top` as the ink top ABOVE the baseline, so centring the ink box in
+  // the cell puts the baseline at (cell - inkHeight)/2 + top below the cell's top edge.
+  return (cellPx - height) / 2 + top;
+}
+
 std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCallback onPageReady, bool isFinalFlush) {
   std::vector<VerticalPage> pages;
   // A break recorded at exactly stream-end (a trailing '\n' in this batch's last run) can never
@@ -527,15 +542,41 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Nothing new to lay out AND nothing left over from a previous non-final call to finalize.
   if (stream_.empty() && !(isFinalFlush && pendingPageValid_)) return pages;
 
+  // Coordinate convention, uniform for every RenderKind: VerticalGlyph::y is the TOP of the
+  // glyph's cell, never a baseline. Baselines are a property of drawing, not of layout, and the
+  // two used to be mixed per kind -- upright glyphs stored cellTop + ascender while the rotated
+  // kinds stored cellTop. Since GfxRenderer::drawText takes a TOP and adds the ascender itself,
+  // the upright ones were drawn a full ascender low, and the constants that compensated for it
+  // (a 3/8-cell "down nudge", a two-cell bottom reserve, `2 * ascender - gt` here) then had to be
+  // tuned by eye against that error. With one convention the ink positions come out of measured
+  // metrics instead: see verticalCellBaselineOffset.
   const int cellPx = std::max(1, charAdvancePx());
   const int columnAdvancePx = cellPx + columnGapPx_;
   const int ascender = renderer_.getFontAscenderSize(fontId_);
-  const int globalDownNudge = std::max(1, (cellPx * 3) / 8);
-  const int bottomReservedPx = std::max(cellPx * 2, ascender + globalDownNudge + cellPx);
-  const int usableHeightPx = std::max(cellPx, static_cast<int>(viewportHeight_) - bottomReservedPx);
-  const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, usableHeightPx / cellPx));
+  // Rows come straight out of the text area's height: as many whole cells as fit.
+  //
+  // The last row's ink hangs a few px below its own cell (baselineInCell + descender exceeds the
+  // cell by ~2px at a 33px cell), and that overhang is left to the margin below the text area,
+  // exactly as ruby is left to the margin beside it (JLREQ Fig 2.37). Reserving it inside the
+  // text area instead used to cost a whole character per column whenever the height divided
+  // evenly: 759px of viewport at a 33px cell is exactly 23 rows, but subtracting a 2px reserve
+  // rounded that down to 22 and left ~31px of dead space at every column's foot.
+  //
+  // The margin below is the reader's screenMargin plus the status bar (see EpubReaderActivity),
+  // so there is room for a few px of ink; the previous formula's own reserve was smaller than
+  // that margin anyway.
+  const int baselineInCellPx = verticalCellBaselineOffset(renderer_, fontId_, cellPx);
+  const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, static_cast<int>(viewportHeight_) / cellPx));
   const int usableWidthPx = std::max(cellPx, static_cast<int>(viewportWidth_) - rightPaddingPx_);
   const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, usableWidthPx / columnAdvancePx));
+  // Columns are anchored to the right edge and march leftwards, so whatever width does not divide
+  // evenly into columns piled up as dead space on the LEFT -- up to a full column plus a gap, and
+  // wider than the margin the reader actually set. Spread that remainder across the gaps instead:
+  // the leftmost column then lands on the left margin, both sides match the setting, and the
+  // columns stay evenly spaced. (x stays >= 0: (N-1) * (advance + leftover/(N-1)) <= usable - cell.)
+  const int leftoverPx = std::max(0, usableWidthPx - cellPx - (columnsPerPage - 1) * columnAdvancePx);
+  const int spreadColumnAdvancePx =
+      columnsPerPage > 1 ? columnAdvancePx + leftoverPx / (columnsPerPage - 1) : columnAdvancePx;
 
   // Index into paragraphBreaksBeforeIndex_ of the *next* paragraph start,
   // so we know when we've crossed into a new paragraph and should force a
@@ -550,7 +591,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Snapshot the geometry for box-rect building: finalizePendingPage() runs OUTSIDE this
   // function and must still be able to close an open box on the final page.
   boxGeomCellPx_ = cellPx;
-  boxGeomColumnAdvancePx_ = columnAdvancePx;
+  boxGeomColumnAdvancePx_ = spreadColumnAdvancePx;
   boxGeomUsableWidthPx_ = usableWidthPx;
   boxGeomRowsPerColumn_ = rowsPerColumn;
 
@@ -737,7 +778,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   uint16_t& column = pendingColumn_;
   uint16_t& row = pendingRow_;
 
-  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - col * columnAdvancePx; };
+  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - col * spreadColumnAdvancePx; };
 
   // Row where a fresh column starts: 0 normally; inside a styled block, the block's start
   // offset (start-Xem), plus the hanging indent (h-indent-Xem) when the column continues a
@@ -783,7 +824,87 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
   };
 
+  // JLREQ 3.1.4, consecutive brackets / commas / full stops / middle dots. Each of these marks
+  // is a half-em glyph occupying one half of its full-em cell, so which halves two neighbours use
+  // decides how much white ends up between their ink:
+  //
+  //   first half (top, in vertical)  - closing brackets, 、。，．
+  //   second half (bottom)           - opening brackets
+  //   centre                         - middle dot ・
+  //
+  // Set solid, a first-half mark followed by a second-half one leaves a WHOLE em of white (the
+  // first's empty tail plus the second's empty head), which the spec reduces to a half em. Every
+  // other combination already lands on its target when set solid, so this one test reproduces the
+  // whole table: 、「 and 」「 close up (figures 3, 4), 」・「 closes up on both sides of the dot
+  // (figure 7), while 。」, ）。, 「『 and ）」 are left alone (figures 1, 2, 5, 6).
+  auto punctEmHalf = [](const uint32_t cp) -> int {  // 0 none, 1 first half, 2 second half, 3 centre
+    if (cp == 0x30FB || cp == 0x00B7) return 3;      // ・
+    switch (Kinsoku::verticalShiftType(cp)) {
+      case 1:
+        return 1;  // 、。，．
+      case 2:
+        return 1;  // closing brackets
+      case 3:
+        return 2;  // opening brackets
+      default:
+        return 0;
+    }
+  };
+  auto applyPunctPairSpacing = [&](const uint32_t cp, const uint16_t columnArg) {
+    if (page.glyphs.empty()) return;
+    const VerticalGlyph& prev = page.glyphs.back();
+    if (prev.column != columnArg || prev.codepoint == 0) return;
+    const int prevHalf = punctEmHalf(prev.codepoint);
+    const int thisHalf = punctEmHalf(cp);
+    if (prevHalf == 0 || thisHalf == 0) return;
+
+    // Every pair in the figures closes up by a half em: 、「 and 」「 go from a full em of white
+    // down to a half (figures 3, 4); 。」, ）。, 「『 and ）」 go from a half em to solid (1, 2, 5,
+    // 6); and 」・「 goes from three quarters to a quarter on each side of the dot (7).
+    int reduction = cellPx / 2;
+
+    // 。and 、 are the exception, because they no longer occupy a whole cell: they end a half em
+    // after their own ink (see commaTighten), so that half em is already gone.
+    //   - an OPENING bracket after them wants exactly that half em -- leave it (figure 3);
+    //   - a CLOSING bracket or another 。/、 is set solid, so take it (figures 1, 2);
+    //   - a middle dot keeps a quarter, so take half of it.
+    if (Kinsoku::verticalShiftType(prev.codepoint) == 1) {
+      if (thisHalf == 2) return;
+      reduction = (thisHalf == 3) ? cellPx / 4 : cellPx / 2;
+    }
+    columnYShift += reduction;
+    shiftColumn = columnArg;
+  };
+
+  // 。and 、 occupy the upper-RIGHT quadrant of their cell in vertical writing. Place them by
+  // their own ink box -- flush to the cell's right edge and to its top -- rather than by shifting
+  // the glyph half a cell, which only approximated it and drifted with the font: these glyphs
+  // are drawn with their ink at the bottom-left of the em, so how far it has to travel depends
+  // entirely on that font's bearings. Returns false when metrics are unavailable.
+  //
+  // centreInHalf picks between the two shapes this is used for:
+  //   。、  - "character advance of full stops and commas is half-width, 1/2 em space after", so
+  //           the mark lives in a HALF-em box at the head of the cell and its ink is centred in
+  //           that box. Pinning the ink to the very top of a full cell instead left about 3/4 em
+  //           of white before the next character.
+  //   small kana - the reference figures put the letter face against the top edge of its box.
+  auto quadrantTopRight = [&](const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
+                              const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) -> bool {
+    int gl = 0, gw = 0, gt = 0, gh = 0;
+    if (!renderer_.getGlyphMetrics(fontId_, cp, static_cast<EpdFontFamily::Style>(style), &gl, &gw, &gt, &gh) ||
+        gw <= 0 || gh <= 0) {
+      return false;
+    }
+    // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
+    const int inkTopInCell = centreInHalf ? std::max(0, (cellPx / 2 - gh) / 2) : 0;
+    *gxOut = columnLeftX(col) + cellPx - gl - gw;
+    *gyOut = std::max(0, rowIdx * cellPx + inkTopInCell + gt - baselineInCellPx);
+    if (inkHeightOut) *inkHeightOut = inkTopInCell + gh;
+    return true;
+  };
+
   auto placeUprightAt = [&](const PendingChar& pc, uint16_t col, uint16_t rowIdx) {
+    applyPunctPairSpacing(pc.codepoint, col);
     VerticalGlyph g;
     g.codepoint = pc.codepoint;
     g.column = col;
@@ -800,23 +921,48 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       g.x = static_cast<uint16_t>(columnLeftX(col));
       g.y = static_cast<uint16_t>(rowIdx * cellPx);
       g.renderKind = VerticalGlyph::RotatedPunct;
+      // JLREQ: an opening bracket at the LINE HEAD has the half em before it removed -- it is set
+      // flush to the head (tentsuki). Its ink normally occupies the second half of its em so it
+      // sits against the character it opens, which at a line head left a visible half-em hole
+      // above it and started every quoted line lower than its neighbours.
+      //
+      // "Line head" means the first glyph of THIS column, not row 0: a styled block (a CSS indent
+      // or hanging indent) opens its column further down, and dialogue paragraphs -- the ones that
+      // actually begin with 「 -- are typically indented, so a row-0 test missed every one of them.
+      // Checked BEFORE the glyph is pushed, since afterwards the bracket is itself the last glyph.
+      const bool atLineHead = page.glyphs.empty() || page.glyphs.back().column != col;
+      const bool flushOpeningBracket = atLineHead && Kinsoku::verticalShiftType(pc.codepoint) == 3;
+      if (flushOpeningBracket) g.lineHeadFlush = 1;
       pushGlyph(page, g, pc.rubyText);
+      if (flushOpeningBracket) {
+        // The half em it no longer needs comes off the rest of the column.
+        columnYShift += cellPx / 2;
+        shiftColumn = col;
+      }
       return;
     }
 
     if (Kinsoku::isSmallKana(pc.codepoint)) {
-      // Keep small kana in normal row flow to avoid overlap with neighboring
-      // glyphs on fonts where "small" forms still have tall ink boxes.
-      // Apply only a light rightward bias inside the cell.
-      g.x = static_cast<uint16_t>(columnLeftX(col) + std::max(1, cellPx / 8));
-      g.y = static_cast<uint16_t>(rowIdx * cellPx + ascender - std::max(1, cellPx / 8));
+      // Small kana (っゃゅょ, ィ ョ ...) sit in the upper-right of their cell in vertical writing --
+      // the reference figures show the letter face against the TOP edge of its box, not centred in
+      // it. Same measured placement as 。and 、: flush to the cell's right edge and to its top,
+      // from the glyph's own ink box rather than an eighth-of-a-cell bias, since how far the ink
+      // has to travel depends entirely on the font's bearings.
+      int qx = 0, qy = 0;
+      if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/false, &qx, &qy)) {
+        g.x = static_cast<uint16_t>(qx);
+        g.y = static_cast<uint16_t>(qy);
+      } else {
+        g.x = static_cast<uint16_t>(columnLeftX(col) + std::max(1, cellPx / 8));
+        g.y = static_cast<uint16_t>(rowIdx * cellPx);
+      }
       g.renderKind = VerticalGlyph::Upright;
       pushGlyph(page, g, pc.rubyText);
       return;
     }
 
     int gx = columnLeftX(col);
-    int gy = rowIdx * cellPx + ascender;
+    int gy = rowIdx * cellPx;
     if (pc.codepoint >= '0' && pc.codepoint <= '9') {
       int left = 0, width = 0, top = 0, height = 0;
       if (renderer_.getGlyphMetrics(fontId_, pc.codepoint, static_cast<EpdFontFamily::Style>(pc.style), &left, &width,
@@ -824,15 +970,30 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         gx = columnLeftX(col) + (cellPx - width) / 2 - left - 1;
       }
     }
+    int commaTighten = 0;
     if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
-      // Comma/period: bottom-left → upper-right of the cell.
-      gx += cellPx / 2;
-      gy -= cellPx / 2;
+      // Comma/period: bottom-left of the em -> upper-right of the cell.
+      int qx = 0, qy = 0, inkH = 0;
+      if (quadrantTopRight(pc.codepoint, pc.style, col, rowIdx, /*centreInHalf=*/true, &qx, &qy, &inkH)) {
+        gx = qx;
+        gy = qy;
+        // These marks do not deserve a whole square: they take the height of their own ink plus a
+        // half em of space, and the next character follows. Whatever is left of the cell after
+        // that comes off the rest of the column, so a comma no longer reads as a full blank cell.
+        commaTighten = std::max(0, cellPx - (inkH + cellPx / 2));
+      } else {
+        gx += cellPx / 2;
+        gy = std::max(0, gy - cellPx / 2);
+      }
     }
     g.x = static_cast<uint16_t>(gx);
     g.y = static_cast<uint16_t>(gy);
     g.renderKind = VerticalGlyph::Upright;
     pushGlyph(page, g, pc.rubyText);
+    if (commaTighten > 0) {
+      columnYShift += commaTighten;
+      shiftColumn = col;
+    }
   };
 
   auto placeUpright = [&](const PendingChar& pc) { placeUprightAt(pc, column, row); };
@@ -920,7 +1081,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     g.column = column;
     g.row = row;
     g.x = static_cast<uint16_t>(std::max(0, runX));
-    g.y = static_cast<uint16_t>(row * cellPx + ascender);
+    g.y = static_cast<uint16_t>(row * cellPx);
     g.paragraphIndex = stream_[i0].paragraphIndex;
     g.byteOffset = stream_[i0].byteOffset;
     g.style = stream_[i0].style;
@@ -963,7 +1124,11 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     if (page.glyphs.empty()) return topYArg;
     const VerticalGlyph& pg = page.glyphs.back();
     if (pg.column != columnArg) return topYArg;
-    int startY = topYArg + std::max(5, cellPx / 4);
+    // Start on the grid; the only reason to push further is a predecessor whose ink actually
+    // reaches into this cell, and that is measured below. The old unconditional quarter-cell
+    // (min 5px) gap was tuned when upright ink was drawn an ascender low, and now just leaves a
+    // visible hole before an embedded Latin word.
+    int startY = topYArg;
     if (pg.renderKind == VerticalGlyph::RotatedPunct) {
       // Brackets are placed from their cell box and hang roughly a full cell lower than that
       // box (「 opens the character in the NEXT cell), so a run that only stepped one cell
@@ -982,7 +1147,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // pg.y already carries this column's slide-up; startY is computed on the raw grid and
         // gets the same slide applied at push time, so compare in raw space.
         const int pgRawY = static_cast<int>(pg.y) + ((pg.column == shiftColumn) ? columnYShift : 0);
-        startY = std::max(startY, pgRawY + ascender - gt + gh);
+        startY = std::max(startY, pgRawY + baselineInCellPx - gt + gh);
       }
     }
     return startY;
@@ -1025,7 +1190,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       const std::string nextChar = encodeCp(next.codepoint);
       renderer_.ensureSdCardFontReady(fontId_, nextChar.c_str(), static_cast<uint8_t>(1u << (next.style & 3)));
       if (renderer_.getGlyphMetrics(fontId_, next.codepoint, nextStyle, &gl, &gw, &gt, &gh) && gh > 0) {
-        offset = 2 * ascender - gt;
+        offset = baselineInCellPx - gt;
       }
     }
     // A miss is worth caching too -- it is the expensive case, and a glyph the font lacks
@@ -1474,13 +1639,31 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     const bool startingNewColumn = page.glyphs.empty() || page.glyphs.back().column < column;
     if (startingNewColumn && !paraBreakJustFired && Kinsoku::isLineStartProhibited(pc.codepoint)) {
       if (!page.glyphs.empty()) {
-        // Oikomi (追い込み): pull this character back into the previous
-        // column as an extra row.
         const VerticalGlyph& prev = page.glyphs.back();
-        placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
-        idx++;
-        continue;
-      } else if (!pages.empty()) {
+        // Oikomi (追い込み) only while the previous column still has a row spare. Nothing used to
+        // check that, so a small kana or 。 arriving at a FULL column was written one row past the
+        // bottom -- printing over the status bar (device photo: 「…とっく」's small っ).
+        if (prev.row + 1 < rowsPerColumn) {
+          placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
+          idx++;
+          continue;
+        }
+        // Oidashi (追い出し): no room to pull it back, so send the character BEFORE it forward
+        // instead and let the pair start this column together. Rewinding one step re-places that
+        // character here through the normal path; this character then follows it and no longer
+        // starts a column, so the rule is satisfied without overrunning the grid.
+        //
+        // Only safe when the previous glyph is this batch's previous stream entry -- with
+        // streamed layout the page can carry glyphs from an earlier batch, and those are not
+        // ours to re-place. Falls back to leaving the character where it is otherwise.
+        if (idx > 0 && prev.byteOffset == stream_[idx - 1].byteOffset &&
+            prev.paragraphIndex == stream_[idx - 1].paragraphIndex) {
+          page.glyphs.pop_back();
+          idx--;
+          continue;
+        }
+      }
+      if (page.glyphs.empty() && !pages.empty()) {
         // Page just broke — pull back to the last column of the previous page.
         VerticalPage& prevPage = pages.back();
         // prevPage.glyphs was reserved for exactly one page's grid capacity when it was created;
@@ -1490,17 +1673,26 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // and heap is tight, skip the pull-back (the character starts the next page/column
         // normally instead) rather than risk it -- a minor formatting nicety, not correctness.
         const bool hasHeadroom = prevPage.glyphs.size() < prevPage.glyphs.capacity();
-        if (!prevPage.glyphs.empty() && (hasHeadroom || ESP.getMaxAllocHeap() >= MIN_FREE_HEAP_FOR_RESERVE)) {
+        // Same bound as the in-page pull-back: only while that column has a row spare, or the
+        // character lands past the bottom of the previous page and over its status bar.
+        const bool prevColumnHasRoom = !prevPage.glyphs.empty() && prevPage.glyphs.back().row + 1 < rowsPerColumn;
+        if (prevColumnHasRoom && (hasHeadroom || ESP.getMaxAllocHeap() >= MIN_FREE_HEAP_FOR_RESERVE)) {
           const VerticalGlyph& prev = prevPage.glyphs.back();
           VerticalGlyph g;
           g.codepoint = pc.codepoint;
           g.column = prev.column;
           g.row = static_cast<uint16_t>(prev.row + 1);
           int gx = columnLeftX(prev.column);
-          int gy = g.row * cellPx + ascender;
+          int gy = g.row * cellPx;
           if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
-            gx += cellPx / 2;
-            gy -= cellPx / 2;
+            int qx = 0, qy = 0;
+            if (quadrantTopRight(pc.codepoint, pc.style, prev.column, g.row, /*centreInHalf=*/true, &qx, &qy)) {
+              gx = qx;
+              gy = qy;
+            } else {
+              gx += cellPx / 2;
+              gy = std::max(0, gy - cellPx / 2);
+            }
           }
           g.x = static_cast<uint16_t>(gx);
           g.y = static_cast<uint16_t>(gy);
@@ -1590,9 +1782,8 @@ void VerticalParsedText::appendBoxRectToPage(VerticalPage& p, const uint16_t sta
   const int gap = boxGeomColumnAdvancePx_ - boxGeomCellPx_;
   const int padX = std::max(2, gap / 2);
   const int padTop = std::max(2, boxGeomCellPx_ / 6);
-  // The last row's glyph ink reaches ascender+descender past its cell top, plus the renderer's
-  // global down-nudge -- and the reference rendering (Apple Books) leaves roughly a full
-  // character of air below the last line. The bottom-reserved strip has the room.
+  // The reference rendering (Apple Books) leaves roughly a full character of air below a boxed
+  // block's last line, and the box may extend past the text area into the bottom margin.
   const int padBottom = std::max(6, (boxGeomCellPx_ * 5) / 4);
   auto colLeft = [&](const uint16_t c) -> int {
     return boxGeomUsableWidthPx_ - boxGeomCellPx_ - static_cast<int>(c) * boxGeomColumnAdvancePx_;

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -1199,7 +1199,24 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   };
 
   size_t idx = 0;
+  size_t suppressKinsokuUntilIdx = 0;  // watchdog escape hatch: place plainly up to here
+  // Kinsoku oidashi rewinds one character (idx--) so a prohibited pair starts a column together.
+  // Re-running the SAME rewind forever is possible when the re-placed character lands right back
+  // at a column end, and the alternating index defeats a naive "stuck on one index" check -- so
+  // this tracks how far the layout has ever got instead. A live-locked build holds the render
+  // lock and freezes the reader, so this must be a bound, not an assumption.
+  size_t highWaterIdx = 0;
+  int spinsSinceProgress = 0;
   while (idx < stream_.size()) {
+    if (idx > highWaterIdx) {
+      highWaterIdx = idx;
+      spinsSinceProgress = 0;
+    } else if (++spinsSinceProgress > 64) {
+      LOG_ERR("VPT", "Layout made no progress past idx=%u (cp=U+%04X col=%u row=%u rows/col=%u); skipping rule",
+              static_cast<unsigned>(idx), stream_[idx].codepoint, column, row, rowsPerColumn);
+      spinsSinceProgress = 0;
+      suppressKinsokuUntilIdx = highWaterIdx + 1;
+    }
     // Emergency page split: the page's glyph vector is effectively full and the heap has no
     // block for the grow-copy. Close the page at this character boundary and continue on a
     // fresh one (whose vector starts small and grows in fragment-sized steps) -- an early
@@ -1607,15 +1624,46 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           idx++;
           continue;
         }
-        // Oidashi (追い出し): send the character BEFORE it forward instead, so the pair starts
-        // this column together. Rewinding one step re-places it through the normal path.
-        // Only safe when that glyph is this batch's previous stream entry -- streamed layout can
-        // leave glyphs from an earlier batch on the page, which are not ours to re-place.
-        if (idx > 0 && prev.byteOffset == stream_[idx - 1].byteOffset &&
+        // JLREQ 3.1.4: 。/、 and a closing bracket after it SHARE one em -- the mark takes the
+        // first half, the bracket the second. The mark is already set tight (commaTighten), so
+        // the half it left free is exactly where the bracket belongs. No new cell is needed, and
+        // neither character has to leave the column its sentence ended in.
+        if (Kinsoku::verticalShiftType(prev.codepoint) == 1 && Kinsoku::verticalShiftType(pc.codepoint) == 2 &&
+            Kinsoku::needsVerticalRotation(pc.codepoint)) {
+          VerticalGlyph g;
+          g.codepoint = pc.codepoint;
+          g.column = prev.column;
+          g.row = prev.row;
+          g.x = static_cast<uint16_t>(columnLeftX(prev.column));
+          // Raw grid position: pushGlyph applies this column's slide, as every other path expects.
+          g.y = static_cast<uint16_t>(prev.row * cellPx + cellPx / 2);
+          g.renderKind = VerticalGlyph::RotatedPunct;
+          g.paragraphIndex = pc.paragraphIndex;
+          g.byteOffset = pc.byteOffset;
+          g.style = pc.style;
+          g.emphasis = pc.emphasis;
+          pushGlyph(page, g, pc.rubyText);
+          idx++;
+          continue;
+        }
+
+        // Oidashi (追い出し): move the character BEFORE this one forward, so the pair starts this
+        // column together (。」 must not be split across columns).
+        //
+        // Move it EXPLICITLY into this column. Popping it and rewinding idx does not work: the
+        // normal path re-places it in the very cell that was just freed, so the bracket is back at
+        // a column head and asks for the same rewind -- forever. That was a live-locked build
+        // holding the render lock, i.e. a frozen reader.
+        //
+        // Only safe when that glyph is this batch's previous stream entry: streamed layout can
+        // leave glyphs from an earlier batch on the page, which are not ours to re-place. And only
+        // when the pair actually fits, so a short column cannot strand the bracket instead.
+        if (idx > 0 && row + 1 < rowsPerColumn && prev.byteOffset == stream_[idx - 1].byteOffset &&
             prev.paragraphIndex == stream_[idx - 1].paragraphIndex) {
           page.glyphs.pop_back();
-          idx--;
-          continue;
+          placeUprightAt(stream_[idx - 1], column, row);
+          row++;
+          // Fall through: this character is placed normally, now one row below its partner.
         }
       }
       if (page.glyphs.empty() && !pages.empty()) {

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <Logging.h>
+#include <Utf8.h>
 
 #include <algorithm>
 #include <cmath>
@@ -26,16 +27,47 @@ namespace {
 // the app is quiescent (largest concurrent needs: SD write buffers and log lines, low KBs). 4KB
 // lets the real page buffer win over fragmenting incremental growth.
 constexpr uint32_t MIN_FREE_HEAP_FOR_RESERVE = 4 * 1024;
+
+// Cushion left for the rest of the app when growing a vector one element at a time, as opposed
+// to MIN_FREE_HEAP_FOR_RESERVE's cushion for a bulk reserve.
+constexpr uint32_t SMALL_ALLOC_MARGIN = 8 * 1024;
+
+// Every reserve() here is one contiguous allocation that ABORTS the process on failure under
+// -fno-exceptions, so nothing may be requested without first checking it fits. `margin` is what
+// the request must leave behind for everything else.
+inline bool heapCanAfford(const size_t bytes, const uint32_t margin) { return ESP.getMaxAllocHeap() >= bytes + margin; }
+
+// Make room for one more push_back. Tries a doubling first (amortised growth), then a small
+// linear step at each margin in turn, most protective first -- so a heap too tight for the
+// doubled request still gets a cheap retry instead of latching. Without that fallback one
+// refusal blocked every later element, since the doubled request never shrinks on its own:
+// confirmed on device as the real cause of "sparse" pages.
+// A margin of 0 is a deliberate last resort where the alternative is losing content outright.
+template <typename T, size_t N>
+bool growForOnePush(std::vector<T>& vec, const uint32_t (&margins)[N], const size_t linearStep) {
+  if (vec.size() < vec.capacity()) return true;  // no reallocation needed, cheap path
+  const size_t doubled = vec.capacity() == 0 ? 1 : vec.capacity() * 2;
+  if (heapCanAfford(doubled * sizeof(T), margins[0])) {
+    vec.reserve(doubled);
+    return true;
+  }
+  const size_t linear = vec.capacity() + linearStep;
+  for (size_t i = 0; i < N; i++) {
+    if (heapCanAfford(linear * sizeof(T), margins[i])) {
+      vec.reserve(linear);
+      return true;
+    }
+  }
+  return false;
+}
 }  // namespace
 
 namespace {
 
-// Minimal local UTF-8 decoder. Deliberately self-contained rather than
-// depending on the project's internal utf8NextCodepoint() (used inside
-// GfxRenderer.cpp) since that helper's visibility/signature wasn't
-// confirmed against the exact checkout this lands on -- swap this out for
-// the shared helper if/when it's exposed publicly, to avoid having two
-// implementations to keep in sync.
+// Index-based UTF-8 decode. The shared utf8NextCodepoint() walks a NUL-terminated buffer via a
+// pointer; this bounds every multi-byte sequence against the string's length instead, so a
+// truncated tail in EPUB markup yields one replacement char rather than reading past the end.
+// Encoding has no such difference and uses utf8AppendCodepoint() directly.
 uint32_t decodeUtf8At(const std::string& s, size_t i, size_t* bytesConsumed) {
   const unsigned char c0 = static_cast<unsigned char>(s[i]);
   if (c0 < 0x80) {
@@ -64,24 +96,7 @@ uint32_t decodeUtf8At(const std::string& s, size_t i, size_t* bytesConsumed) {
 
 std::string encodeCp(uint32_t cp) {
   std::string out;
-  if (cp < 0x80) {
-    out.push_back(static_cast<char>(cp));
-  } else if (cp < 0x800) {
-    out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else if (cp < 0x10000) {
-    out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else {
-    // Supplementary plane (4-byte). Reachable: rare CJK ideographs like U+23D40 (a Vita
-    // Sexualis gaiji) do occur in Aozora-derived EPUBs; the old 3-byte fallthrough emitted an
-    // invalid sequence for them (high bits truncated into a wrong lead byte).
-    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  }
+  utf8AppendCodepoint(cp, out);
   return out;
 }
 
@@ -227,21 +242,39 @@ VerticalParsedText::VerticalParsedText(const GfxRenderer& renderer, int fontId, 
                                        uint16_t viewportHeight)
     : renderer_(renderer), fontId_(fontId), viewportWidth_(viewportWidth), viewportHeight_(viewportHeight) {}
 
-int VerticalParsedText::charAdvancePx() const {
-  // Measure the advance width of a reference CJK character to get the
-  // true em-square size. For CJK fonts this matches advanceY; for
-  // Latin-oriented fonts (NotoSerif) where advanceY includes extra
-  // interline spacing, this gives the correct tighter cell size.
-  // SD fonts measure through their advance table; make sure the reference glyph is in it.
-  // Without this, a freshly loaded SD font (e.g. the JP companion serving as the effective
-  // reader font) measured 漢 as 0 and the cell size fell back to getLineHeight() -- for CJK
-  // fonts that includes interline spacing, blowing cells up from ~1em to ~1.45em (visibly
-  // "very wide" character spacing).
-  renderer_.ensureSdCardFontReady(fontId_, "\xe6\xbc\xa2", 0x01);
-  const int cjkAdvance =
-      renderer_.getTextAdvanceX(fontId_, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));  // 漢
-  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 6;
-  return renderer_.getLineHeight(fontId_);
+bool measureGlyphInk(const GfxRenderer& renderer, const int fontId, const uint32_t cp, const uint8_t style,
+                     GlyphInk* out) {
+  int left = 0, width = 0, top = 0, height = 0;
+  if (!renderer.getGlyphMetrics(fontId, cp, static_cast<EpdFontFamily::Style>(style), &left, &width, &top, &height)) {
+    return false;
+  }
+  *out = GlyphInk{left, width, top, height};
+  return true;
+}
+
+int verticalCellPx(const GfxRenderer& renderer, const int fontId) {
+  // SD fonts measure through their advance table; make sure the reference glyph is in it. A cold
+  // table measures 漢 as 0, and the getLineHeight fallback includes interline spacing -- cells
+  // jump ~1em -> ~1.45em, and layout and draw disagree for that frame.
+  renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
+  const int cjkAdvance = renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));  // 漢
+  if (cjkAdvance > 0) return cjkAdvance;
+  return renderer.getLineHeight(fontId);
+}
+
+int verticalNominalInkGapPx(const GfxRenderer& renderer, const int fontId, const int cellPx) {
+  renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
+  GlyphInk ink;
+  if (!measureGlyphInk(renderer, fontId, 0x6F22 /* 漢 */, 0, &ink) || ink.height <= 0 || ink.height > cellPx) return 0;
+  return cellPx - ink.height;
+}
+
+// Record a paragraph boundary before stream index `idx`, ignoring a repeat at the same index --
+// several sources (a source newline, a run boundary, a carried-over trailing break) can each
+// report the same boundary, and a duplicate would open an extra empty column.
+void VerticalParsedText::recordParagraphBreakAt(const size_t idx) {
+  if (!paragraphBreaksBeforeIndex_.empty() && paragraphBreaksBeforeIndex_.back() == idx) return;
+  paragraphBreaksBeforeIndex_.push_back(idx);
 }
 
 void VerticalParsedText::reserveStreamFor(size_t utf8Bytes) {
@@ -257,7 +290,7 @@ void VerticalParsedText::reserveStreamFor(size_t utf8Bytes) {
   const size_t needed = stream_.size() + slots;
   if (needed <= stream_.capacity()) return;
   const size_t requestBytes = needed * sizeof(PendingChar);
-  if (ESP.getMaxAllocHeap() < requestBytes + MIN_FREE_HEAP_FOR_RESERVE) {
+  if (!heapCanAfford(requestBytes, MIN_FREE_HEAP_FOR_RESERVE)) {
     LOG_ERR("VPT", "Reserve of %u bytes doesn't fit (free=%u); growing incrementally",
             static_cast<unsigned>(requestBytes), ESP.getMaxAllocHeap());
     return;
@@ -269,7 +302,7 @@ void VerticalParsedText::preallocateStream() {
   constexpr size_t STREAM_STABLE_ENTRIES = 512;
   const size_t bytes = STREAM_STABLE_ENTRIES * sizeof(PendingChar);
   if (stream_.capacity() >= STREAM_STABLE_ENTRIES) return;
-  if (ESP.getMaxAllocHeap() >= bytes + MIN_FREE_HEAP_FOR_RESERVE) {
+  if (heapCanAfford(bytes, MIN_FREE_HEAP_FOR_RESERVE)) {
     stream_.reserve(STREAM_STABLE_ENTRIES);
   } else {
     LOG_ERR("VPT", "preallocateStream: %u bytes don't fit (maxAlloc=%u); falling back to incremental growth",
@@ -279,32 +312,10 @@ void VerticalParsedText::preallocateStream() {
 
 bool VerticalParsedText::canPushStreamChar() {
   if (oom_) return false;
-  if (stream_.size() < stream_.capacity()) return true;  // no reallocation needed, cheap path
-  // Same trap as pushGlyph() in layoutPages(): plain doubling means one failed growth attempt
-  // permanently blocks every later char in this batch (oom_ latches, and the doubled request
-  // never gets smaller on its own) -- confirmed on a real device as the actual cause of "sparse"
-  // pages surviving even after pushGlyph() was fixed, because the text never made it into the
-  // stream for layoutPages() to place in the first place. Fall back to a small linear growth step
-  // before giving up, so a later char (after some other allocation frees up) has a real chance.
-  constexpr uint32_t SMALL_ALLOC_MARGIN = 8 * 1024;
+  static constexpr uint32_t MARGINS[] = {SMALL_ALLOC_MARGIN};
   constexpr size_t LINEAR_GROWTH_STEP = 64;  // PendingChar elements; keeps stalled retries cheap
-
-  const size_t doubledCapacity = stream_.capacity() == 0 ? 1 : stream_.capacity() * 2;
-  const size_t doubledBytes = doubledCapacity * sizeof(PendingChar);
-  if (ESP.getMaxAllocHeap() >= doubledBytes + SMALL_ALLOC_MARGIN) {
-    stream_.reserve(doubledCapacity);
-    return true;
-  }
-
-  const size_t linearCapacity = stream_.capacity() + LINEAR_GROWTH_STEP;
-  const size_t linearBytes = linearCapacity * sizeof(PendingChar);
-  if (ESP.getMaxAllocHeap() >= linearBytes + SMALL_ALLOC_MARGIN) {
-    stream_.reserve(linearCapacity);
-    return true;
-  }
-
-  LOG_ERR("VPT", "Low heap (%u bytes, need ~%u) while building vertical text stream; truncating batch",
-          ESP.getMaxAllocHeap(), static_cast<unsigned>(linearBytes));
+  if (growForOnePush(stream_, MARGINS, LINEAR_GROWTH_STEP)) return true;
+  LOG_ERR("VPT", "Low heap (%u bytes) while building vertical text stream; truncating batch", ESP.getMaxAllocHeap());
   oom_ = true;
   everDroppedForHeap_ = true;
   return false;
@@ -331,9 +342,7 @@ void VerticalParsedText::addParagraph(const std::string& utf8Text) {
     // Keep explicit source line breaks as hard vertical column breaks.
     // Tabs are still ignored.
     if (cp == '\n' || cp == '\r') {
-      if (paragraphBreaksBeforeIndex_.empty() || paragraphBreaksBeforeIndex_.back() != stream_.size()) {
-        paragraphBreaksBeforeIndex_.push_back(stream_.size());
-      }
+      recordParagraphBreakAt(stream_.size());
       i += consumed;
       continue;
     }
@@ -364,9 +373,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
   // This is DELIBERATELY independent of continuesPreviousParagraph: the flag comes from a
   // real newline in the source, not from the sink's memory-bound chunking.
   if (pendingTrailingBreak_) {
-    if (paragraphBreaksBeforeIndex_.empty() || paragraphBreaksBeforeIndex_.back() != stream_.size()) {
-      paragraphBreaksBeforeIndex_.push_back(stream_.size());
-    }
+    recordParagraphBreakAt(stream_.size());
     pendingTrailingBreak_ = false;
   }
 
@@ -441,10 +448,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
     // into the current column.
     if (baseCps.empty()) {
       for (size_t relIdx : breakBeforeBaseIndex) {
-        const size_t absBreakIdx = stream_.size() + relIdx;  // relIdx is always 0 here
-        if (paragraphBreaksBeforeIndex_.empty() || paragraphBreaksBeforeIndex_.back() != absBreakIdx) {
-          paragraphBreaksBeforeIndex_.push_back(absBreakIdx);
-        }
+        recordParagraphBreakAt(stream_.size() + relIdx);  // relIdx is always 0 here
       }
       continue;
     }
@@ -479,24 +483,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
         const size_t rubyStart = rubyCount * k / baseCount;
         const size_t rubyEnd = rubyCount * (k + 1) / baseCount;
         std::string slice;
-        for (size_t r = rubyStart; r < rubyEnd; r++) {
-          const uint32_t rcp = rubyCps[r];
-          if (rcp < 0x80) {
-            slice.push_back(static_cast<char>(rcp));
-          } else if (rcp < 0x800) {
-            slice.push_back(static_cast<char>(0xC0 | (rcp >> 6)));
-            slice.push_back(static_cast<char>(0x80 | (rcp & 0x3F)));
-          } else if (rcp < 0x10000) {
-            slice.push_back(static_cast<char>(0xE0 | (rcp >> 12)));
-            slice.push_back(static_cast<char>(0x80 | ((rcp >> 6) & 0x3F)));
-            slice.push_back(static_cast<char>(0x80 | (rcp & 0x3F)));
-          } else {
-            slice.push_back(static_cast<char>(0xF0 | (rcp >> 18)));
-            slice.push_back(static_cast<char>(0x80 | ((rcp >> 12) & 0x3F)));
-            slice.push_back(static_cast<char>(0x80 | ((rcp >> 6) & 0x3F)));
-            slice.push_back(static_cast<char>(0x80 | (rcp & 0x3F)));
-          }
-        }
+        for (size_t r = rubyStart; r < rubyEnd; r++) utf8AppendCodepoint(rubyCps[r], slice);
         if (!canPushStreamChar()) return;
         stream_.push_back(PendingChar{baseCps[k], paragraphIndex, static_cast<uint32_t>(baseOffsets[k]), run.style,
                                       run.emphasis, std::move(slice)});
@@ -504,10 +491,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
     }
 
     for (size_t relIdx : breakBeforeBaseIndex) {
-      const size_t absBreakIdx = runStartStreamIndex + relIdx;
-      if (paragraphBreaksBeforeIndex_.empty() || paragraphBreaksBeforeIndex_.back() != absBreakIdx) {
-        paragraphBreaksBeforeIndex_.push_back(absBreakIdx);
-      }
+      recordParagraphBreakAt(runStartStreamIndex + relIdx);
     }
   }
 }
@@ -516,15 +500,13 @@ int verticalCellBaselineOffset(const GfxRenderer& renderer, const int fontId, co
   const int ascender = renderer.getFontAscenderSize(fontId);
   // String literal, no allocation -- this is called from the pagination path.
   renderer.ensureSdCardFontReady(fontId, "\xe4\xb8\xad", 0x01);
-  int left = 0, width = 0, top = 0, height = 0;
-  if (!renderer.getGlyphMetrics(fontId, 0x4E2D /* 中 */, static_cast<EpdFontFamily::Style>(0), &left, &width, &top,
-                                &height) ||
-      height <= 0 || height > cellPx * 2) {
+  GlyphInk ink;
+  if (!measureGlyphInk(renderer, fontId, 0x4E2D /* 中 */, 0, &ink) || ink.height <= 0 || ink.height > cellPx * 2) {
     return ascender;
   }
   // getGlyphMetrics reports `top` as the ink top ABOVE the baseline, so centring the ink box in
   // the cell puts the baseline at (cell - inkHeight)/2 + top below the cell's top edge.
-  return (cellPx - height) / 2 + top;
+  return (cellPx - ink.height) / 2 + ink.top;
 }
 
 std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCallback onPageReady, bool isFinalFlush) {
@@ -545,8 +527,10 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Coordinate convention, uniform for every RenderKind: VerticalGlyph::y is the TOP of the
   // glyph's cell, never a baseline -- baselines belong to drawing, which converts per draw call
   // (see VerticalTextBlock::drawGlyphs). Ink offsets come from verticalCellBaselineOffset().
-  const int cellPx = std::max(1, charAdvancePx());
+  const int cellPx = std::max(1, verticalCellPx(renderer_, fontId_));
   const int columnAdvancePx = cellPx + columnGapPx_;
+  // What a normal grid-adjacent pair leaves between its ink boxes; off-grid runs match it.
+  const int inkGapPx = verticalNominalInkGapPx(renderer_, fontId_, cellPx);
   const int ascender = renderer_.getFontAscenderSize(fontId_);
   // As many whole cells as the text area's height allows. The last row's ink hangs a few px past
   // its cell; that goes in the margin below (screenMargin + status bar), just as ruby goes in the
@@ -607,7 +591,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   {
     const size_t worstCasePages = stream_.size() / std::max<size_t>(1, columnsPerPage) + 2;
     const size_t requestBytes = worstCasePages * sizeof(VerticalPage);
-    if (ESP.getMaxAllocHeap() >= requestBytes + MIN_FREE_HEAP_FOR_RESERVE) {
+    if (heapCanAfford(requestBytes, MIN_FREE_HEAP_FOR_RESERVE)) {
       pages.reserve(worstCasePages);
     } else {
       LOG_ERR("VPT", "Skipping pages reserve (%u bytes doesn't fit, free=%u); growing incrementally",
@@ -621,7 +605,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // memory use during its own relocation). Check the request against free heap every time.
   auto reservePageGlyphs = [&](VerticalPage& p) {
     const size_t requestBytes = glyphsPerPage * sizeof(VerticalGlyph);
-    if (ESP.getMaxAllocHeap() >= requestBytes + MIN_FREE_HEAP_FOR_RESERVE) {
+    if (heapCanAfford(requestBytes, MIN_FREE_HEAP_FOR_RESERVE)) {
       p.glyphs.reserve(glyphsPerPage);
       return;
     }
@@ -635,7 +619,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     for (size_t fraction = 2; fraction <= 8; fraction *= 2) {
       const size_t partial = glyphsPerPage / fraction;
       if (partial < 32) break;
-      if (ESP.getMaxAllocHeap() >= (partial * sizeof(VerticalGlyph)) + MIN_FREE_HEAP_FOR_RESERVE) {
+      if (heapCanAfford(partial * sizeof(VerticalGlyph), MIN_FREE_HEAP_FOR_RESERVE)) {
         p.glyphs.reserve(partial);
         LOG_DBG("VPT", "Partial page glyphs reserve: %u/%u elements (maxAlloc=%u)", static_cast<unsigned>(partial),
                 static_cast<unsigned>(glyphsPerPage), ESP.getMaxAllocHeap());
@@ -692,57 +676,19 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // slides it down (ink that leaves its own cell, e.g. the low ellipsis dot stack).
       g.y = static_cast<uint16_t>(std::max(0, static_cast<int>(g.y) - columnYShift));
     }
-    if (glyphs.size() < glyphs.capacity()) {
+    // Tiers, most protective first. The 4K tier: device evidence (450+ page chapter) showed
+    // maxAlloc dips bottoming at 14324 while the linear request sat at ~9216 -- the 8K margin
+    // missed by 12 bytes, dropped glyphs, and the stale mark re-indexed the chapter on every
+    // open. The 0 tier: at that point the margin protects only allocations that fail gracefully
+    // and retry (font advance tables, staging buffers, the next page's reserve), while a dropped
+    // glyph is a character permanently missing from the page.
+    static constexpr uint32_t MARGINS[] = {SMALL_ALLOC_MARGIN, 4 * 1024, 0};
+    constexpr size_t LINEAR_GROWTH_STEP = 16;  // elements; keeps a stalled page's retries cheap
+    if (growForOnePush(glyphs, MARGINS, LINEAR_GROWTH_STEP)) {
       glyphs.push_back(g);
       return true;
     }
-    constexpr uint32_t SMALL_ALLOC_MARGIN = 8 * 1024;  // headroom for the rest of the app, not the reserve() margin
-    constexpr size_t LINEAR_GROWTH_STEP = 16;          // elements; keeps a stalled page's retries cheap
-
-    const size_t doubledCapacity = glyphs.capacity() == 0 ? 1 : glyphs.capacity() * 2;
-    const size_t doubledBytes = doubledCapacity * sizeof(VerticalGlyph);
-    if (ESP.getMaxAllocHeap() >= doubledBytes + SMALL_ALLOC_MARGIN) {
-      glyphs.reserve(doubledCapacity);
-      glyphs.push_back(g);
-      return true;
-    }
-
-    const size_t linearCapacity = glyphs.capacity() + LINEAR_GROWTH_STEP;
-    const size_t linearBytes = linearCapacity * sizeof(VerticalGlyph);
-    if (ESP.getMaxAllocHeap() >= linearBytes + SMALL_ALLOC_MARGIN) {
-      glyphs.reserve(linearCapacity);
-      glyphs.push_back(g);
-      return true;
-    }
-
-    // Last resort before CONTENT LOSS: accept half the margin. Device evidence (whole-book
-    // chapter, 450+ pages): maxAlloc dips bottomed at 14324/17396 while linearBytes sat at
-    // ~9216 -- the 8K margin missed by 12 bytes, dropped glyphs, and the stale-mark then
-    // re-indexed the chapter on every open. 4K clears every observed dip; briefly dipping
-    // into the safety margin for a block that the page flush frees moments later is strictly
-    // better than losing content and looping the rebuild.
-    constexpr uint32_t LINEAR_LAST_RESORT_MARGIN = 4 * 1024;
-    if (ESP.getMaxAllocHeap() >= linearBytes + LINEAR_LAST_RESORT_MARGIN) {
-      glyphs.reserve(linearCapacity);
-      glyphs.push_back(g);
-      return true;
-    }
-
-    // Final zero-margin attempt before CONTENT LOSS. At this point the margin no longer
-    // shields anything that outranks the text itself: the allocations it protects (font
-    // advance tables, staging buffers, the next page's reserve) all fail gracefully and
-    // retry later, while a dropped glyph is a character permanently missing from the page.
-    // Device evidence across three instrumented whole-book builds: every observed drop
-    // burst (need 8064 @ 11764 free, 10368 @ 10740 and even 14324, 11736 @ 12788) had the
-    // block itself available and died only on the margin check.
-    if (ESP.getMaxAllocHeap() >= linearBytes) {
-      glyphs.reserve(linearCapacity);
-      glyphs.push_back(g);
-      return true;
-    }
-
-    LOG_ERR("VPT", "Low heap (%u bytes, need ~%u); dropping glyph", ESP.getMaxAllocHeap(),
-            static_cast<unsigned>(linearBytes));
+    LOG_ERR("VPT", "Low heap (%u bytes); dropping glyph", ESP.getMaxAllocHeap());
     everDroppedForHeap_ = true;
     return false;
   };
@@ -862,16 +808,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   //   small kana - letter face against the top edge of its box
   auto quadrantTopRight = [&](const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
                               const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) -> bool {
-    int gl = 0, gw = 0, gt = 0, gh = 0;
-    if (!renderer_.getGlyphMetrics(fontId_, cp, static_cast<EpdFontFamily::Style>(style), &gl, &gw, &gt, &gh) ||
-        gw <= 0 || gh <= 0) {
-      return false;
-    }
+    GlyphInk ink;
+    if (!measureGlyphInk(renderer_, fontId_, cp, style, &ink) || ink.width <= 0 || ink.height <= 0) return false;
     // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
-    const int inkTopInCell = centreInHalf ? std::max(0, (cellPx / 2 - gh) / 2) : 0;
-    *gxOut = columnLeftX(col) + cellPx - gl - gw;
-    *gyOut = std::max(0, rowIdx * cellPx + inkTopInCell + gt - baselineInCellPx);
-    if (inkHeightOut) *inkHeightOut = inkTopInCell + gh;
+    const int inkTopInCell = centreInHalf ? std::max(0, (cellPx / 2 - ink.height) / 2) : 0;
+    *gxOut = columnLeftX(col) + cellPx - ink.left - ink.width;
+    *gyOut = std::max(0, rowIdx * cellPx + inkTopInCell + ink.top - baselineInCellPx);
+    if (inkHeightOut) *inkHeightOut = inkTopInCell + ink.height;
     return true;
   };
 
@@ -927,10 +870,9 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     int gx = columnLeftX(col);
     int gy = rowIdx * cellPx;
     if (pc.codepoint >= '0' && pc.codepoint <= '9') {
-      int left = 0, width = 0, top = 0, height = 0;
-      if (renderer_.getGlyphMetrics(fontId_, pc.codepoint, static_cast<EpdFontFamily::Style>(pc.style), &left, &width,
-                                    &top, &height)) {
-        gx = columnLeftX(col) + (cellPx - width) / 2 - left - 1;
+      GlyphInk ink;
+      if (measureGlyphInk(renderer_, fontId_, pc.codepoint, pc.style, &ink)) {
+        gx = columnLeftX(col) + (cellPx - ink.width) / 2 - ink.left;
       }
     }
     int commaTighten = 0;
@@ -969,27 +911,14 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Exclamation/question marks that books put in tate-chu-yoko pairs (!? / !!).
   // Halfwidth only: fullwidth ！？ already render upright as normal CJK cells.
   auto isBangOrQuestion = [](uint32_t cp) { return cp == '!' || cp == '?'; };
-  auto encodeDigitUtf8 = [](uint32_t cp, std::string& out) {
-    if (cp < 0x80) {
-      out.push_back(static_cast<char>(cp));
-    } else if (cp < 0x800) {
-      out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-    } else if (cp < 0x10000) {
-      out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-    }
-  };
-
   // Place a two-character tate-chu-yoko run (a 2-digit number like 26, or a
   // !?/!! pair) upright in a single cell, ink-centered on the column, and
   // advance row/column past it. Shared by the digit and punctuation-pair
   // branches in the loop below.
   auto placeTcyPairAt = [&](size_t i0) {
     std::string runUtf8;
-    encodeDigitUtf8(stream_[i0].codepoint, runUtf8);
-    encodeDigitUtf8(stream_[i0 + 1].codepoint, runUtf8);
+    utf8AppendCodepoint(stream_[i0].codepoint, runUtf8);
+    utf8AppendCodepoint(stream_[i0 + 1].codepoint, runUtf8);
     // Measure with the pair's ACTUAL style -- rendered with g.style, and bold digits are
     // wider, so an unstyled measurement mis-centers the pair in its cell.
     const auto tcyStyle = static_cast<EpdFontFamily::Style>(stream_[i0].style);
@@ -1009,7 +938,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       if (renderer_.getGlyphMetrics(fontId_, cpFirst, tcyStyle, &l1, &w1, &t1, &h1) &&
           renderer_.getGlyphMetrics(fontId_, cpLast, tcyStyle, &lN, &wN, &tN, &hN)) {
         std::string lastUtf8;
-        encodeDigitUtf8(cpLast, lastUtf8);
+        utf8AppendCodepoint(cpLast, lastUtf8);
         const int lastAdvance = renderer_.getRenderAdvanceX(fontId_, lastUtf8.c_str(), tcyStyle);
         // Ink spans pen+l1 .. pen+(runWidthPx-lastAdvance)+lN+wN.
         const int inkWidth = (runWidthPx - lastAdvance + lN + wN) - l1;
@@ -1020,8 +949,10 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           // -max(4, cellPx/4) was tuned on one photo/font (Kyokasho, 「築26年」) and
           // over-corrected elsewhere -- device photo: 「10年」 sat a quarter cell LEFT of the
           // column in Mincho. Measure the 中 reference glyph's ink center at this size/style
-          // and use its delta from the cell center, clamped so a metrics outlier can't fling
-          // the pair off-axis. Falls back to plain ink centering when metrics are unavailable.
+          // and use its delta from the cell center. A well-formed full-width glyph cannot be
+          // off-centre by more than its own side bearing, so that bounds the delta and a metrics
+          // outlier can't fling the pair off-axis.
+          // Falls back to plain ink centering when metrics are unavailable.
           int cjkDelta = 0;
           int kl = 0, kw = 0, kt = 0, kh = 0;
           // String literal, no allocation -- this sits in the pagination path (review finding:
@@ -1029,7 +960,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           renderer_.ensureSdCardFontReady(fontId_, "\xe4\xb8\xad", tcyStyleBit);
           if (renderer_.getGlyphMetrics(fontId_, 0x4E2D /* 中 */, tcyStyle, &kl, &kw, &kt, &kh) && kw > 0) {
             cjkDelta = (kl + kw / 2) - cellPx / 2;
-            const int clampPx = std::max(2, cellPx / 8);
+            const int clampPx = std::max(1, (cellPx - kw) / 2);
             if (cjkDelta > clampPx) cjkDelta = clampPx;
             if (cjkDelta < -clampPx) cjkDelta = -clampPx;
           }
@@ -1097,17 +1028,15 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       if (renderer_.verticalPunctInkBox(fontId_, pg.codepoint, static_cast<EpdFontFamily::Style>(pg.style),
                                         static_cast<int>(pg.y), cellPx, Kinsoku::verticalShiftType(pg.codepoint),
                                         &inkTop, &inkHeight)) {
-        startY = std::max(startY, inkTop + inkHeight + std::max(3, cellPx / 8));
+        startY = std::max(startY, inkTop + inkHeight + inkGapPx);
       }
     } else if (pg.renderKind == VerticalGlyph::Upright && pg.codepoint != 0) {
-      int gl = 0, gw = 0, gt = 0, gh = 0;
-      if (renderer_.getGlyphMetrics(fontId_, pg.codepoint, static_cast<EpdFontFamily::Style>(pg.style), &gl, &gw, &gt,
-                                    &gh) &&
-          gh > 0) {
+      GlyphInk ink;
+      if (measureGlyphInk(renderer_, fontId_, pg.codepoint, pg.style, &ink) && ink.height > 0) {
         // pg.y already carries this column's slide-up; startY is computed on the raw grid and
         // gets the same slide applied at push time, so compare in raw space.
         const int pgRawY = static_cast<int>(pg.y) + ((pg.column == shiftColumn) ? columnYShift : 0);
-        startY = std::max(startY, pgRawY + baselineInCellPx - gt + gh);
+        startY = std::max(startY, pgRawY + baselineInCellPx - ink.top + ink.height);
       }
     }
     return startY;
@@ -1144,13 +1073,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         offset = inkTop;
       }
     } else {
-      int gl = 0, gw = 0, gt = 0, gh = 0;
       // Metrics for a glyph the SD font has not paged in yet come back empty, which silently
       // disabled the tail allowance; page the one character in first.
       const std::string nextChar = encodeCp(next.codepoint);
       renderer_.ensureSdCardFontReady(fontId_, nextChar.c_str(), static_cast<uint8_t>(1u << (next.style & 3)));
-      if (renderer_.getGlyphMetrics(fontId_, next.codepoint, nextStyle, &gl, &gw, &gt, &gh) && gh > 0) {
-        offset = baselineInCellPx - gt;
+      GlyphInk ink;
+      if (measureGlyphInk(renderer_, fontId_, next.codepoint, next.style, &ink) && ink.height > 0) {
+        offset = baselineInCellPx - ink.top;
       }
     }
     // A miss is worth caching too -- it is the expensive case, and a glyph the font lacks
@@ -1162,7 +1091,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Rows the run occupies: enough that the next character's ink clears the run's, no more.
   auto rotatedRunRows = [&](const int startY, const int inkWidthPx, const uint16_t rowArg,
                             const int nextInkOffset) -> uint16_t {
-    const int intrusion = (nextInkOffset >= 0) ? std::max(0, nextInkOffset - 2) : 0;
+    const int intrusion = (nextInkOffset >= 0) ? nextInkOffset : 0;
     const int endRow = static_cast<int>(std::ceil(static_cast<double>(startY + inkWidthPx - intrusion) / cellPx));
     return static_cast<uint16_t>(std::max(1, endRow - static_cast<int>(rowArg)));
   };
@@ -1179,10 +1108,12 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     if (c0 >= 0xC0 && lastChar.size() >= 2) {
       lastCp = static_cast<uint32_t>(c0 & 0x1F) << 6 | (static_cast<unsigned char>(lastChar[1]) & 0x3F);
     }
-    int gl = 0, gw = 0, gt = 0, gh = 0;
-    if (!renderer_.getGlyphMetrics(fontId_, lastCp, style, &gl, &gw, &gt, &gh) || gw <= 0) return advanceWidth;
+    GlyphInk ink;
+    if (!measureGlyphInk(renderer_, fontId_, lastCp, static_cast<uint8_t>(style), &ink) || ink.width <= 0) {
+      return advanceWidth;
+    }
     const int lastAdvance = renderer_.getRenderAdvanceX(fontId_, lastChar.c_str(), style);
-    return advanceWidth - std::max(0, lastAdvance - (gl + gw));
+    return advanceWidth - std::max(0, lastAdvance - (ink.left + ink.width));
   };
 
   // Take up the cell-rounding leftover after a run: the rest of the column slides up by it, so
@@ -1191,7 +1122,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
                             const int nextInkOffset) {
     if (nextInkOffset < 0 || rowAfter >= rowsPerColumn) return;
     const int nextGridInkTop = rowAfter * cellPx + nextInkOffset;
-    const int slack = nextGridInkTop - (startY + inkWidthPx) - std::max(3, cellPx / 8);
+    const int slack = nextGridInkTop - (startY + inkWidthPx) - inkGapPx;
     if (slack > 0) {
       columnYShift += slack;
       shiftColumn = columnArg;
@@ -1354,7 +1285,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       if (digitCount > 2) {
         std::string runUtf8;
         for (size_t i = idx; i < digitEnd; i++) {
-          encodeDigitUtf8(stream_[i].codepoint, runUtf8);
+          utf8AppendCodepoint(stream_[i].codepoint, runUtf8);
         }
 
         // Render-truth measurement with the run's ACTUAL style: getRenderAdvanceX resolves
@@ -1614,7 +1545,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     // order, so the last glyph sitting in an earlier column (or an empty page) means this
     // character would be the column's first.
     const bool startingNewColumn = page.glyphs.empty() || page.glyphs.back().column < column;
-    if (startingNewColumn && !paraBreakJustFired && Kinsoku::isLineStartProhibited(pc.codepoint)) {
+    if (startingNewColumn && !paraBreakJustFired && idx >= suppressKinsokuUntilIdx &&
+        Kinsoku::isLineStartProhibited(pc.codepoint)) {
       if (!page.glyphs.empty()) {
         const VerticalGlyph& prev = page.glyphs.back();
         // Oikomi (追い込み) only while the previous column has a row spare -- otherwise it writes
@@ -1742,9 +1674,9 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           renderer_.verticalPunctInkBox(fontId_, pc.codepoint, static_cast<EpdFontFamily::Style>(pc.style),
                                         placedRow * cellPx, cellPx, Kinsoku::verticalShiftType(pc.codepoint), &inkTop,
                                         &inkHeight)) {
-        // Half a cell of clearance, not the usual eighth: the dots sit low in their cell and
-        // still read tight against the next character at the nominal distance (device check).
-        const int deficit = (inkTop + inkHeight + std::max(3, cellPx / 2)) - (row * cellPx + nextInkOffset);
+        // The dots sit low in their cell, so close the resulting overlap down to the same ink
+        // gap a normal pair of characters leaves.
+        const int deficit = (inkTop + inkHeight + inkGapPx) - (row * cellPx + nextInkOffset);
         if (deficit > 0) {
           columnYShift -= deficit;
           shiftColumn = column;
@@ -1782,11 +1714,13 @@ void VerticalParsedText::appendBoxRectToPage(VerticalPage& p, const uint16_t sta
                                              const bool openLeft, const bool openRight) const {
   if (boxGeomCellPx_ <= 0 || activeBlock_.borderEdges == 0) return;
   const int gap = boxGeomColumnAdvancePx_ - boxGeomCellPx_;
+  // Sideways: the border sits on the column axis, i.e. halfway across the gap it runs in.
+  // Lengthwise: the same half-gap at the head, and a full character of air at the foot -- the
+  // reference rendering (Apple Books) sets the last line one character clear of the rule. The
+  // box may extend past the text area into the bottom margin.
   const int padX = std::max(2, gap / 2);
-  const int padTop = std::max(2, boxGeomCellPx_ / 6);
-  // The reference rendering (Apple Books) leaves roughly a full character of air below a boxed
-  // block's last line, and the box may extend past the text area into the bottom margin.
-  const int padBottom = std::max(6, (boxGeomCellPx_ * 5) / 4);
+  const int padTop = padX;
+  const int padBottom = boxGeomCellPx_;
   auto colLeft = [&](const uint16_t c) -> int {
     return boxGeomUsableWidthPx_ - boxGeomCellPx_ - static_cast<int>(c) * boxGeomColumnAdvancePx_;
   };

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -551,26 +551,46 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Coordinate convention, uniform for every RenderKind: VerticalGlyph::y is the TOP of the
   // glyph's cell, never a baseline -- baselines belong to drawing, which converts per draw call
   // (see VerticalTextBlock::drawGlyphs). Ink offsets come from verticalCellBaselineOffset().
-  const int cellPx = std::max(1, verticalCellPx(renderer_, fontId_));
+  // Measured once per chapter, not per paragraph -- see the memo fields' comment.
+  bool metricOk = false;
+  int cellPxNow = cellPxMemo_;
+  if (cellPxNow <= 0) {
+    cellPxNow = verticalCellPx(renderer_, fontId_, &metricOk);
+    if (metricOk) cellPxMemo_ = cellPxNow;
+  }
+  const int cellPx = std::max(1, cellPxNow);
   const int columnAdvancePx = cellPx + columnGapPx_;
   // What a normal grid-adjacent pair leaves between its ink boxes; off-grid runs match it.
-  const int inkGapPx = verticalNominalInkGapPx(renderer_, fontId_, cellPx);
+  int inkGapNow = inkGapPxMemo_;
+  if (inkGapNow < 0) {
+    metricOk = false;
+    inkGapNow = verticalNominalInkGapPx(renderer_, fontId_, cellPx, &metricOk);
+    if (metricOk) inkGapPxMemo_ = inkGapNow;
+  }
+  const int inkGapPx = inkGapNow;
   const int ascender = renderer_.getFontAscenderSize(fontId_);
   // As many whole cells as the text area's height allows. The last row's ink hangs a few px past
   // its cell; that goes in the margin below (screenMargin + status bar), just as ruby goes in the
   // margin beside the text (JLREQ Fig 2.37). Reserving it here instead costs a whole character
   // per column whenever the height divides evenly.
-  const int baselineInCellPx = verticalCellBaselineOffset(renderer_, fontId_, cellPx);
+  int baselineNow = baselineInCellMemo_;
+  if (baselineNow < 0) {
+    metricOk = false;
+    baselineNow = verticalCellBaselineOffset(renderer_, fontId_, cellPx, &metricOk);
+    if (metricOk) baselineInCellMemo_ = baselineNow;
+  }
+  const int baselineInCellPx = baselineNow;
   const uint16_t rowsPerColumn = static_cast<uint16_t>(std::max(1, static_cast<int>(viewportHeight_) / cellPx));
   const int usableWidthPx = std::max(cellPx, static_cast<int>(viewportWidth_) - rightPaddingPx_);
   const uint16_t columnsPerPage = static_cast<uint16_t>(std::max(1, usableWidthPx / columnAdvancePx));
   // Columns are anchored to the right edge and march leftwards, so the width that does not divide
-  // evenly into columns would pile up as dead space on the LEFT. Spread it across the gaps: the
-  // leftmost column lands on the left margin and the columns stay evenly spaced.
-  // (x stays >= 0: (N-1) * (advance + leftover/(N-1)) <= usable - cell.)
+  // evenly into columns would pile up as dead space on the LEFT. Split it between the two margins
+  // instead of adding it to the gaps: the gap is 行間, set in quarter ems by the line-spacing
+  // setting (and by whether furigana needs room in it), so widening it here overrides the very
+  // rule that chose it -- measurably, a 21px gap became 25px against a 29px em.
+  // (x stays >= 0: the leftmost column sits at leftover - leftover/2.)
   const int leftoverPx = std::max(0, usableWidthPx - cellPx - (columnsPerPage - 1) * columnAdvancePx);
-  const int spreadColumnAdvancePx =
-      columnsPerPage > 1 ? columnAdvancePx + leftoverPx / (columnsPerPage - 1) : columnAdvancePx;
+  const int blockShiftPx = leftoverPx / 2;
 
   // Index into paragraphBreaksBeforeIndex_ of the *next* paragraph start,
   // so we know when we've crossed into a new paragraph and should force a
@@ -585,8 +605,10 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // Snapshot the geometry for box-rect building: finalizePendingPage() runs OUTSIDE this
   // function and must still be able to close an open box on the final page.
   boxGeomCellPx_ = cellPx;
-  boxGeomColumnAdvancePx_ = spreadColumnAdvancePx;
-  boxGeomUsableWidthPx_ = usableWidthPx;
+  boxGeomColumnAdvancePx_ = columnAdvancePx;
+  // Fold the block shift in here: appendBoxRectToPage's colLeft is columnLeftX with the shift
+  // already applied, so the two must not drift apart.
+  boxGeomUsableWidthPx_ = usableWidthPx - blockShiftPx;
   boxGeomRowsPerColumn_ = rowsPerColumn;
 
   // Re-record box markers carried across a batch boundary (see reset()) at index 0.
@@ -734,7 +756,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   uint16_t& column = pendingColumn_;
   uint16_t& row = pendingRow_;
 
-  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - col * spreadColumnAdvancePx; };
+  auto columnLeftX = [&](uint16_t col) -> int { return usableWidthPx - cellPx - blockShiftPx - col * columnAdvancePx; };
 
   // Row where a fresh column starts: 0 normally; inside a styled block, the block's start
   // offset (start-Xem), plus the hanging indent (h-indent-Xem) when the column continues a

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -330,16 +330,18 @@ struct ColumnGeometry {
   int columnLeftX(const uint16_t col) const { return usableWidthPx - cellPx - static_cast<int>(col) * columnAdvancePx; }
 };
 
-// Upper-RIGHT quadrant placement, from the glyph's own ink box: 。、 are drawn with their ink at
-// the bottom-left of the em, so how far it must travel is font-specific. False when metrics are
-// unavailable, which every caller has a fallback for.
-//
-// centreInHalf distinguishes the two users:
-//   。、        - ink centred in a half-em box at the cell's head
-//   small kana - letter face against the TOP edge of its box
-bool quadrantTopRight(const GfxRenderer& renderer, const int fontId, InkMemo& memo, const ColumnGeometry& geom,
-                      const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
-                      const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) {
+// Where a right-aligned mark's ink sits along the column.
+enum class InkVAlign : uint8_t {
+  HalfEmHead,  // 。、 -- centred in the FIRST half em, so the second half is free (JLREQ 3.1.4)
+  Centre,      // small kana -- centred in the full em (JLREQ A.11)
+};
+
+// Places a mark's letter face against the RIGHT edge of its cell, from the glyph's own ink box:
+// these characters are drawn toward the bottom-left of the em, so how far the face must travel is
+// font-specific. False when metrics are unavailable, which every caller has a fallback for.
+bool rightAlignedInk(const GfxRenderer& renderer, const int fontId, InkMemo& memo, const ColumnGeometry& geom,
+                     const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
+                     const InkVAlign vAlign, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) {
   GlyphInk ink;
   if (!memo.lookup(cp, style, &ink)) {
     if (!measureGlyphInk(renderer, fontId, cp, style, &ink)) return false;
@@ -347,7 +349,8 @@ bool quadrantTopRight(const GfxRenderer& renderer, const int fontId, InkMemo& me
   }
   if (ink.width <= 0 || ink.height <= 0) return false;
   // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
-  const int inkTopInCell = centreInHalf ? std::max(0, (geom.cellPx / 2 - ink.height) / 2) : 0;
+  const int inkTopInCell = vAlign == InkVAlign::HalfEmHead ? std::max(0, (geom.cellPx / 2 - ink.height) / 2)
+                                                           : std::max(0, (geom.cellPx - ink.height) / 2);
   *gxOut = geom.columnLeftX(col) + geom.cellPx - ink.left - ink.width;
   *gyOut = std::max(0, rowIdx * geom.cellPx + inkTopInCell + ink.top - geom.baselineInCellPx);
   if (inkHeightOut) *inkHeightOut = inkTopInCell + ink.height;
@@ -916,10 +919,12 @@ struct VerticalParsedText::LayoutCursor {
     }
 
     if (Kinsoku::isSmallKana(pc.codepoint)) {
-      // Small kana (っゃゅょ ィ ョ) sit upper-right, letter face against the TOP edge of the box.
+      // JLREQ A.11: in vertical writing the letter face of a small kana (cl-11: ぁぃぅ ァィゥ っゃゅょ)
+      // is centred VERTICALLY in the frame and set right of its horizontal centre -- not against
+      // the frame's top edge, which is where the horizontal-mode intuition puts it.
       int qx = 0, qy = 0;
-      if (quadrantTopRight(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
-                           /*centreInHalf=*/false, &qx, &qy)) {
+      if (rightAlignedInk(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx, InkVAlign::Centre,
+                          &qx, &qy)) {
         g.x = static_cast<uint16_t>(qx);
         g.y = static_cast<uint16_t>(qy);
       } else {
@@ -943,8 +948,8 @@ struct VerticalParsedText::LayoutCursor {
     if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
       // Comma/period: bottom-left of the em -> upper-right of the cell.
       int qx = 0, qy = 0, inkH = 0;
-      if (quadrantTopRight(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
-                           /*centreInHalf=*/true, &qx, &qy, &inkH)) {
+      if (rightAlignedInk(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
+                          InkVAlign::HalfEmHead, &qx, &qy, &inkH)) {
         gx = qx;
         gy = qy;
         // Not a whole square: the mark takes its own ink height plus a half em, then the next
@@ -1766,8 +1771,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           int gy = g.row * cellPx;
           if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
             int qx = 0, qy = 0;
-            if (quadrantTopRight(renderer_, fontId_, inkMemo, geom, pc.codepoint, pc.style, prev.column, g.row,
-                                 /*centreInHalf=*/true, &qx, &qy)) {
+            if (rightAlignedInk(renderer_, fontId_, inkMemo, geom, pc.codepoint, pc.style, prev.column, g.row,
+                                InkVAlign::HalfEmHead, &qx, &qy)) {
               gx = qx;
               gy = qy;
             } else {

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -913,10 +913,19 @@ struct VerticalParsedText::LayoutCursor {
   // still reads as an indent, and it is very often the only thing a short column has to offer.
   static bool isReducible(const uint32_t cp) { return Kinsoku::verticalShiftType(cp) != 0 || cp == 0x3000; }
 
-  bool squeezeColumnForOneMore(const uint16_t col) {
+  // How much room a character actually needs at the end of a column. A half-em mark (a closing
+  // bracket, 。、) is set in one half of its em and the other half is white, so half a cell is
+  // enough for it -- demanding a whole one is what kept a lone 」 off the column it belongs to.
+  int spaceNeededFor(const uint32_t cp) const {
+    return Kinsoku::verticalShiftType(cp) != 0 ? (geom.cellPx + 1) / 2 : geom.cellPx;
+  }
+
+  // Returns the pixels actually recovered (0 when the column has nothing to give). The caller
+  // places its character `applied` px above the grid row, since the tail moved up by that much.
+  int squeezeColumnForOneMore(const uint16_t col, const int neededPx) {
     size_t first = page.glyphs.size();
     while (first > 0 && page.glyphs[first - 1].column == col) first--;
-    if (first == page.glyphs.size()) return false;
+    if (first == page.glyphs.size()) return 0;
 
     // The LAST glyph's trailing space is what the new character will occupy, so it is not itself
     // reducible.
@@ -924,18 +933,19 @@ struct VerticalParsedText::LayoutCursor {
     for (size_t i = first; i + 1 < page.glyphs.size(); i++) {
       if (isReducible(page.glyphs[i].codepoint)) marks++;
     }
-    if (marks == 0) return false;
+    if (marks == 0) return 0;
 
     // A mark may give up to the half em it carries. Round that cap UP: on an odd cell, two floored
     // halves sum to one pixel less than the whole (14 + 14 against a 29px cell), which made every
     // two-mark column miss by a pixel and fail.
     const int maxPerMark = (geom.cellPx + 1) / 2;
-    if (marks * maxPerMark < geom.cellPx) return false;
+    if (marks * maxPerMark < neededPx) return 0;
 
-    // Spread the cell being recovered across the marks rather than taking a fixed step from each:
-    // it lands on exactly one cell, and with four or more marks nobody gives more than the quarter
-    // em 3.8 prefers. The share is rounded up so the remainder shrinks to zero on the last mark.
-    int needed = geom.cellPx;
+    // Spread the space being recovered across the marks rather than taking a fixed step from each:
+    // it lands on exactly what is needed, and with four or more marks nobody gives more than the
+    // quarter em 3.8 prefers. The share is rounded up so the remainder shrinks to zero on the last
+    // mark.
+    int needed = neededPx;
     int remainingMarks = marks;
     int applied = 0;
     for (size_t i = first; i < page.glyphs.size(); i++) {
@@ -949,6 +959,45 @@ struct VerticalParsedText::LayoutCursor {
         remainingMarks--;
       }
     }
+    return applied;
+  }
+
+  // Place a character in a cell the squeeze just freed: placeUprightAt works off the grid, so it
+  // has to come up by the same amount the column's tail did.
+  void placeAfterSqueeze(const PendingChar& pc, const uint16_t col, const uint16_t rowIdx, const int applied) {
+    placeUprightAt(pc, col, rowIdx);
+    if (page.glyphs.empty()) return;
+    VerticalGlyph& placed = page.glyphs.back();
+    placed.y = static_cast<uint16_t>(std::max(0, static_cast<int>(placed.y) - applied));
+  }
+
+  // JLREQ 3.1.4: two adjacent half-em marks SHARE one em -- the first takes the first half, the
+  // second the second. Covers 。」 and 、」 as well as 』」 and 」」, since a closing bracket is
+  // itself a half-em glyph set in the first half of its cell. The half the first mark left free
+  // is exactly where the second belongs: no new cell, and neither character leaves the column its
+  // sentence ended in. A FULL-em character before the bracket (？」) genuinely needs 1.5 em, so
+  // this declines and the caller falls back.
+  bool placeHalfEmPair(const PendingChar& pc) {
+    if (page.glyphs.empty()) return false;
+    const VerticalGlyph& prev = page.glyphs.back();
+    const int prevHalfEm = Kinsoku::verticalShiftType(prev.codepoint);
+    if ((prevHalfEm != 1 && prevHalfEm != 2) || Kinsoku::verticalShiftType(pc.codepoint) != 2 ||
+        !Kinsoku::needsVerticalRotation(pc.codepoint)) {
+      return false;
+    }
+    VerticalGlyph g;
+    g.codepoint = pc.codepoint;
+    g.column = prev.column;
+    g.row = prev.row;
+    g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column));
+    // Raw grid position: pushGlyph applies this column's slide, as every other path expects.
+    g.y = static_cast<uint16_t>(prev.row * geom.cellPx + geom.cellPx / 2);
+    g.renderKind = VerticalGlyph::RotatedPunct;
+    g.paragraphIndex = pc.paragraphIndex;
+    g.byteOffset = pc.byteOffset;
+    g.style = pc.style;
+    g.emphasis = pc.emphasis;
+    pushGlyph(page, g, pc.rubyText);
     return true;
   }
 
@@ -999,6 +1048,33 @@ struct VerticalParsedText::LayoutCursor {
       column = 0;
       row = 0;
     }
+  }
+
+  // Kinsoku at a PAGE boundary, decided before the page is handed over. A character that may not
+  // start a line cannot be pulled back once this page is emitted -- the in-page rules all need the
+  // previous glyph, and a fresh page has none -- so it ends up stranded at the top of the next
+  // page, or alone on a page of its own. Resolve it here, while the closing column is still in
+  // hand, in the same order the in-page rules use. `row` is the row just past the column's last
+  // glyph. Returns true when the character was absorbed, and advances `idx` past it.
+  bool absorbIntoClosingColumn(size_t& idx) {
+    if (idx >= o.stream_.size() || page.glyphs.empty() || column == 0) return false;
+    const PendingChar& next = o.stream_[idx];
+    if (next.paragraphIndex != page.glyphs.back().paragraphIndex) return false;
+    if (!Kinsoku::isLineStartProhibited(next.codepoint)) return false;
+    const uint16_t prevColumn = static_cast<uint16_t>(column - 1);
+    if (Kinsoku::verticalShiftType(next.codepoint) == 1) {
+      // 。/、 hang past the column end (JLREQ 3.1.9). Only these may.
+      placeUprightAt(next, prevColumn, row);
+    } else if (placeHalfEmPair(next)) {
+      // A closing bracket after a half-em mark shares its cell -- no room needed at all.
+    } else if (const int applied = squeezeColumnForOneMore(prevColumn, spaceNeededFor(next.codepoint))) {
+      // 3.8 line adjustment freed room in the closing column.
+      placeAfterSqueeze(next, prevColumn, row, applied);
+    } else {
+      return false;
+    }
+    idx++;
+    return true;
   }
 
   // Place one upright character in a given cell, applying the JLREQ quadrant/half-em rules.
@@ -1823,43 +1899,14 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           idx++;
           continue;
         }
-        if (cur.squeezeColumnForOneMore(prev.column)) {
-          // The squeeze pulled the column's tail up by a cell, so the freed cell is the one the
-          // last glyph used to end in. placeUprightAt works off the grid, so move the new glyph
-          // by the same amount the tail moved.
-          const int prevBottomBefore = (prev.row + 1) * cellPx;
-          cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
-          if (!page.glyphs.empty()) {
-            VerticalGlyph& placed = page.glyphs.back();
-            const int delta = prevBottomBefore - (static_cast<int>(page.glyphs[page.glyphs.size() - 2].y) + cellPx);
-            placed.y = static_cast<uint16_t>(std::max(0, static_cast<int>(placed.y) - delta));
-          }
+        const uint16_t oikomiCol = prev.column;
+        const uint16_t oikomiRow = static_cast<uint16_t>(prev.row + 1);
+        if (const int applied = cur.squeezeColumnForOneMore(oikomiCol, cur.spaceNeededFor(pc.codepoint))) {
+          cur.placeAfterSqueeze(pc, oikomiCol, oikomiRow, applied);
           idx++;
           continue;
         }
-        // JLREQ 3.1.4: two adjacent half-em marks SHARE one em -- the first takes the first half,
-        // the second the second. That covers 。」 and 、」 as well as 』」 and 」」, since a closing
-        // bracket is itself a half-em glyph set in the first half of its cell (and 。/、 are set
-        // tight for the same reason). The half the first mark left free is exactly where the
-        // second belongs: no new cell, and neither character leaves the column its sentence
-        // ended in. Only the FIRST of the pair may already be placed -- a full-em character
-        // before the bracket (？」) genuinely needs 1.5 em and falls through to oidashi.
-        const int prevHalfEm = Kinsoku::verticalShiftType(prev.codepoint);
-        if ((prevHalfEm == 1 || prevHalfEm == 2) && Kinsoku::verticalShiftType(pc.codepoint) == 2 &&
-            Kinsoku::needsVerticalRotation(pc.codepoint)) {
-          VerticalGlyph g;
-          g.codepoint = pc.codepoint;
-          g.column = prev.column;
-          g.row = prev.row;
-          g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column));
-          // Raw grid position: pushGlyph applies this column's slide, as every other path expects.
-          g.y = static_cast<uint16_t>(prev.row * cellPx + cellPx / 2);
-          g.renderKind = VerticalGlyph::RotatedPunct;
-          g.paragraphIndex = pc.paragraphIndex;
-          g.byteOffset = pc.byteOffset;
-          g.style = pc.style;
-          g.emphasis = pc.emphasis;
-          cur.pushGlyph(page, g, pc.rubyText);
+        if (cur.placeHalfEmPair(pc)) {
           idx++;
           continue;
         }
@@ -1982,6 +2029,12 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
     if (row >= cur.rowsAvailable()) {
       column++;
+      if (column >= columnsPerPage) {
+        size_t nextIdx = idx + 1;
+        if (cur.absorbIntoClosingColumn(nextIdx)) {
+          idx = nextIdx - 1;  // the loop's own idx++ steps past the absorbed character
+        }
+      }
       row = 0;
       cur.finalizePageIfNeeded();
       row = cur.columnStartRow(false);

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -366,11 +366,11 @@ int runInkWidth(const GfxRenderer& renderer, const int fontId, const std::string
   size_t lastStart = s.size() - 1;
   while (lastStart > 0 && (static_cast<unsigned char>(s[lastStart]) & 0xC0) == 0x80) lastStart--;
   const std::string lastChar = s.substr(lastStart);
-  const auto c0 = static_cast<unsigned char>(lastChar[0]);
-  uint32_t lastCp = c0;
-  if (c0 >= 0xC0 && lastChar.size() >= 2) {
-    lastCp = static_cast<uint32_t>(c0 & 0x1F) << 6 | (static_cast<unsigned char>(lastChar[1]) & 0x3F);
-  }
+  // Full decode, not a 2-byte shortcut: a rotated run may end in a 3-byte codepoint (U+2122 (TM)
+  // is in Kinsoku::isRotatedRunCharacter), and mis-decoding it measured the wrong glyph's ink,
+  // fell back to the advance, and reserved an extra row.
+  const auto* lastPtr = reinterpret_cast<const unsigned char*>(lastChar.c_str());
+  const uint32_t lastCp = utf8NextCodepoint(&lastPtr);
   GlyphInk ink;
   if (!measureGlyphInk(renderer, fontId, lastCp, static_cast<uint8_t>(style), &ink) || ink.width <= 0) {
     return advanceWidth;

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -94,12 +94,6 @@ uint32_t decodeUtf8At(const std::string& s, size_t i, size_t* bytesConsumed) {
   return c0;
 }
 
-std::string encodeCp(uint32_t cp) {
-  std::string out;
-  utf8AppendCodepoint(cp, out);
-  return out;
-}
-
 uint32_t composeKanaDiacritic(uint32_t base, uint32_t mark) {
   // U+3099 COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
   if (mark == 0x3099) {
@@ -252,21 +246,50 @@ bool measureGlyphInk(const GfxRenderer& renderer, const int fontId, const uint32
   return true;
 }
 
-int verticalCellPx(const GfxRenderer& renderer, const int fontId) {
+// Ink boxes for the handful of codepoints placed by quadrant. A miss is NOT stored: a probe
+// against a not-yet-resident SD font fails transiently, and caching that would place every
+// later occurrence by the fallback for the rest of the chapter.
+struct InkMemo {
+  static constexpr int CAPACITY = 24;
+  uint32_t keys[CAPACITY] = {};  // codepoint | style << 24; 0 = free
+  GlyphInk inks[CAPACITY];
+  int count = 0;
+  static uint32_t keyOf(const uint32_t cp, const uint8_t style) { return cp | (static_cast<uint32_t>(style) << 24); }
+  bool lookup(const uint32_t cp, const uint8_t style, GlyphInk* out) const {
+    const uint32_t k = keyOf(cp, style);
+    for (int i = 0; i < count; i++) {
+      if (keys[i] == k) {
+        *out = inks[i];
+        return true;
+      }
+    }
+    return false;
+  }
+  void store(const uint32_t cp, const uint8_t style, const GlyphInk& ink) {
+    if (count >= CAPACITY) return;  // full: fall back to probing, never evict
+    keys[count] = keyOf(cp, style);
+    inks[count] = ink;
+    count++;
+  }
+};
+
+int verticalCellPx(const GfxRenderer& renderer, const int fontId, bool* measured) {
   // SD fonts measure through their advance table; make sure the reference glyph is in it. A cold
   // table measures 漢 as 0, and the getLineHeight fallback includes interline spacing -- cells
   // jump ~1em -> ~1.45em, and layout and draw disagree for that frame.
   renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
   const int cjkAdvance = renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));  // 漢
+  if (measured) *measured = cjkAdvance > 0;
   if (cjkAdvance > 0) return cjkAdvance;
   return renderer.getLineHeight(fontId);
 }
 
-int verticalNominalInkGapPx(const GfxRenderer& renderer, const int fontId, const int cellPx) {
+int verticalNominalInkGapPx(const GfxRenderer& renderer, const int fontId, const int cellPx, bool* measured) {
   renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
   GlyphInk ink;
-  if (!measureGlyphInk(renderer, fontId, 0x6F22 /* 漢 */, 0, &ink) || ink.height <= 0 || ink.height > cellPx) return 0;
-  return cellPx - ink.height;
+  const bool ok = measureGlyphInk(renderer, fontId, 0x6F22 /* 漢 */, 0, &ink) && ink.height > 0 && ink.height <= cellPx;
+  if (measured) *measured = ok;
+  return ok ? cellPx - ink.height : 0;
 }
 
 // Record a paragraph boundary before stream index `idx`, ignoring a repeat at the same index --
@@ -496,14 +519,15 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
   }
 }
 
-int verticalCellBaselineOffset(const GfxRenderer& renderer, const int fontId, const int cellPx) {
+int verticalCellBaselineOffset(const GfxRenderer& renderer, const int fontId, const int cellPx, bool* measured) {
   const int ascender = renderer.getFontAscenderSize(fontId);
   // String literal, no allocation -- this is called from the pagination path.
   renderer.ensureSdCardFontReady(fontId, "\xe4\xb8\xad", 0x01);
   GlyphInk ink;
-  if (!measureGlyphInk(renderer, fontId, 0x4E2D /* 中 */, 0, &ink) || ink.height <= 0 || ink.height > cellPx * 2) {
-    return ascender;
-  }
+  const bool ok =
+      measureGlyphInk(renderer, fontId, 0x4E2D /* 中 */, 0, &ink) && ink.height > 0 && ink.height <= cellPx * 2;
+  if (measured) *measured = ok;
+  if (!ok) return ascender;
   // getGlyphMetrics reports `top` as the ink top ABOVE the baseline, so centring the ink box in
   // the cell puts the baseline at (cell - inkHeight)/2 + top below the cell's top edge.
   return (cellPx - ink.height) / 2 + ink.top;
@@ -799,6 +823,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     shiftColumn = columnArg;
   };
 
+  InkMemo inkMemo;
+
   // Upper-RIGHT quadrant placement, from the glyph's own ink box: these marks are drawn with
   // their ink at the bottom-left of the em, so how far it must travel is font-specific. Returns
   // false when metrics are unavailable.
@@ -808,8 +834,16 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   //   small kana - letter face against the top edge of its box
   auto quadrantTopRight = [&](const uint32_t cp, const uint8_t style, const uint16_t col, const uint16_t rowIdx,
                               const bool centreInHalf, int* gxOut, int* gyOut, int* inkHeightOut = nullptr) -> bool {
+    // Only 。、 and the small kana reach here -- about fifteen codepoints per style for a whole
+    // chapter, each otherwise re-probed for every occurrence. A probe pages the glyph in from the
+    // SD font and evicts another from its small on-demand table, so the repeat cost is SD reads,
+    // not arithmetic.
     GlyphInk ink;
-    if (!measureGlyphInk(renderer_, fontId_, cp, style, &ink) || ink.width <= 0 || ink.height <= 0) return false;
+    if (!inkMemo.lookup(cp, style, &ink)) {
+      if (!measureGlyphInk(renderer_, fontId_, cp, style, &ink)) return false;
+      inkMemo.store(cp, style, ink);
+    }
+    if (ink.width <= 0 || ink.height <= 0) return false;
     // Draw resolves ink left as x + glyph->left, and ink top as (cellTop + baselineInCell) - top.
     const int inkTopInCell = centreInHalf ? std::max(0, (cellPx / 2 - ink.height) / 2) : 0;
     *gxOut = columnLeftX(col) + cellPx - ink.left - ink.width;
@@ -1075,8 +1109,9 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     } else {
       // Metrics for a glyph the SD font has not paged in yet come back empty, which silently
       // disabled the tail allowance; page the one character in first.
-      const std::string nextChar = encodeCp(next.codepoint);
-      renderer_.ensureSdCardFontReady(fontId_, nextChar.c_str(), static_cast<uint8_t>(1u << (next.style & 3)));
+      char nextChar[5] = {};
+      utf8EncodeCodepoint(next.codepoint, nextChar);
+      renderer_.ensureSdCardFontReady(fontId_, nextChar, static_cast<uint8_t>(1u << (next.style & 3)));
       GlyphInk ink;
       if (measureGlyphInk(renderer_, fontId_, next.codepoint, next.style, &ink) && ink.height > 0) {
         offset = baselineInCellPx - ink.top;
@@ -1359,7 +1394,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       std::string runUtf8;
       while (runEnd < boundaryLimit && Kinsoku::isRotatedRunCharacter(stream_[runEnd].codepoint) &&
              stream_[runEnd].paragraphIndex == pc.paragraphIndex) {
-        runUtf8 += encodeCp(stream_[runEnd].codepoint);
+        utf8AppendCodepoint(stream_[runEnd].codepoint, runUtf8);
         runEnd++;
         if (runEnd - idx > 64) break;
       }

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -747,9 +747,9 @@ struct VerticalParsedText::LayoutCursor {
     // quarters to a quarter each side of the dot (7).
     int reduction = geom.cellPx / 2;
 
-    // 。and 、 already end a half em after their own ink (commaTighten), so that half is gone:
-    // an opening bracket wants exactly it (figure 3), a closing bracket or another 。/、 is set
-    // solid (1, 2), a middle dot keeps a quarter.
+    // 。and 、 carry their own trailing half em inside their em, so a following mark closes onto
+    // it: an opening bracket wants exactly that half (figure 3), a closing bracket or another
+    // 。/、 is set solid (1, 2), a middle dot keeps a quarter.
     if (Kinsoku::verticalShiftType(prev.codepoint) == 1) {
       if (thisHalf == 2) return;
       reduction = (thisHalf == 3) ? geom.cellPx / 4 : geom.cellPx / 2;
@@ -776,6 +776,7 @@ struct VerticalParsedText::LayoutCursor {
     if (page.glyphs.empty()) return topYArg;
     const VerticalGlyph& pg = page.glyphs.back();
     if (pg.column != columnArg) return topYArg;
+    const int leadSpacePx = latinLeadSpacePx();
     // Start on the grid; the only reason to push further is a predecessor whose ink actually
     // reaches into this cell, which is measured below.
     int startY = topYArg;
@@ -798,7 +799,7 @@ struct VerticalParsedText::LayoutCursor {
         startY = std::max(startY, pgRawY + geom.baselineInCellPx - ink.top + ink.height);
       }
     }
-    return startY;
+    return startY + leadSpacePx;
   }
 
   // How far into its cell the next glyph's ink starts, or -1 when there is no next glyph in
@@ -835,13 +836,102 @@ struct VerticalParsedText::LayoutCursor {
     return offset;
   }
 
+  // JLREQ 3.2.6: a quarter em separates a Latin run / European numerals from the Japanese around
+  // it. Every exception comes down to "somebody else already owns that space":
+  //   line head / line end             nothing
+  //   after 。、 or a closing bracket   they carry their own trailing space
+  //   after an opening bracket         solid
+  //   before 。、 or a closing bracket  solid
+  //   before an opening bracket        it carries its own leading space
+  // verticalShiftType is non-zero for exactly that punctuation, so one test covers each side.
+  int latinLeadSpacePx() const {
+    if (page.glyphs.empty()) return 0;
+    const VerticalGlyph& pg = page.glyphs.back();
+    if (pg.column != column) return 0;  // first thing in this column
+    return Kinsoku::verticalShiftType(pg.codepoint) != 0 ? 0 : geom.cellPx / 4;
+  }
+
+  int latinTrailSpacePx(const size_t nextIdx, const uint32_t paragraphIndex) const {
+    if (nextIdx >= o.stream_.size() || o.stream_[nextIdx].paragraphIndex != paragraphIndex) return 0;
+    return Kinsoku::verticalShiftType(o.stream_[nextIdx].codepoint) != 0 ? 0 : geom.cellPx / 4;
+  }
+
+  // How many cells this column can still take. The grid says geom.rowsPerColumn, but every
+  // tightening -- 。、 and closing brackets keeping a quarter em instead of a whole cell, a
+  // rotated run's cell-rounding slack taken up -- slides this column's tail UP by columnYShift.
+  // That reclaimed height has to be spent on more characters, or each column ends wherever its
+  // punctuation happened to leave it. JLREQ sets every line to the same length; only hanging
+  // punctuation passes it. A negative shift (ink pushed down, e.g. the low ellipsis stack)
+  // correctly yields fewer rows.
+  uint16_t rowsAvailable() const {
+    const int shift = (column == shiftColumn) ? columnYShift : 0;
+    const int rows = (static_cast<int>(o.viewportHeight_) + shift) / geom.cellPx;
+    return static_cast<uint16_t>(std::clamp(rows, 1, static_cast<int>(UINT16_MAX)));
+  }
+
+  // JLREQ 3.8 line adjustment, 追い込み (oikomi): recover one cell in column `col` so a character
+  // that may not start a line can join it instead of being pushed to the next column.
+  //
+  // The reducible space is the half em that 。、 and brackets carry inside their own em; 3.8
+  // reduces each by a QUARTER em, so four such marks buy one cell. The pull is progressive --
+  // only the glyphs AFTER a reduced space move up -- which is why this cannot go through
+  // columnYShift, that shifts a whole column uniformly.
+  //
+  // Two passes: measure first, and only touch the glyphs once a full cell is actually available.
+  // A partial squeeze would tighten the column for nothing and still push the character out.
+  // What line adjustment may take space from: the half em 。、 and brackets carry inside their own
+  // em, and a paragraph's leading ideographic space. Aozora-derived books write that indent as a
+  // U+3000 GLYPH rather than CSS, so it is a full em sitting in the column -- giving up half of it
+  // still reads as an indent, and it is very often the only thing a short column has to offer.
+  static bool isReducible(const uint32_t cp) { return Kinsoku::verticalShiftType(cp) != 0 || cp == 0x3000; }
+
+  bool squeezeColumnForOneMore(const uint16_t col) {
+    size_t first = page.glyphs.size();
+    while (first > 0 && page.glyphs[first - 1].column == col) first--;
+    if (first == page.glyphs.size()) return false;
+
+    // The LAST glyph's trailing space is what the new character will occupy, so it is not itself
+    // reducible.
+    int marks = 0;
+    for (size_t i = first; i + 1 < page.glyphs.size(); i++) {
+      if (isReducible(page.glyphs[i].codepoint)) marks++;
+    }
+    if (marks == 0) return false;
+
+    // A mark may give up to the half em it carries. Round that cap UP: on an odd cell, two floored
+    // halves sum to one pixel less than the whole (14 + 14 against a 29px cell), which made every
+    // two-mark column miss by a pixel and fail.
+    const int maxPerMark = (geom.cellPx + 1) / 2;
+    if (marks * maxPerMark < geom.cellPx) return false;
+
+    // Spread the cell being recovered across the marks rather than taking a fixed step from each:
+    // it lands on exactly one cell, and with four or more marks nobody gives more than the quarter
+    // em 3.8 prefers. The share is rounded up so the remainder shrinks to zero on the last mark.
+    int needed = geom.cellPx;
+    int remainingMarks = marks;
+    int applied = 0;
+    for (size_t i = first; i < page.glyphs.size(); i++) {
+      if (applied > 0) {
+        page.glyphs[i].y = static_cast<uint16_t>(std::max(0, static_cast<int>(page.glyphs[i].y) - applied));
+      }
+      if (needed > 0 && i + 1 < page.glyphs.size() && isReducible(page.glyphs[i].codepoint)) {
+        const int give = std::min(maxPerMark, (needed + remainingMarks - 1) / remainingMarks);
+        applied += give;
+        needed -= give;
+        remainingMarks--;
+      }
+    }
+    return true;
+  }
+
   // Take up the cell-rounding leftover after a run: the rest of the column slides up by it, so
   // the next character follows at normal spacing instead of after a partly empty cell.
   void takeUpRunSlack(const int startY, const int inkWidthPx, const uint16_t rowAfter, const uint16_t columnArg,
-                      const int nextInkOffset) {
-    if (nextInkOffset < 0 || rowAfter >= geom.rowsPerColumn) return;
+                      const int nextInkOffset, const int trailSpacePx) {
+    if (nextInkOffset < 0 || rowAfter >= rowsAvailable()) return;
     const int nextGridInkTop = rowAfter * geom.cellPx + nextInkOffset;
-    const int slack = nextGridInkTop - (startY + inkWidthPx) - geom.inkGapPx;
+    // Leave the run's trailing space (3.2.6), never less than the gap a normal pair leaves.
+    const int slack = nextGridInkTop - (startY + inkWidthPx) - std::max(geom.inkGapPx, trailSpacePx);
     if (slack > 0) {
       columnYShift += slack;
       shiftColumn = columnArg;
@@ -944,17 +1034,17 @@ struct VerticalParsedText::LayoutCursor {
         gx = geom.columnLeftX(col) + (geom.cellPx - ink.width) / 2 - ink.left;
       }
     }
-    int commaTighten = 0;
     if (Kinsoku::verticalShiftType(pc.codepoint) == 1) {
-      // Comma/period: bottom-left of the em -> upper-right of the cell.
-      int qx = 0, qy = 0, inkH = 0;
+      // 。and 、 occupy a FULL em like every other character -- only their ink sits in one half
+      // of it, at the cell's head. Charging them just their ink plus a half em looks tighter per
+      // mark but takes a quarter em off the grid at every sentence, so no two columns end at the
+      // same depth. Closing up against a neighbour is the pair rules' job (3.1.4), not the
+      // mark's own advance. (JLREQ 3.8 does reduce this, but per line and only to make one fit.)
+      int qx = 0, qy = 0;
       if (rightAlignedInk(o.renderer_, o.fontId_, inkMemo, geom, pc.codepoint, pc.style, col, rowIdx,
-                          InkVAlign::HalfEmHead, &qx, &qy, &inkH)) {
+                          InkVAlign::HalfEmHead, &qx, &qy)) {
         gx = qx;
         gy = qy;
-        // Not a whole square: the mark takes its own ink height plus a half em, then the next
-        // character follows. The remainder of the cell comes off the rest of the column.
-        commaTighten = std::max(0, geom.cellPx - (inkH + geom.cellPx / 2));
       } else {
         gx += geom.cellPx / 2;
         gy = std::max(0, gy - geom.cellPx / 2);
@@ -964,10 +1054,6 @@ struct VerticalParsedText::LayoutCursor {
     g.y = static_cast<uint16_t>(gy);
     g.renderKind = VerticalGlyph::Upright;
     pushGlyph(page, g, pc.rubyText);
-    if (commaTighten > 0) {
-      columnYShift += commaTighten;
-      shiftColumn = col;
-    }
   }
 
   // Place a two-character tate-chu-yoko run (a 2-digit number, or a !?/!! pair) upright in one
@@ -1039,7 +1125,7 @@ struct VerticalParsedText::LayoutCursor {
     pushGlyph(page, g, runUtf8);
 
     row++;
-    if (row >= geom.rowsPerColumn) {
+    if (row >= rowsAvailable()) {
       column++;
       row = 0;
       finalizePageIfNeeded();
@@ -1266,12 +1352,6 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
   // the cell top when nothing precedes it in this column.
 
   // How far the character AFTER the run may be intruded upon: its ink only starts that far
-  // below its own cell top. Reports the ink offset inside the cell, or -1 when unknown.
-  //
-
-  // Take up the cell-rounding leftover after a run: the rest of the column slides up by it, so
-  // the next character follows at normal spacing instead of after a partly empty cell.
-
   size_t idx = 0;
   size_t suppressKinsokuUntilIdx = 0;  // watchdog escape hatch: place plainly up to here
   // Kinsoku oidashi rewinds one character (idx--) so a prohibited pair starts a column together.
@@ -1447,7 +1527,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         int startY = cur.rotatedRunStartY(column, row * cellPx);
         uint16_t rowsNeeded = rotatedRunRows(cellPx, startY, digitInkWidth, row, nextInkOffset);
 
-        if (row != 0 && row + rowsNeeded > rowsPerColumn) {
+        if (row != 0 && row + rowsNeeded > cur.rowsAvailable()) {
           column++;
           row = 0;
           cur.finalizePageIfNeeded();
@@ -1460,7 +1540,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         g.codepoint = 0;
         g.column = column;
         g.row = row;
-        g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
+        g.x = static_cast<uint16_t>(geom.columnLeftX(column));
         g.y = static_cast<uint16_t>(startY);
         g.paragraphIndex = pc.paragraphIndex;
         g.byteOffset = pc.byteOffset;
@@ -1470,8 +1550,9 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
 
         const uint16_t digitColumn = column;
         row = static_cast<uint16_t>(row + rowsNeeded);
-        cur.takeUpRunSlack(startY, digitInkWidth, row, digitColumn, nextInkOffset);
-        if (row >= rowsPerColumn) {
+        cur.takeUpRunSlack(startY, digitInkWidth, row, digitColumn, nextInkOffset,
+                           cur.latinTrailSpacePx(digitEnd, pc.paragraphIndex));
+        if (row >= cur.rowsAvailable()) {
           column++;
           row = 0;
           cur.finalizePageIfNeeded();
@@ -1484,7 +1565,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // Single digit (digitCount == 1): place centered upright
       cur.placeUprightAt(pc, column, row);
       row++;
-      if (row >= rowsPerColumn) {
+      if (row >= cur.rowsAvailable()) {
         column++;
         row = 0;
         cur.finalizePageIfNeeded();
@@ -1512,7 +1593,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // unstyled measurement, which under-reserved rows and overprinted the next glyph).
       const auto runStyle = static_cast<EpdFontFamily::Style>(pc.style);
       renderer_.ensureSdCardFontReady(fontId_, runUtf8.c_str(), static_cast<uint8_t>(1u << (pc.style & 3)));
-      const int maxColumnPx = rowsPerColumn * cellPx;
+      const int maxColumnPx = cur.rowsAvailable() * cellPx;
       // JP sources separate embedded Latin from kana with ASCII spaces (それは Germinal や).
       // Drawn verbatim, the leading space pushes the first letter deep into the run's first
       // cell and the trailing space inflates the reserved rows -- the word floats low with a
@@ -1521,32 +1602,27 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       // keep only the inner ones (word gaps and break points).
       const int nextInkOffset = cur.nextGlyphInkOffset(runEnd, pc.paragraphIndex);
       std::string remaining = runUtf8;
-      const bool hadLeadingSpace = !runUtf8.empty() && runUtf8[0] == ' ';
       trimSpaces(remaining);
       if (remaining.empty()) {
         idx = runEnd;
         continue;
       }
-      // A source space before the word (哲学と Sokrates) is a visible separator in
-      // tategaki: give it a full empty cell so the word starts one character below the
-      // preceding glyph instead of sharing its cell (device photo: S printed onto the と).
-      // Skipped at a fresh column start -- line-leading spaces collapse, as in kinsoku.
-      if (hadLeadingSpace && row > cur.columnStartRow(false)) {
-        row++;
-        if (row >= rowsPerColumn) {
-          column++;
-          row = 0;
-          cur.finalizePageIfNeeded();
-          row = cur.columnStartRow(false);
-        }
-      }
+      // A source space before the word (哲学と Sokrates) used to take a whole empty cell, to stop
+      // the run sharing a cell with the preceding glyph. JLREQ 3.2.6's quarter em now separates
+      // them properly, so the cell would be a second, much larger gap on top of it.
+
+      // Where the NEXT chunk of this run continues, when a split leaves it in the same column:
+      // one word space after the previous chunk's ink, not the next cell boundary -- rounding a
+      // word gap up to a whole cell is what made "au thority" read as two words.
+      const int wordSpacePx = renderer_.getRenderAdvanceX(fontId_, " ", runStyle);
+      int continueY = -1;
 
       while (!remaining.empty()) {
         const int remWidthPx = renderer_.getRenderAdvanceX(fontId_, remaining.c_str(), runStyle);
-        const int startY = cur.rotatedRunStartY(column, row * cellPx);
+        const int startY = continueY >= 0 ? continueY : cur.rotatedRunStartY(column, row * cellPx);
         const uint16_t remRows = rotatedRunRows(
             cellPx, startY, runInkWidth(renderer_, fontId_, remaining, remWidthPx, runStyle), row, nextInkOffset);
-        const uint16_t availRows = rowsPerColumn - row;
+        const uint16_t availRows = static_cast<uint16_t>(std::max(0, cur.rowsAvailable() - row));
 
         if (remRows <= availRows) {
           // Fits in the current column.
@@ -1554,7 +1630,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.codepoint = 0;
           g.column = column;
           g.row = row;
-          g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
+          g.x = static_cast<uint16_t>(geom.columnLeftX(column));
           g.y = static_cast<uint16_t>(startY);
           g.paragraphIndex = pc.paragraphIndex;
           g.byteOffset = pc.byteOffset;
@@ -1563,8 +1639,8 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           cur.pushGlyph(page, g, remaining);
           row = static_cast<uint16_t>(row + remRows);
           cur.takeUpRunSlack(startY, runInkWidth(renderer_, fontId_, remaining, remWidthPx, runStyle), row, g.column,
-                             nextInkOffset);
-          if (row >= rowsPerColumn) {
+                             nextInkOffset, cur.latinTrailSpacePx(runEnd, pc.paragraphIndex));
+          if (row >= cur.rowsAvailable()) {
             column++;
             row = 0;
             cur.finalizePageIfNeeded();
@@ -1604,6 +1680,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
             row = 0;
             cur.finalizePageIfNeeded();
             row = cur.columnStartRow(false);
+            continueY = -1;
           } else {
             // At (or above) a fresh column's start row and still doesn't fit — force-place the
             // whole thing at the CURRENT row to guarantee progress. It may overrun the column
@@ -1612,15 +1689,15 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
             g.codepoint = 0;
             g.column = column;
             g.row = row;
-            g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
+            g.x = static_cast<uint16_t>(geom.columnLeftX(column));
             g.y = static_cast<uint16_t>(startY);
             g.paragraphIndex = pc.paragraphIndex;
             g.byteOffset = pc.byteOffset;
             g.style = pc.style;
             g.renderKind = VerticalGlyph::RotatedRun;
             cur.pushGlyph(page, g, remaining);
-            row = static_cast<uint16_t>(std::min<int>(row + remRows, rowsPerColumn));
-            if (row >= rowsPerColumn) {
+            row = static_cast<uint16_t>(std::min<int>(row + remRows, cur.rowsAvailable()));
+            if (row >= cur.rowsAvailable()) {
               column++;
               row = 0;
               cur.finalizePageIfNeeded();
@@ -1649,7 +1726,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         g.codepoint = 0;
         g.column = column;
         g.row = row;
-        g.x = static_cast<uint16_t>(geom.columnLeftX(column) + cellPx - ascender);
+        g.x = static_cast<uint16_t>(geom.columnLeftX(column));
         g.y = static_cast<uint16_t>(startY);
         g.paragraphIndex = pc.paragraphIndex;
         g.byteOffset = pc.byteOffset;
@@ -1658,11 +1735,14 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         cur.pushGlyph(page, g, chunk);
 
         row = static_cast<uint16_t>(row + chunkRows);
-        if (row >= rowsPerColumn) {
+        if (row >= cur.rowsAvailable()) {
           column++;
           row = 0;
           cur.finalizePageIfNeeded();
           row = cur.columnStartRow(false);
+          continueY = -1;
+        } else {
+          continueY = startY + runInkWidth(renderer_, fontId_, chunk, chunkPx, runStyle) + wordSpacePx;
         }
 
         // Skip the space and continue with the rest.
@@ -1685,10 +1765,25 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         Kinsoku::isLineStartProhibited(pc.codepoint)) {
       if (!page.glyphs.empty()) {
         const VerticalGlyph& prev = page.glyphs.back();
-        // Oikomi (追い込み) only while the previous column has a row spare -- otherwise it writes
-        // past the bottom of the grid, over the status bar.
-        if (prev.row + 1 < rowsPerColumn) {
+        // Oikomi (追い込み): put the character on the previous column after all. Free when that
+        // column has a row spare; otherwise 3.8 line adjustment can recover one by tightening the
+        // punctuation already in it, which keeps 一 with しょ instead of splitting them.
+        if (prev.row + 1 < cur.rowsAvailable()) {
           cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
+          idx++;
+          continue;
+        }
+        if (cur.squeezeColumnForOneMore(prev.column)) {
+          // The squeeze pulled the column's tail up by a cell, so the freed cell is the one the
+          // last glyph used to end in. placeUprightAt works off the grid, so move the new glyph
+          // by the same amount the tail moved.
+          const int prevBottomBefore = (prev.row + 1) * cellPx;
+          cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
+          if (!page.glyphs.empty()) {
+            VerticalGlyph& placed = page.glyphs.back();
+            const int delta = prevBottomBefore - (static_cast<int>(page.glyphs[page.glyphs.size() - 2].y) + cellPx);
+            placed.y = static_cast<uint16_t>(std::max(0, static_cast<int>(placed.y) - delta));
+          }
           idx++;
           continue;
         }
@@ -1724,7 +1819,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // cell, so the overhang is small and falls in the bottom margin -- the same margin ruby
         // uses beside the text (JLREQ Fig 2.37). Without this, oidashi pulled the preceding
         // character along and left a column holding just those two.
-        if (Kinsoku::verticalShiftType(pc.codepoint) == 1 && prev.row + 1 == rowsPerColumn) {
+        if (Kinsoku::verticalShiftType(pc.codepoint) == 1 && prev.row + 1 == cur.rowsAvailable()) {
           cur.placeUprightAt(pc, prev.column, static_cast<uint16_t>(prev.row + 1));
           idx++;
           continue;
@@ -1741,7 +1836,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // Only safe when that glyph is this batch's previous stream entry: streamed layout can
         // leave glyphs from an earlier batch on the page, which are not ours to re-place. And only
         // when the pair actually fits, so a short column cannot strand the bracket instead.
-        if (idx > 0 && row + 1 < rowsPerColumn && prev.byteOffset == stream_[idx - 1].byteOffset &&
+        if (idx > 0 && row + 1 < cur.rowsAvailable() && prev.byteOffset == stream_[idx - 1].byteOffset &&
             prev.paragraphIndex == stream_[idx - 1].paragraphIndex) {
           page.glyphs.pop_back();
           cur.placeUprightAt(stream_[idx - 1], column, row);
@@ -1760,7 +1855,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         // normally instead) rather than risk it -- a minor formatting nicety, not correctness.
         const bool hasHeadroom = prevPage.glyphs.size() < prevPage.glyphs.capacity();
         // Same bound as the in-page pull-back: only while that column has a row spare.
-        const bool prevColumnHasRoom = !prevPage.glyphs.empty() && prevPage.glyphs.back().row + 1 < rowsPerColumn;
+        const bool prevColumnHasRoom = !prevPage.glyphs.empty() && prevPage.glyphs.back().row + 1 < cur.rowsAvailable();
         if (prevColumnHasRoom && (hasHeadroom || ESP.getMaxAllocHeap() >= MIN_FREE_HEAP_FOR_RESERVE)) {
           const VerticalGlyph& prev = prevPage.glyphs.back();
           VerticalGlyph g;
@@ -1784,7 +1879,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
           g.y = static_cast<uint16_t>(gy);
           g.renderKind = VerticalGlyph::Upright;
           if (Kinsoku::needsVerticalRotation(pc.codepoint)) {
-            g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column) + cellPx - ascender);
+            g.x = static_cast<uint16_t>(geom.columnLeftX(prev.column));
             g.y = static_cast<uint16_t>(g.row * cellPx);
             g.renderKind = VerticalGlyph::RotatedPunct;
           }
@@ -1797,7 +1892,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
       }
     }
 
-    bool endingColumn = (row == rowsPerColumn - 1);
+    bool endingColumn = (row + 1 == cur.rowsAvailable());
     if (endingColumn && Kinsoku::isLineEndProhibited(pc.codepoint)) {
       // Oidashi (追い出し): push this character forward into a fresh
       // column instead of letting it end the current one.
@@ -1819,7 +1914,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     const bool endsEllipsisGroup =
         (pc.codepoint == 0x2026 || pc.codepoint == 0x2025) &&
         (idx + 1 >= stream_.size() || (stream_[idx + 1].codepoint != 0x2026 && stream_[idx + 1].codepoint != 0x2025));
-    if (endsEllipsisGroup && row < rowsPerColumn) {
+    if (endsEllipsisGroup && row < cur.rowsAvailable()) {
       const int nextInkOffset = cur.nextGlyphInkOffset(idx + 1, pc.paragraphIndex);
       int inkTop = 0, inkHeight = 0;
       if (nextInkOffset >= 0 &&
@@ -1835,7 +1930,7 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
         }
       }
     }
-    if (row >= rowsPerColumn) {
+    if (row >= cur.rowsAvailable()) {
       column++;
       row = 0;
       cur.finalizePageIfNeeded();

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -402,9 +402,13 @@ int verticalCellPx(const GfxRenderer& renderer, const int fontId, bool* measured
 int verticalNominalInkGapPx(const GfxRenderer& renderer, const int fontId, const int cellPx, bool* measured) {
   renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
   GlyphInk ink;
-  const bool ok = measureGlyphInk(renderer, fontId, 0x6F22 /* 漢 */, 0, &ink) && ink.height > 0 && ink.height <= cellPx;
+  const bool ok = measureGlyphInk(renderer, fontId, 0x6F22 /* 漢 */, 0, &ink) && ink.height > 0;
   if (measured) *measured = ok;
-  return ok ? cellPx - ink.height : 0;
+  // A face whose ink is TALLER than its own em leaves no white at all -- that is a measurement,
+  // not a failure, so clamp it to zero and let it be cached. Treating it as unmeasured (NotoSerif
+  // JP: 30px of ink in a 29px em) re-probed 漢 on every batch for the whole chapter, which is the
+  // SD-glyph eviction the memo exists to prevent.
+  return ok ? std::max(0, cellPx - ink.height) : 0;
 }
 
 // Record a paragraph boundary before stream index `idx`, ignoring a repeat at the same index --

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -392,6 +392,12 @@ class VerticalParsedText {
   // Codepoint-estimating, request-size-aware reserve for stream_ (see .cpp for the full story --
   // both the byte-count-as-slot-count over-request and the unchecked-request-size reserve have
   // crashed a real device).
+  // Mutable page-building state for one layoutPages() pass, with the placement rules that act on
+  // it. Defined in the .cpp -- it exists to give those rules a named home and an explicit set of
+  // state, instead of a dozen variables shared by reference between twenty lambdas. Nested so it
+  // can reach this class's private stream/box state directly.
+  struct LayoutCursor;
+
   void reserveStreamFor(size_t utf8Bytes);
 
   // Font metrics for this object's fontId, measured once and reused for every paragraph of the

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -394,23 +394,20 @@ class VerticalParsedText {
   // would be needed and heap is too tight to risk it; the caller should skip this element.
   bool canPushStreamChar();
 
-  // Codepoint-estimating, request-size-aware reserve for stream_ (see .cpp for the full story --
-  // both the byte-count-as-slot-count over-request and the unchecked-request-size reserve have
-  // crashed a real device).
-  // Mutable page-building state for one layoutPages() pass, with the placement rules that act on
-  // it. Defined in the .cpp -- it exists to give those rules a named home and an explicit set of
-  // state, instead of a dozen variables shared by reference between twenty lambdas. Nested so it
-  // can reach this class's private stream/box state directly.
+  // Mutable page-building state for one layoutPages() pass, with the placement rules that act on it.
+  // Defined in the .cpp: it exists to give those rules a named home and an explicit set of state.
+  // Nested so it can reach this class's private stream/box state directly.
   struct LayoutCursor;
 
   void reserveStreamFor(size_t utf8Bytes);
 
-  // Font metrics for this object's fontId, measured once and reused for every paragraph of the
-  // chapter. Each probe pages its reference glyph (漢/中) in from the SD font, and the font's
-  // on-demand slot table is small -- re-measuring per paragraph evicted real text glyphs and made
-  // the reference glyphs ~27% of all SD glyph loads during a chapter build.
-  // Only a SUCCESSFUL measurement is cached: a probe against a font that is not resident yet
-  // returns a fallback, and storing that would freeze the fallback in for the whole chapter.
+  // Font metrics for this object's fontId, measured once and reused for every paragraph of the chapter.
+  // Each probe pages its reference glyph (漢/中) in from the SD font, whose on-demand slot table is
+  // small, so re-measuring per paragraph evicts real text glyphs -- it accounted for ~27% of all SD
+  // glyph loads during a chapter build.
+  //
+  // Cache only a SUCCESSFUL measurement: a probe against a font that is not resident yet returns a
+  // fallback, and storing that freezes the fallback in for the whole chapter.
   int cellPxMemo_ = 0;
   int inkGapPxMemo_ = -1;
   int baselineInCellMemo_ = -1;

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -6,21 +6,13 @@
 
 class GfxRenderer;
 
-// Where a glyph's baseline sits inside its cell, measured down from the cell's top.
+// Where a glyph's baseline sits inside its cell, measured down from the cell's top: the offset
+// that centres the reference CJK glyph's ink box (中 -- full-width, even bearings, the same
+// reference the tate-chu-yoko centring uses). Falls back to the font ascender when metrics are
+// unavailable, e.g. an SD font not yet resident.
 //
-// Replaces a hardcoded "global down nudge" of 3/8 of a cell that used to be added to every glyph
-// at draw time. Measured on device (33px cell, ascender 34, nudge 12) that constant put CJK ink at
-// cellTop+19..+47 -- most of a half-cell low, hanging 17px past its own cell. Harmless mid-column,
-// where rows overlap slightly by design, but it opened a gap at the top of every page and drove
-// the last row's ink into the status bar, and it could not respond to font or size.
-//
-// Instead of a fraction, measure: centre the reference CJK glyph's ink box in the cell. 中 is the
-// same reference the tate-chu-yoko centring already uses -- full-width with even bearings, so its
-// ink box represents the column. Falls back to the plain font ascender when metrics aren't
-// available (e.g. an SD font not yet resident), which is the placement this had before the nudge.
-//
-// Layout and drawing MUST agree here: the layout sizes the bottom reserve from it and the draw
-// positions ink with it, so a mismatch shows up as text creeping into the status bar.
+// Layout and drawing MUST agree here -- the layout paginates with it, the draw positions ink with
+// it -- or the mismatch accumulates down a column and the last row lands on the status bar.
 int verticalCellBaselineOffset(const GfxRenderer& renderer, int fontId, int cellPx);
 
 // A single positioned glyph cell within a vertically-laid-out page.
@@ -54,9 +46,8 @@ struct VerticalGlyph {
   uint8_t renderKind = Upright;
   uint8_t style = 0;      // EpdFontFamily::Style flags (BOLD, ITALIC, etc.)
   bool emphasis = false;  // text-emphasis (sesame dots beside character)
-  // An opening bracket that starts its column: JLREQ deletes the half em before it and sets it
-  // flush to the line head (tentsuki). Decided during layout -- which knows where columns start,
-  // including indented ones -- and applied when drawing.
+  // Opening bracket starting its column: set flush to the line head (tentsuki), the half em
+  // before it deleted. Decided in layout, which knows where columns start (indents included).
   uint8_t lineHeadFlush = 0;
   // Index into the owning VerticalPage's texts pool: the run string for
   // RotatedRun/UprightRun glyphs, the furigana/ruby annotation (UTF-8) for

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -6,13 +6,40 @@
 
 class GfxRenderer;
 
+// --- Shared cell metrics -------------------------------------------------------------------
+// Layout and drawing MUST agree on every one of these -- the layout paginates with them, the
+// draw positions ink with them -- or the mismatch accumulates down a column and the last row
+// lands on the status bar. They live here, not in either caller, so there is one definition.
+
+// A glyph's ink box relative to its origin, as GfxRenderer::getGlyphMetrics reports it: `top` is
+// the ink top ABOVE the baseline, `left` the left side bearing. Bundled because vertical layout
+// probes glyph ink constantly and four out-params per call buried the geometry in boilerplate.
+struct GlyphInk {
+  int left = 0;
+  int width = 0;
+  int top = 0;
+  int height = 0;
+};
+// False when the font has no such glyph (or it is blank), in which case `out` is untouched --
+// every caller has a metrics-free fallback, since an SD font may not be resident yet.
+bool measureGlyphInk(const GfxRenderer& renderer, int fontId, uint32_t cp, uint8_t style, GlyphInk* out);
+
+// The kihon-hanmen cell: one em, measured as the advance of the reference full-width glyph 漢
+// (advanceY would include interline spacing on Latin-oriented fonts). JLREQ sets solid, so the
+// cell IS the em -- inter-character air comes from the line-gap setting, never from padding here.
+// Falls back to the line height when the font has no such advance.
+int verticalCellPx(const GfxRenderer& renderer, int fontId);
+
+// The gap a grid-adjacent pair of full-width characters leaves between their ink boxes, measured
+// as the reference glyph's unused cell height. Used wherever something off-grid (a rotated Latin
+// run, a bracket, an ellipsis) must clear the character after it: matching this keeps that
+// spacing indistinguishable from the surrounding text instead of inventing a fraction of a cell.
+int verticalNominalInkGapPx(const GfxRenderer& renderer, int fontId, int cellPx);
+
 // Where a glyph's baseline sits inside its cell, measured down from the cell's top: the offset
 // that centres the reference CJK glyph's ink box (中 -- full-width, even bearings, the same
 // reference the tate-chu-yoko centring uses). Falls back to the font ascender when metrics are
 // unavailable, e.g. an SD font not yet resident.
-//
-// Layout and drawing MUST agree here -- the layout paginates with it, the draw positions ink with
-// it -- or the mismatch accumulates down a column and the last row lands on the status bar.
 int verticalCellBaselineOffset(const GfxRenderer& renderer, int fontId, int cellPx);
 
 // A single positioned glyph cell within a vertically-laid-out page.
@@ -365,5 +392,5 @@ class VerticalParsedText {
   // crashed a real device).
   void reserveStreamFor(size_t utf8Bytes);
 
-  int charAdvancePx() const;
+  void recordParagraphBreakAt(size_t idx);
 };

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -371,6 +371,11 @@ class VerticalParsedText {
   VerticalPage pendingPage_;
   // A paragraph break recorded at exactly the end of a batch's stream (trailing newline) --
   // carried across reset() and re-recorded at the start of the next batch. See layoutPages().
+  // A rotated Latin run that reaches the end of a non-final batch is NOT placed: the layout
+  // gathers a run only within one batch, so placing it would render "authority" as "au", a blank
+  // cell, then "thority". Its characters are held here and prepended to the next batch, where the
+  // rest of the word joins them. Survives reset(), which clears the stream itself.
+  std::vector<PendingChar> carriedRunTail_;
   bool pendingTrailingBreak_ = false;
   uint16_t pendingColumn_ = 0;
   uint16_t pendingRow_ = 0;

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -6,6 +6,23 @@
 
 class GfxRenderer;
 
+// Where a glyph's baseline sits inside its cell, measured down from the cell's top.
+//
+// Replaces a hardcoded "global down nudge" of 3/8 of a cell that used to be added to every glyph
+// at draw time. Measured on device (33px cell, ascender 34, nudge 12) that constant put CJK ink at
+// cellTop+19..+47 -- most of a half-cell low, hanging 17px past its own cell. Harmless mid-column,
+// where rows overlap slightly by design, but it opened a gap at the top of every page and drove
+// the last row's ink into the status bar, and it could not respond to font or size.
+//
+// Instead of a fraction, measure: centre the reference CJK glyph's ink box in the cell. 中 is the
+// same reference the tate-chu-yoko centring already uses -- full-width with even bearings, so its
+// ink box represents the column. Falls back to the plain font ascender when metrics aren't
+// available (e.g. an SD font not yet resident), which is the placement this had before the nudge.
+//
+// Layout and drawing MUST agree here: the layout sizes the bottom reserve from it and the draw
+// positions ink with it, so a mismatch shows up as text creeping into the status bar.
+int verticalCellBaselineOffset(const GfxRenderer& renderer, int fontId, int cellPx);
+
 // A single positioned glyph cell within a vertically-laid-out page.
 // `paragraphIndex` + `byteOffset` identify exactly where this character
 // came from in the source text -- this is the hook point for phase 2
@@ -37,6 +54,10 @@ struct VerticalGlyph {
   uint8_t renderKind = Upright;
   uint8_t style = 0;      // EpdFontFamily::Style flags (BOLD, ITALIC, etc.)
   bool emphasis = false;  // text-emphasis (sesame dots beside character)
+  // An opening bracket that starts its column: JLREQ deletes the half em before it and sets it
+  // flush to the line head (tentsuki). Decided during layout -- which knows where columns start,
+  // including indented ones -- and applied when drawing.
+  uint8_t lineHeadFlush = 0;
   // Index into the owning VerticalPage's texts pool: the run string for
   // RotatedRun/UprightRun glyphs, the furigana/ruby annotation (UTF-8) for
   // every other kind. NO_TEXT = none. An id instead of inline std::strings

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -28,19 +28,21 @@ bool measureGlyphInk(const GfxRenderer& renderer, int fontId, uint32_t cp, uint8
 // (advanceY would include interline spacing on Latin-oriented fonts). JLREQ sets solid, so the
 // cell IS the em -- inter-character air comes from the line-gap setting, never from padding here.
 // Falls back to the line height when the font has no such advance.
-int verticalCellPx(const GfxRenderer& renderer, int fontId);
+// `measured` (optional) reports whether the font answered: a caller that caches the result must
+// only cache a measured one, or a probe against a not-yet-resident SD font freezes its fallback in.
+int verticalCellPx(const GfxRenderer& renderer, int fontId, bool* measured = nullptr);
 
 // The gap a grid-adjacent pair of full-width characters leaves between their ink boxes, measured
 // as the reference glyph's unused cell height. Used wherever something off-grid (a rotated Latin
 // run, a bracket, an ellipsis) must clear the character after it: matching this keeps that
 // spacing indistinguishable from the surrounding text instead of inventing a fraction of a cell.
-int verticalNominalInkGapPx(const GfxRenderer& renderer, int fontId, int cellPx);
+int verticalNominalInkGapPx(const GfxRenderer& renderer, int fontId, int cellPx, bool* measured = nullptr);
 
 // Where a glyph's baseline sits inside its cell, measured down from the cell's top: the offset
 // that centres the reference CJK glyph's ink box (中 -- full-width, even bearings, the same
 // reference the tate-chu-yoko centring uses). Falls back to the font ascender when metrics are
 // unavailable, e.g. an SD font not yet resident.
-int verticalCellBaselineOffset(const GfxRenderer& renderer, int fontId, int cellPx);
+int verticalCellBaselineOffset(const GfxRenderer& renderer, int fontId, int cellPx, bool* measured = nullptr);
 
 // A single positioned glyph cell within a vertically-laid-out page.
 // `paragraphIndex` + `byteOffset` identify exactly where this character
@@ -391,6 +393,16 @@ class VerticalParsedText {
   // both the byte-count-as-slot-count over-request and the unchecked-request-size reserve have
   // crashed a real device).
   void reserveStreamFor(size_t utf8Bytes);
+
+  // Font metrics for this object's fontId, measured once and reused for every paragraph of the
+  // chapter. Each probe pages its reference glyph (漢/中) in from the SD font, and the font's
+  // on-demand slot table is small -- re-measuring per paragraph evicted real text glyphs and made
+  // the reference glyphs ~27% of all SD glyph loads during a chapter build.
+  // Only a SUCCESSFUL measurement is cached: a probe against a font that is not resident yet
+  // returns a fallback, and storing that would freeze the fallback in for the whole chapter.
+  int cellPxMemo_ = 0;
+  int inkGapPxMemo_ = -1;
+  int baselineInCellMemo_ = -1;
 
   void recordParagraphBreakAt(size_t idx);
 };

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -43,7 +43,7 @@ namespace {
 // v99: merge of upstream 1.5.0. Not a format change -- an invalidation. Upstream reworked the
 // measurement stack the vertical layout is built on (SD kern classes + ligatures, the advance-table
 // fast path, fallback-resolved text font ids), so a v98 cache's stored glyph positions no longer
-// match the cell VerticalTextBlock::computeCellPx re-derives at DRAW time from the new metrics --
+// match the cell verticalCellPx() re-derives at DRAW time from the new metrics --
 // the exact "cell flapping" mismatch that path exists to prevent. The horizontal pipeline
 // invalidates for the same reason (SECTION_FILE_VERSION 51); this one must not be forgotten.
 // v100: image pages carry their source href.
@@ -563,6 +563,52 @@ namespace {
 // The footer lets loadSectionFile() open a chapter by reading only the header + 4 bytes/page,
 // and getPage() seek straight to one page -- pages are never all resident in RAM.
 
+// The glyph and box field lists below are visited by BOTH the writer and the reader, so their
+// order is defined exactly once. Writing and reading used to be two hand-maintained lists in
+// two functions: any divergence desyncs every record in the file, and because the bytes still
+// parse the version stamp gives no warning -- pages just come back scrambled.
+struct PodReadArchive {
+  HalFile& file;
+  template <typename T>
+  void operator()(T& v) {
+    serialization::readPod(file, v);
+  }
+};
+template <typename Sink>
+struct PodWriteArchive {
+  Sink& file;
+  template <typename T>
+  void operator()(const T& v) {
+    serialization::writePod(file, v);
+  }
+};
+
+// G is const on the write side, mutable on the read side.
+template <typename Ar, typename G>
+void visitGlyphFields(Ar& ar, G& g) {
+  ar(g.codepoint);
+  ar(g.column);
+  ar(g.row);
+  ar(g.x);
+  ar(g.y);
+  ar(g.paragraphIndex);
+  ar(g.byteOffset);
+  ar(g.renderKind);
+  ar(g.style);
+  ar(g.emphasis);
+  ar(g.lineHeadFlush);
+  ar(g.textId);
+}
+
+template <typename Ar, typename R>
+void visitBoxFields(Ar& ar, R& r) {
+  ar(r.x);
+  ar(r.y);
+  ar(r.w);
+  ar(r.h);
+  ar(r.edges);
+}
+
 // Sink is HalFile (direct, the historical path) or serialization::BufWriter
 // (whole page into RAM, flushed with one file.write) -- identical byte layout.
 template <typename Sink>
@@ -585,28 +631,10 @@ bool writePage(Sink& file, const VerticalPage& page) {
   // Boxed-block border rects (v63+). Bounded small (a page holds at most a handful of boxes).
   const auto boxCount = static_cast<uint8_t>(std::min<size_t>(page.boxes.size(), 8));
   serialization::writePod(file, boxCount);
-  for (uint8_t bi = 0; bi < boxCount; bi++) {
-    serialization::writePod(file, page.boxes[bi].x);
-    serialization::writePod(file, page.boxes[bi].y);
-    serialization::writePod(file, page.boxes[bi].w);
-    serialization::writePod(file, page.boxes[bi].h);
-    serialization::writePod(file, page.boxes[bi].edges);
-  }
+  PodWriteArchive<Sink> ar{file};
+  for (uint8_t bi = 0; bi < boxCount; bi++) visitBoxFields(ar, page.boxes[bi]);
 
-  for (const auto& g : page.glyphs) {
-    serialization::writePod(file, g.codepoint);
-    serialization::writePod(file, g.column);
-    serialization::writePod(file, g.row);
-    serialization::writePod(file, g.x);
-    serialization::writePod(file, g.y);
-    serialization::writePod(file, g.paragraphIndex);
-    serialization::writePod(file, g.byteOffset);
-    serialization::writePod(file, g.renderKind);
-    serialization::writePod(file, g.style);
-    serialization::writePod(file, g.emphasis);
-    serialization::writePod(file, g.lineHeadFlush);
-    serialization::writePod(file, g.textId);
-  }
+  for (const auto& g : page.glyphs) visitGlyphFields(ar, g);
 
   // Per-page text pool (v104): ruby annotations and run strings, referenced by textId.
   const auto textCount = static_cast<uint16_t>(page.texts.size());
@@ -660,13 +688,10 @@ ReadResult readPage(HalFile& file, VerticalPage& page) {
     return ReadResult::Corrupt;
   }
   page.boxes.reserve(boxCount);
+  PodReadArchive ar{file};
   for (uint8_t bi = 0; bi < boxCount; bi++) {
     VerticalBoxRect r;
-    serialization::readPod(file, r.x);
-    serialization::readPod(file, r.y);
-    serialization::readPod(file, r.w);
-    serialization::readPod(file, r.h);
-    serialization::readPod(file, r.edges);
+    visitBoxFields(ar, r);
     page.boxes.push_back(r);
   }
 
@@ -695,18 +720,7 @@ ReadResult readPage(HalFile& file, VerticalPage& page) {
 
   for (uint32_t gi = 0; gi < glyphCount; gi++) {
     VerticalGlyph g;
-    serialization::readPod(file, g.codepoint);
-    serialization::readPod(file, g.column);
-    serialization::readPod(file, g.row);
-    serialization::readPod(file, g.x);
-    serialization::readPod(file, g.y);
-    serialization::readPod(file, g.paragraphIndex);
-    serialization::readPod(file, g.byteOffset);
-    serialization::readPod(file, g.renderKind);
-    serialization::readPod(file, g.style);
-    serialization::readPod(file, g.emphasis);
-    serialization::readPod(file, g.lineHeadFlush);
-    serialization::readPod(file, g.textId);
+    visitGlyphFields(ar, g);
     page.glyphs.push_back(g);
   }
 

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -208,11 +208,11 @@ struct TextExtractor {
     return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
   }
 
-  // Whether `s` ends in the middle of something the layout must see whole. Byte-level is not
-  // enough: Japanese books write years in FULLWIDTH digits (１９３８), and U+FF10-U+FF19 encode as
-  // EF BC 90..99, whose tail byte is no ASCII word byte. Cutting there handed the layout two
-  // 2-digit batches, and it set each as its own tate-chu-yoko pair -- 19 stacked over 38 instead
-  // of one rotated run (変な家２, 日時：１９３８年).
+  // Whether `s` ends mid-token, i.e. inside something the layout must see whole. Byte-level testing is
+  // not enough: Japanese books write years in FULLWIDTH digits (１９３８), and U+FF10-U+FF19 encode as
+  // EF BC 90..99, whose tail byte is not an ASCII word byte. Cutting there hands the layout two
+  // 2-digit batches and each is set as its own tate-chu-yoko pair -- 19 stacked over 38 rather than one
+  // rotated run.
   static bool endsMidToken(const std::string& s) {
     if (s.empty()) return false;
     const auto last = static_cast<unsigned char>(s.back());
@@ -224,14 +224,14 @@ struct TextExtractor {
   // paragraphEnds=false streams a partial paragraph: the sink lays it out with no break
   // recorded, and the next emit continues it seamlessly (continuesPrevious=true).
   void emitRuns(const bool paragraphEnds) {
-    // A soft flush is a cadence, not a deadline. If the text so far ends inside a Latin word or a
-    // number,
-    // skip this one and let the next take it: the vertical layout gathers a rotated run only
-    // within one batch, so cutting here renders "authority" as "au", a blank cell, then
-    // "thority". Deferring is bounded -- the paragraph's own end always flushes -- and the
-    // triggers retry on the next character or the next run.
-    // The tail lives in currentText, or, when the run-COUNT trigger fires from the </ruby>
-    // handler, in the last run already pushed.
+    // A soft flush is a cadence, not a deadline. If the text so far ends inside a Latin word or a number,
+    // skip this one and let the next take it: the vertical layout gathers a rotated run only within one
+    // batch, so cutting here renders "authority" as "au", a blank cell, then "thority". Deferring is
+    // bounded -- the paragraph's own end always flushes -- and the triggers retry on the next character
+    // or run.
+    //
+    // The tail is in currentText, or, when the run-COUNT trigger fires from the </ruby> handler, in the
+    // last run already pushed.
     if (!paragraphEnds) {
       const std::string& tail =
           !currentText.empty() ? currentText : (currentRuns.empty() ? currentText : currentRuns.back().baseText);
@@ -594,10 +594,10 @@ namespace {
 // The footer lets loadSectionFile() open a chapter by reading only the header + 4 bytes/page,
 // and getPage() seek straight to one page -- pages are never all resident in RAM.
 
-// The glyph and box field lists below are visited by BOTH the writer and the reader, so their
-// order is defined exactly once. Writing and reading used to be two hand-maintained lists in
-// two functions: any divergence desyncs every record in the file, and because the bytes still
-// parse the version stamp gives no warning -- pages just come back scrambled.
+// The glyph and box field lists below are visited by BOTH the writer and the reader, so their order
+// is defined exactly once. Two hand-maintained lists desync every record in the file on any
+// divergence, and the bytes still parse, so the version stamp gives no warning -- pages simply come
+// back scrambled. G is const on the write side, mutable on the read side.
 struct PodReadArchive {
   HalFile& file;
   template <typename T>
@@ -1229,11 +1229,11 @@ struct LayoutPageSink final : ParagraphSink {
   }
 };
 
-// Byte offset of the pageCount field: everything createSectionFile writes ahead of it. Keep this
-// in step with that write order -- it is a seek target, so a stale value silently OVERWRITES the
-// preceding field rather than failing. Adding the furigana flag without updating this wrote
-// pageCount over it, and a chapter whose page count happened to equal the flag passed the
-// parameter check and then read its page table from a shifted offset ("empty chapter").
+// Byte offset of the pageCount field: everything createSectionFile writes ahead of it. Keep in step
+// with that write order. This is a SEEK target, so a stale value silently overwrites the preceding
+// field instead of failing -- adding the furigana flag without updating it wrote pageCount over the
+// flag, and a chapter whose page count happened to equal the flag passed the parameter check and
+// then read its page table from a shifted offset ("empty chapter").
 constexpr size_t HEADER_PAGECOUNT_OFFSET = sizeof(uint8_t)     // version
                                            + sizeof(int)       // fontId
                                            + sizeof(uint16_t)  // viewportWidth
@@ -1256,12 +1256,11 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   const uint32_t buildStartMs = millis();
   LOG_INF("VSC", "streamParseAndLayout start spine=%d free=%u maxAlloc=%u", spineIndex, ESP.getFreeHeap(),
           ESP.getMaxAllocHeap());
-  // Vertical placement measures each glyph's real ink extents (burasage, half-em pairing, the
-  // 3.8 squeeze deficits). Those measurements go through the font decompressor, so a heap too
-  // tight for a glyph group makes them silently fall back to nominal metrics -- and the result
-  // is written to the section cache, where nothing would ever re-examine it. Sample the starved
-  // count across the build and treat any increase as heap degradation, which the stale-stamp
-  // below turns into a rebuild on next open.
+  // Vertical placement measures each glyph's real ink extents (burasage, half-em pairing, the 3.8
+  // squeeze deficits), and those measurements go through the font decompressor. A heap too tight for a
+  // glyph group makes them fall back to nominal metrics silently, and the result is written to the
+  // section cache where nothing re-examines it. Sample the starved count across the build and treat any
+  // increase as heap degradation, which the stale stamp below turns into a rebuild on next open.
   uint32_t starvedGlyphsAtStart = 0;
   if (auto* fcm = renderer.getFontCacheManager()) {
     if (auto* fd = fcm->getDecompressor()) starvedGlyphsAtStart = fd->getStarvedGlyphCount();

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -60,7 +60,7 @@ namespace {
 // v104: glyph records are fixed-size (textId) with a per-page text pool appended after
 // the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
 // v105: the header includes the vertical column-spacing setting.
-constexpr uint8_t VSECTION_FILE_VERSION = 123;
+constexpr uint8_t VSECTION_FILE_VERSION = 124;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -60,7 +60,7 @@ namespace {
 // v104: glyph records are fixed-size (textId) with a per-page text pool appended after
 // the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
 // v105: the header includes the vertical column-spacing setting.
-constexpr uint8_t VSECTION_FILE_VERSION = 105;
+constexpr uint8_t VSECTION_FILE_VERSION = 121;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -604,6 +604,7 @@ bool writePage(Sink& file, const VerticalPage& page) {
     serialization::writePod(file, g.renderKind);
     serialization::writePod(file, g.style);
     serialization::writePod(file, g.emphasis);
+    serialization::writePod(file, g.lineHeadFlush);
     serialization::writePod(file, g.textId);
   }
 
@@ -704,6 +705,7 @@ ReadResult readPage(HalFile& file, VerticalPage& page) {
     serialization::readPod(file, g.renderKind);
     serialization::readPod(file, g.style);
     serialization::readPod(file, g.emphasis);
+    serialization::readPod(file, g.lineHeadFlush);
     serialization::readPod(file, g.textId);
     page.glyphs.push_back(g);
   }
@@ -1188,7 +1190,8 @@ constexpr size_t HEADER_PAGECOUNT_OFFSET = 1 + sizeof(int) + 2 * sizeof(uint16_t
 }  // namespace
 
 bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const uint16_t viewportWidth,
-                                           const uint16_t viewportHeight, const uint8_t lineSpacing) {
+                                           const uint16_t viewportHeight, const uint8_t lineSpacing,
+                                           const bool furiganaEnabled) {
   lastBuildDroppedForHeap_ = false;
   // Diagnostic: the "sparse page" investigation found maxAlloc already down at the very first
   // paragraph flush, staying flat for the rest of the chapter -- logging both metrics here checks
@@ -1239,9 +1242,6 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   // XML_ParserCreate's own setup.
   LOG_DBG("VSC", "after readItemContentsToStream: maxAlloc=%u", ESP.getMaxAllocHeap());
 
-  const bool hasRuby = fileContainsRubyTag(tmpHtmlPath);
-  LOG_DBG("VSC", "after fileContainsRubyTag: maxAlloc=%u", ESP.getMaxAllocHeap());
-
   // Resolve image paths relative to the chapter's directory in the EPUB.
   const auto& spineItem = epub->getSpineItem(spineIndex);
   std::string chapterDir;
@@ -1253,15 +1253,31 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
 
   VerticalParsedText layout(renderer, fontId, viewportWidth, viewportHeight);
   layout.preallocateStream();
-  const int lineH = renderer.getLineHeight(fontId);
-  // Tight/Normal/Wide use one, two, or four sixths of a line between columns.
+  // Column gap (行間), measured in EMS rather than line heights.
+  //
+  // The em is what the constraint is expressed in: JLREQ 3.3.3 has ruby characters at half the
+  // size of their base, and in vertical writing ruby is drawn in this very gap, beside its base
+  // column. So a gap under 1/2 em guarantees ruby collides with the next column, whatever the
+  // font. Line height is the wrong yardstick for that -- it carries Latin ascent/descent leading
+  // (42px against a 28px em in NotoSansJP here), so the same setting drifted relative to the
+  // ruby it had to clear as soon as the font changed.
+  //
+  // Japanese body text conventionally runs between a half and a full em of line gap, so with
+  // furigana ON the three settings span exactly that range, Tight landing on the half-em minimum
+  // that still fits ruby. (This is why the old code widened every gap in a chapter as soon as it
+  // saw one <ruby> tag: Tight was a quarter em, and ruby never fitted.)
+  //
+  // With furigana OFF nothing is ever drawn in the gap, so the floor does not apply and every
+  // setting drops a quarter em: the columns tighten and more text fits on a page, which is rather
+  // the point of turning it off.
+  renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);  // 漢
+  const int emPx = std::max(1, renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0)));
   const int clampedLineSpacing = std::clamp<int>(lineSpacing, 0, 2);
-  const int gapSixths = clampedLineSpacing == 2 ? 4 : clampedLineSpacing + 1;
-  layout.setColumnGapPx(std::max(4, lineH * gapSixths / 6));
-  if (hasRuby) {
-    layout.setColumnGapPx(std::max(4, lineH * (gapSixths + 2) / 6));
-    layout.setRightPaddingPx((lineH / 2) < 2 ? 2 : (lineH / 2));
-  }
+  static constexpr int kGapQuarterEmsWithRuby[] = {2, 3, 4};  // Tight 1/2, Normal 3/4, Wide 1 em
+  static constexpr int kGapQuarterEmsPlain[] = {1, 2, 3};     // Tight 1/4, Normal 1/2, Wide 3/4 em
+  const int gapQuarterEms =
+      furiganaEnabled ? kGapQuarterEmsWithRuby[clampedLineSpacing] : kGapQuarterEmsPlain[clampedLineSpacing];
+  layout.setColumnGapPx(std::max(2, emPx * gapQuarterEms / 4));
 
   LayoutPageSink sink(layout, out, pageOffsets_, *epub, renderer, chapterDir, imageBasePath, viewportWidth,
                       viewportHeight);
@@ -1390,7 +1406,7 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
 }
 
 bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight,
-                                        const uint8_t lineSpacing) {
+                                        const uint8_t lineSpacing, const bool furiganaEnabled) {
   const auto vsectionsDir = epub->getCachePath() + "/vsections";
   Storage.mkdir(vsectionsDir.c_str());
 
@@ -1411,12 +1427,14 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   serialization::writePod(file, viewportWidth);
   serialization::writePod(file, viewportHeight);
   serialization::writePod(file, lineSpacing);
+  const uint8_t furiganaFlag = furiganaEnabled ? 1 : 0;
+  serialization::writePod(file, furiganaFlag);
   const uint16_t pageCountPlaceholder = 0;
   const uint32_t indexOffsetPlaceholder = 0;
   serialization::writePod(file, pageCountPlaceholder);
   serialization::writePod(file, indexOffsetPlaceholder);
 
-  if (!streamParseAndLayout(file, fontId, viewportWidth, viewportHeight, lineSpacing)) {
+  if (!streamParseAndLayout(file, fontId, viewportWidth, viewportHeight, lineSpacing, furiganaEnabled)) {
     file.close();
     Storage.remove(filePath.c_str());
     pageOffsets_.clear();
@@ -1461,7 +1479,7 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
 }
 
 bool VerticalSection::loadSectionFile(const int fontId, const uint16_t viewportWidth, const uint16_t viewportHeight,
-                                      const uint8_t lineSpacing) {
+                                      const uint8_t lineSpacing, const bool furiganaEnabled) {
   // A missing cache file is the NORMAL case here, not an error: the book-progress counter probes
   // every spine's section on each page turn, and unbuilt chapters simply don't have one yet.
   // openFileForRead would print "File does not exist" per spine per probe -- pure log spam.
@@ -1488,13 +1506,15 @@ bool VerticalSection::loadSectionFile(const int fontId, const uint16_t viewportW
   int cachedFontId;
   uint16_t cachedWidth, cachedHeight;
   uint8_t cachedLineSpacing;
+  uint8_t cachedFurigana;
   serialization::readPod(file, cachedFontId);
   serialization::readPod(file, cachedWidth);
   serialization::readPod(file, cachedHeight);
   serialization::readPod(file, cachedLineSpacing);
+  serialization::readPod(file, cachedFurigana);
 
   if (cachedFontId != fontId || cachedWidth != viewportWidth || cachedHeight != viewportHeight ||
-      cachedLineSpacing != lineSpacing) {
+      cachedLineSpacing != lineSpacing || cachedFurigana != (furiganaEnabled ? 1 : 0)) {
     file.close();
     LOG_DBG("VSC", "Parameter mismatch, clearing cache");
     clearCache();

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1253,23 +1253,11 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
 
   VerticalParsedText layout(renderer, fontId, viewportWidth, viewportHeight);
   layout.preallocateStream();
-  // Column gap (行間), measured in EMS rather than line heights.
-  //
-  // The em is what the constraint is expressed in: JLREQ 3.3.3 has ruby characters at half the
-  // size of their base, and in vertical writing ruby is drawn in this very gap, beside its base
-  // column. So a gap under 1/2 em guarantees ruby collides with the next column, whatever the
-  // font. Line height is the wrong yardstick for that -- it carries Latin ascent/descent leading
-  // (42px against a 28px em in NotoSansJP here), so the same setting drifted relative to the
-  // ruby it had to clear as soon as the font changed.
-  //
-  // Japanese body text conventionally runs between a half and a full em of line gap, so with
-  // furigana ON the three settings span exactly that range, Tight landing on the half-em minimum
-  // that still fits ruby. (This is why the old code widened every gap in a chapter as soon as it
-  // saw one <ruby> tag: Tight was a quarter em, and ruby never fitted.)
-  //
-  // With furigana OFF nothing is ever drawn in the gap, so the floor does not apply and every
-  // setting drops a quarter em: the columns tighten and more text fits on a page, which is rather
-  // the point of turning it off.
+  // Column gap (行間) in EMS -- the unit the constraint is stated in. Ruby is half an em (JLREQ
+  // 3.3.3) and is drawn in this gap beside its base column, so with furigana ON the floor is half
+  // an em, and the settings span the half-to-full em Japanese body text conventionally uses. With
+  // furigana OFF nothing is drawn there, so every setting tightens by a quarter em. (Line height
+  // would be the wrong yardstick: it carries Latin leading, 42px against a 28px em here.)
   renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);  // 漢
   const int emPx = std::max(1, renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0)));
   const int clampedLineSpacing = std::clamp<int>(lineSpacing, 0, 2);

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -60,7 +60,7 @@ namespace {
 // v104: glyph records are fixed-size (textId) with a per-page text pool appended after
 // the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
 // v105: the header includes the vertical column-spacing setting.
-constexpr uint8_t VSECTION_FILE_VERSION = 124;
+constexpr uint8_t VSECTION_FILE_VERSION = 126;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -207,10 +207,24 @@ struct TextExtractor {
     return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
   }
 
+  // Whether `s` ends in the middle of something the layout must see whole. Byte-level is not
+  // enough: Japanese books write years in FULLWIDTH digits (１９３８), and U+FF10-U+FF19 encode as
+  // EF BC 90..99, whose tail byte is no ASCII word byte. Cutting there handed the layout two
+  // 2-digit batches, and it set each as its own tate-chu-yoko pair -- 19 stacked over 38 instead
+  // of one rotated run (変な家２, 日時：１９３８年).
+  static bool endsMidToken(const std::string& s) {
+    if (s.empty()) return false;
+    const auto last = static_cast<unsigned char>(s.back());
+    if (isAsciiWordByte(last)) return true;
+    return s.size() >= 3 && static_cast<unsigned char>(s[s.size() - 3]) == 0xEF &&
+           static_cast<unsigned char>(s[s.size() - 2]) == 0xBC && last >= 0x90 && last <= 0x99;
+  }
+
   // paragraphEnds=false streams a partial paragraph: the sink lays it out with no break
   // recorded, and the next emit continues it seamlessly (continuesPrevious=true).
   void emitRuns(const bool paragraphEnds) {
-    // A soft flush is a cadence, not a deadline. If the text so far ends inside a Latin word,
+    // A soft flush is a cadence, not a deadline. If the text so far ends inside a Latin word or a
+    // number,
     // skip this one and let the next take it: the vertical layout gathers a rotated run only
     // within one batch, so cutting here renders "authority" as "au", a blank cell, then
     // "thority". Deferring is bounded -- the paragraph's own end always flushes -- and the
@@ -220,7 +234,7 @@ struct TextExtractor {
     if (!paragraphEnds) {
       const std::string& tail =
           !currentText.empty() ? currentText : (currentRuns.empty() ? currentText : currentRuns.back().baseText);
-      if (!tail.empty() && isAsciiWordByte(static_cast<unsigned char>(tail.back()))) return;
+      if (endsMidToken(tail)) return;
     }
     flushCurrentText();
     if (!currentRuns.empty()) {

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -203,9 +203,25 @@ struct TextExtractor {
   static constexpr size_t SOFT_FLUSH_RUNS = 48;
   bool midParagraph = false;
 
+  static bool isAsciiWordByte(const unsigned char c) {
+    return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+  }
+
   // paragraphEnds=false streams a partial paragraph: the sink lays it out with no break
   // recorded, and the next emit continues it seamlessly (continuesPrevious=true).
   void emitRuns(const bool paragraphEnds) {
+    // A soft flush is a cadence, not a deadline. If the text so far ends inside a Latin word,
+    // skip this one and let the next take it: the vertical layout gathers a rotated run only
+    // within one batch, so cutting here renders "authority" as "au", a blank cell, then
+    // "thority". Deferring is bounded -- the paragraph's own end always flushes -- and the
+    // triggers retry on the next character or the next run.
+    // The tail lives in currentText, or, when the run-COUNT trigger fires from the </ruby>
+    // handler, in the last run already pushed.
+    if (!paragraphEnds) {
+      const std::string& tail =
+          !currentText.empty() ? currentText : (currentRuns.empty() ? currentText : currentRuns.back().baseText);
+      if (!tail.empty() && isAsciiWordByte(static_cast<unsigned char>(tail.back()))) return;
+    }
     flushCurrentText();
     if (!currentRuns.empty()) {
       if (sink) {

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <FontCacheManager.h>
+#include <FontDecompressor.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
@@ -1255,6 +1256,16 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   const uint32_t buildStartMs = millis();
   LOG_INF("VSC", "streamParseAndLayout start spine=%d free=%u maxAlloc=%u", spineIndex, ESP.getFreeHeap(),
           ESP.getMaxAllocHeap());
+  // Vertical placement measures each glyph's real ink extents (burasage, half-em pairing, the
+  // 3.8 squeeze deficits). Those measurements go through the font decompressor, so a heap too
+  // tight for a glyph group makes them silently fall back to nominal metrics -- and the result
+  // is written to the section cache, where nothing would ever re-examine it. Sample the starved
+  // count across the build and treat any increase as heap degradation, which the stale-stamp
+  // below turns into a rebuild on next open.
+  uint32_t starvedGlyphsAtStart = 0;
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    if (auto* fd = fcm->getDecompressor()) starvedGlyphsAtStart = fd->getStarvedGlyphCount();
+  }
   const auto localPath = epub->getSpineItem(spineIndex).href;
   const auto tmpHtmlPath = epub->getCachePath() + "/.tmp_v" + std::to_string(spineIndex) + ".html";
 
@@ -1437,6 +1448,15 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   // arbitrary fill levels, so the same usable-now/rebuild-next-open path applies (and the same
   // rebuildingFromStale_ guard breaks the loop when a retry degrades again).
   lastBuildDroppedForHeap_ = lastBuildDroppedForHeap_ || layout.everDroppedForHeap() || layout.everSplitForHeap();
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    if (auto* fd = fcm->getDecompressor()) {
+      const uint32_t starved = fd->getStarvedGlyphCount() - starvedGlyphsAtStart;
+      if (starved > 0) {
+        LOG_ERR("VSC", "%u glyph(s) measured without ink data on low heap; layout is approximate", starved);
+        lastBuildDroppedForHeap_ = true;
+      }
+    }
+  }
   // Persist harvested furigana pairs; runs after the parse buffers are freed, so the
   // transient merge buffer doesn't compete with layout's peak memory.
   RubyGlossary::merge(epub->getCachePath(), sink.rubyHarvest);

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -60,7 +60,7 @@ namespace {
 // v104: glyph records are fixed-size (textId) with a per-page text pool appended after
 // the glyph array; ruby/run strings moved out of VerticalGlyph (~3x smaller page buffers).
 // v105: the header includes the vertical column-spacing setting.
-constexpr uint8_t VSECTION_FILE_VERSION = 121;
+constexpr uint8_t VSECTION_FILE_VERSION = 123;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -1184,8 +1184,17 @@ struct LayoutPageSink final : ParagraphSink {
   }
 };
 
-// Byte offset of the pageCount field in the header.
-constexpr size_t HEADER_PAGECOUNT_OFFSET = 1 + sizeof(int) + 2 * sizeof(uint16_t) + sizeof(uint8_t);
+// Byte offset of the pageCount field: everything createSectionFile writes ahead of it. Keep this
+// in step with that write order -- it is a seek target, so a stale value silently OVERWRITES the
+// preceding field rather than failing. Adding the furigana flag without updating this wrote
+// pageCount over it, and a chapter whose page count happened to equal the flag passed the
+// parameter check and then read its page table from a shifted offset ("empty chapter").
+constexpr size_t HEADER_PAGECOUNT_OFFSET = sizeof(uint8_t)     // version
+                                           + sizeof(int)       // fontId
+                                           + sizeof(uint16_t)  // viewportWidth
+                                           + sizeof(uint16_t)  // viewportHeight
+                                           + sizeof(uint8_t)   // lineSpacing
+                                           + sizeof(uint8_t);  // furiganaFlag
 
 }  // namespace
 

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -49,7 +49,7 @@ class VerticalSection {
   mutable bool lastReadHeapRefused_ = false;
 
   bool streamParseAndLayout(HalFile& out, int fontId, uint16_t viewportWidth, uint16_t viewportHeight,
-                            uint8_t lineSpacing);
+                            uint8_t lineSpacing, bool furiganaEnabled);
 
   // Set by streamParseAndLayout when the layout dropped chars/glyphs on low heap. The pages that
   // made it to disk are readable (this session keeps working), but createSectionFile stamps the
@@ -100,8 +100,13 @@ class VerticalSection {
   // collapse to the final target.
   void requestPageDuringBuild(int pageIndex) { buildPageRequest_.store(pageIndex, std::memory_order_relaxed); }
 
-  bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing);
-  bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing);
+  // furiganaEnabled is part of the layout, and so part of the cache key: the column gap has to
+  // clear ruby only when ruby is actually drawn (see the gap table in streamParseAndLayout), so
+  // turning furigana off legitimately tightens the columns and the chapter must be re-laid out.
+  bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing,
+                       bool furiganaEnabled);
+  bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing,
+                         bool furiganaEnabled);
   bool clearCache() const;
   const VerticalPage* getPage() const;
   const VerticalPage* getPage(int pageIndex) const;

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -100,9 +100,8 @@ class VerticalSection {
   // collapse to the final target.
   void requestPageDuringBuild(int pageIndex) { buildPageRequest_.store(pageIndex, std::memory_order_relaxed); }
 
-  // furiganaEnabled is part of the layout, and so part of the cache key: the column gap has to
-  // clear ruby only when ruby is actually drawn (see the gap table in streamParseAndLayout), so
-  // turning furigana off legitimately tightens the columns and the chapter must be re-laid out.
+  // furiganaEnabled is part of the cache key: the column gap only has to clear ruby when ruby is
+  // drawn, so turning furigana off tightens the columns and the chapter must be re-laid out.
   bool loadSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing,
                        bool furiganaEnabled);
   bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing,

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -14,7 +14,7 @@ constexpr int kNoStyle = 0;
 // instead of re-deriving it -- every derivation probes the reference glyph out of the SD font.
 int drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
   const int cellPx = verticalCellPx(renderer, fontId);
-  // Hoisted: this was measured per emphasised glyph, inside the loop below.
+  // Measured once for the whole loop: each derivation probes the reference glyph out of the SD font.
   const int inkGapPx = verticalNominalInkGapPx(renderer, fontId, cellPx);
   // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages); the draw calls disagree
   // about what they want, so each converts:
@@ -62,12 +62,11 @@ int drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int 
 
     if (g.renderKind == VerticalGlyph::RotatedPunct) {
       const int shiftType = Kinsoku::verticalShiftType(g.codepoint);
-      // No per-shape dy nudges here any more: drawCharVerticalRotatedInCell places each shape
-      // from its own measured ink box within the cell it is given. The one exception is JLREQ's
-      // line-head rule: an opening bracket starting a column is set flush to the head, so hand
-      // the renderer a cell half an em higher and its second-half placement lands on the line
-      // head. The layout flags which brackets those are (it knows where columns start, indents
-      // and all) and removes the same half em from the rest of the column.
+      // No per-shape dy nudges: drawCharVerticalRotatedInCell places each shape from its own measured ink
+      // box within the cell it is given. The one exception is JLREQ's line-head rule -- an opening bracket
+      // starting a column is set flush to the head, so it is handed a cell half an em higher and its
+      // second-half placement lands on the line head. The layout flags which brackets those are (it knows
+      // where columns start, indents included) and removes the same half em from the rest of the column.
       if (g.lineHeadFlush) dy -= cellPx / 2;
       renderer.drawCharVerticalRotatedInCell(fontId, dx, dy, cellPx, g.codepoint, shiftType, black,
                                              static_cast<EpdFontFamily::Style>(g.style));

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -1,5 +1,7 @@
 #include "VerticalTextBlock.h"
 
+#include <Utf8.h>
+
 #include <cstring>
 
 #include "GfxRenderer.h"
@@ -8,36 +10,8 @@
 namespace {
 constexpr int kNoStyle = 0;
 
-void encodeCodepoint(uint32_t cp, std::string& out) {
-  if (cp < 0x80) {
-    out.push_back(static_cast<char>(cp));
-  } else if (cp < 0x800) {
-    out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else if (cp < 0x10000) {
-    out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  } else {
-    out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-    out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-  }
-}
-
-int computeCellPx(GfxRenderer& renderer, int fontId) {
-  // A cold SD-font advance table measures 漢 as 0 and silently falls back to getLineHeight,
-  // so the draw-time cell no longer matches the layout-time cell and every rotated-punct
-  // nudge lands wrong for that frame (seen live: cell flapping 42 -> 33 on NotoSansJP).
-  renderer.ensureSdCardFontReady(fontId, "\xe6\xbc\xa2", 0x01);
-  const int cjkAdvance = renderer.getTextAdvanceX(fontId, "\xe6\xbc\xa2", static_cast<EpdFontFamily::Style>(0));
-  if (cjkAdvance > 0) return cjkAdvance + cjkAdvance / 6;
-  return renderer.getLineHeight(fontId);
-}
-
 void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
-  const int cellPx = computeCellPx(renderer, fontId);
+  const int cellPx = verticalCellPx(renderer, fontId);
   // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages); the draw calls disagree
   // about what they want, so each converts:
   //   drawText              - a TOP, and it adds the ascender itself, so hand it baseline-ascender
@@ -103,27 +77,27 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
     }
 
     std::string utf8Char;
-    encodeCodepoint(g.codepoint, utf8Char);
+    utf8AppendCodepoint(g.codepoint, utf8Char);
     // For thin glyphs like 一 (height << ascender), the uniform nudge
     // over-shifts them because their ink sits near the em-box center, not
     // the top. Pull them back by the difference between their top and a
     // full glyph's top so the ink stays visually centered in the column.
     int uprightDy = dy;
     {
-      int gl = 0, gw = 0, gt = 0, gh = 0;
-      if (renderer.getGlyphMetrics(fontId, g.codepoint, static_cast<EpdFontFamily::Style>(g.style), &gl, &gw, &gt,
-                                   &gh) &&
-          gh > 0 && gh < gt) {
+      GlyphInk ink;
+      if (measureGlyphInk(renderer, fontId, g.codepoint, g.style, &ink) && ink.height > 0 && ink.height < ink.top) {
         // Thin glyph (一): ink sits near the middle of the em-box, not the top, so centre its
         // ink in the cell instead of using the common baseline. Same space conversion as
         // uprightTopFor: derive the cell's top, then hand drawText a TOP (it adds the ascender).
-        uprightDy = cellTop + cellPx / 2 + gt - gh / 2 - ascender;
+        uprightDy = cellTop + cellPx / 2 + ink.top - ink.height / 2 - ascender;
       }
     }
     renderer.drawText(fontId, dx, uprightDy, utf8Char.c_str(), black, static_cast<EpdFontFamily::Style>(g.style));
 
     if (g.emphasis) {
-      const int emX = dx + cellPx + std::max(1, cellPx / 12);
+      // Sesame dot beside the character, clear of its cell by the same ink gap a normal pair of
+      // characters leaves.
+      const int emX = dx + cellPx + verticalNominalInkGapPx(renderer, fontId, cellPx);
       const int emY = dy;
       renderer.drawText(fontId, emX, emY, "\xef\xb9\x85", black, static_cast<EpdFontFamily::Style>(EpdFontFamily::SUP));
     }
@@ -143,7 +117,7 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
   const int rubyLineH = (renderer.getLineHeight(rubyFontId) + 1) / 2;
   const auto rubyStyle = static_cast<EpdFontFamily::Style>(EpdFontFamily::SUP);
 
-  const int cellPxLocal = computeCellPx(renderer, fontId);
+  const int cellPxLocal = verticalCellPx(renderer, fontId);
   int prevRubyBottom = -9999;
   uint16_t prevRubyColumn = UINT16_MAX;
 
@@ -169,29 +143,15 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
     size_t rubyCharCount = 0;
     int rubyInkRight = 0;
     {
-      size_t ri = 0;
-      while (ri < rubyText.size()) {
-        const auto c0 = static_cast<unsigned char>(rubyText[ri]);
-        size_t len = 1;
-        uint32_t cp = c0;
-        if (c0 >= 0xF0) {
-          len = 4;
-          cp = c0 & 0x07u;
-        } else if (c0 >= 0xE0) {
-          len = 3;
-          cp = c0 & 0x0Fu;
-        } else if (c0 >= 0xC0) {
-          len = 2;
-          cp = c0 & 0x1Fu;
-        }
-        if (ri + len > rubyText.size()) break;
-        for (size_t k = 1; k < len; k++) cp = (cp << 6) | (static_cast<unsigned char>(rubyText[ri + k]) & 0x3Fu);
-        int gl = 0, gw = 0, gt = 0, gh = 0;
-        if (renderer.getGlyphMetrics(rubyFontId, cp, rubyStyle, &gl, &gw, &gt, &gh) && gw > 0) {
+      const auto* p = reinterpret_cast<const unsigned char*>(rubyText.c_str());
+      while (*p) {
+        const uint32_t cp = utf8NextCodepoint(&p);
+        if (cp == 0) break;
+        GlyphInk ink;
+        if (measureGlyphInk(renderer, rubyFontId, cp, static_cast<uint8_t>(rubyStyle), &ink) && ink.width > 0) {
           // SUP draws the glyph at 50%, so its metrics halve too.
-          rubyInkRight = std::max(rubyInkRight, (gl + gw + 1) / 2);
+          rubyInkRight = std::max(rubyInkRight, (ink.left + ink.width + 1) / 2);
         }
-        ri += len;
         rubyCharCount++;
       }
     }

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -38,42 +38,18 @@ int computeCellPx(GfxRenderer& renderer, int fontId) {
 
 void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
   const int cellPx = computeCellPx(renderer, fontId);
-  // Was a flat 3/8-cell "down nudge" added to every glyph; now the correction that sits the
-  // measured CJK ink box in the middle of its cell (see verticalCellBaselineOffset).
-  //
-  // It applies ONLY to the baseline-anchored kinds. Upright/UprightRun carry the font ascender in
-  // g.y, and this is the adjustment to that baseline. RotatedRun, RotatedPunct and SmallKanaCorner
-  // anchor on the cell's top instead (see RenderKind), and their draw calls place ink from that
-  // point -- adding a baseline correction to them shifted their ink relative to the CJK around
-  // them. Measured: a rotated Latin run's ink started 7px above the CJK ink beside it, which read
-  // as the CJK column "starting too low" next to it.
+  // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages); the draw calls disagree
+  // about what they want, so each converts:
+  //   drawText              - a TOP, and it adds the ascender itself, so hand it baseline-ascender
+  //   drawTextRotated90CCW  - the y it is given, used as-is
+  //   drawChar*InCell       - the cell's top-left, positioning within the cell from metrics
   const int ascender = renderer.getFontAscenderSize(fontId);
   const int baselineInCell = verticalCellBaselineOffset(renderer, fontId, cellPx);
-  // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages). What differs is what each
-  // draw call wants:
-  //   drawText              - a TOP; it adds the font ascender itself to reach the baseline, so
-  //                           hand it (baseline - ascender).
-  //   drawTextRotated90CCW  - the y it is given, used as-is.
-  //   drawChar*InCell       - the cell's top-left, positioning within the cell from metrics.
   const int uprightTopAdjust = baselineInCell - ascender;
-  // Two coordinate spaces meet here, and conflating them is what the old "global down nudge" was
-  // really compensating for:
-  //
-  //   Upright / UprightRun  - layout stores g.y as a BASELINE (row*cellPx + ascender), but
-  //                           GfxRenderer::drawText takes the glyph's TOP and adds the ascender
-  //                           itself (yPos = y + getFontAscenderSize). Passing the baseline
-  //                           straight in added the ascender twice, drawing every upright glyph a
-  //                           full ascender low -- measured 34px, which is most of a 33px cell.
-  //   RotatedRun            - drawTextRotated90CCW uses y as given (lastBaseY = y).
-  //   RotatedPunct / SmallKanaCorner - drawChar*InCell position within the cell from its top-left.
-  //
-  // So only the first group needs converting, and the conversion is exact rather than a fraction:
-  // put the baseline at baselineInCell below the cell's top, then hand drawText the top.
 
   // Styled-block borders (kakomi boxes, .k-solid-top separator rules). Rects share the glyphs'
-  // logical coordinate space; glyph y values are baseline-based while rect y is cell-top-based,
-  // but both get the same offsets. `edges` says which lines to draw; EXTEND_* runs the
-  // horizontal lines through to the screen edge (half-open box across a page boundary).
+  // cell-top coordinate space and the same offsets. `edges` says which lines to draw; EXTEND_*
+  // runs the horizontal lines through to the screen edge (half-open box across a page boundary).
   for (const VerticalBoxRect& b : page.boxes) {
     const bool extendLeft = (b.edges & VerticalBoxRect::EXTEND_LEFT) != 0;
     const bool extendRight = (b.edges & VerticalBoxRect::EXTEND_RIGHT) != 0;
@@ -171,10 +147,8 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
   int prevRubyBottom = -9999;
   uint16_t prevRubyColumn = UINT16_MAX;
 
-  // JLREQ 3.3.8: when a ruby text is longer than its base, whether the overhang may fall on the
-  // character before, the character after, or both, depends on what those neighbours are. Ruby
-  // may hang over ordinary kana/kanji, but not over punctuation or bracket shapes (their own
-  // half-em placement is what keeps them legible), nor over a character that itself carries ruby.
+  // JLREQ 3.3.8: ruby may hang over ordinary kana/kanji, but not over punctuation or brackets
+  // (their half-em placement is what keeps them legible), nor over a character carrying its own.
   const auto hangoverAllowedOver = [this](const VerticalGlyph* n) {
     if (!n) return false;                               // page/column edge
     if (!page_.glyphTextStr(*n).empty()) return false;  // it has ruby of its own
@@ -222,34 +196,22 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
       }
     }
 
-    // Ruby starts where its base character's cell ENDS -- its own virtual body beside the base,
-    // not overlapping it. (It used to be pulled back by an eighth of a cell, which read as ruby
-    // crowding the character it annotates.) For the first column that puts it outside the text
-    // area and into the margin, which is what JLREQ asks for (Fig 2.37). The margin is only a few
-    // px on this screen, so clamp to the panel -- using the measured ink reach rather than a
-    // half-cell guess, which held the edge column's ruby a couple of px further left than needed.
+    // Ruby's virtual body starts where the base character's cell ENDS, beside it, not over it.
+    // At the text edge that puts it in the margin, per JLREQ Fig 2.37 -- clamped to the panel by
+    // its measured ink reach, since a margin here is only a few px.
     const int rubyReach = rubyInkRight > 0 ? rubyInkRight : std::max(1, cellPxLocal / 2);
     const int rubyX = std::min(g.x + offsetX + cellPxLocal, renderer.getScreenWidth() - rubyReach);
 
-    // JLREQ 3.3.5 nakatsuki (中付き): "attach a ruby character so that its vertical center
-    // matches that of the base character", and with three or more ruby characters on one base,
-    // "position a ruby text so that its vertical center is aligned with that of its base
-    // character". Ruby is set solid, so the text's virtual length is simply N ruby bodies.
-    //
-    // The alignment is on VIRTUAL BODIES, not ink -- so no glyph measuring and no fudge factor.
-    // One renderer detail has to be undone: ruby draws with EpdFontFamily::SUP, which scales the
-    // glyph to 50%, but GfxRenderer::drawText still offsets by the FULL ascender (yPos = y +
-    // getFontAscenderSize). The rendered baseline therefore belongs half an ascender higher than
-    // drawText will put it, which is exactly what the old "ruby sat a touch high, drop it by
-    // ~6/5 of a ruby line" tuning was compensating for from the wrong end.
+    // JLREQ 3.3.5 nakatsuki (中付き): the ruby text's vertical centre aligns with the base
+    // character's. Ruby is set solid, so its virtual length is N ruby bodies, and the alignment is
+    // on VIRTUAL BODIES rather than ink. The half-ascender term undoes a renderer detail: SUP
+    // scales the glyph to 50% but drawText still offsets by the full ascender.
     const int rubyBlockH = static_cast<int>(rubyCharCount) * rubyLineH;
     const int rubyBodyTop = g.y + offsetY + (cellPxLocal - rubyBlockH) / 2;
     int rubyY = rubyBodyTop - renderer.getFontAscenderSize(rubyFontId) / 2;
 
-    // JLREQ 3.3.8: distribute any overhang according to what the neighbours are. Centring
-    // (nakatsuki) spills half before and half after the base; where a neighbour cannot be hung
-    // over, that share moves to the other side, and where neither can, the ruby stays centred
-    // and simply overlaps as little as possible.
+    // JLREQ 3.3.8: nakatsuki spills half the overhang each way; where a neighbour cannot be hung
+    // over, its share moves to the other side.
     const int overhang = rubyBlockH - cellPxLocal;
     if (overhang > 0) {
       const VerticalGlyph* before = nullptr;
@@ -263,9 +225,8 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
       } else if (canBefore && !canAfter) {
         rubyY -= overhang / 2;  // ... or all onto the preceding one
       }
-      // both or neither: leave it centred -- "at break-even situation, the hangover is usually
-      // on the character after", which centring already favours once the collision check below
-      // only ever pushes forward.
+      // both or neither: leave it centred; the forward-only check below then favours the
+      // character after, as the spec prefers.
     }
     if (g.column == prevRubyColumn && rubyY < prevRubyBottom + 1) {
       rubyY = prevRubyBottom + 1;

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -38,7 +38,37 @@ int computeCellPx(GfxRenderer& renderer, int fontId) {
 
 void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
   const int cellPx = computeCellPx(renderer, fontId);
-  const int globalDownNudge = std::max(1, (cellPx * 3) / 8);
+  // Was a flat 3/8-cell "down nudge" added to every glyph; now the correction that sits the
+  // measured CJK ink box in the middle of its cell (see verticalCellBaselineOffset).
+  //
+  // It applies ONLY to the baseline-anchored kinds. Upright/UprightRun carry the font ascender in
+  // g.y, and this is the adjustment to that baseline. RotatedRun, RotatedPunct and SmallKanaCorner
+  // anchor on the cell's top instead (see RenderKind), and their draw calls place ink from that
+  // point -- adding a baseline correction to them shifted their ink relative to the CJK around
+  // them. Measured: a rotated Latin run's ink started 7px above the CJK ink beside it, which read
+  // as the CJK column "starting too low" next to it.
+  const int ascender = renderer.getFontAscenderSize(fontId);
+  const int baselineInCell = verticalCellBaselineOffset(renderer, fontId, cellPx);
+  // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages). What differs is what each
+  // draw call wants:
+  //   drawText              - a TOP; it adds the font ascender itself to reach the baseline, so
+  //                           hand it (baseline - ascender).
+  //   drawTextRotated90CCW  - the y it is given, used as-is.
+  //   drawChar*InCell       - the cell's top-left, positioning within the cell from metrics.
+  const int uprightTopAdjust = baselineInCell - ascender;
+  // Two coordinate spaces meet here, and conflating them is what the old "global down nudge" was
+  // really compensating for:
+  //
+  //   Upright / UprightRun  - layout stores g.y as a BASELINE (row*cellPx + ascender), but
+  //                           GfxRenderer::drawText takes the glyph's TOP and adds the ascender
+  //                           itself (yPos = y + getFontAscenderSize). Passing the baseline
+  //                           straight in added the ascender twice, drawing every upright glyph a
+  //                           full ascender low -- measured 34px, which is most of a 33px cell.
+  //   RotatedRun            - drawTextRotated90CCW uses y as given (lastBaseY = y).
+  //   RotatedPunct / SmallKanaCorner - drawChar*InCell position within the cell from its top-left.
+  //
+  // So only the first group needs converting, and the conversion is exact rather than a fraction:
+  // put the baseline at baselineInCell below the cell's top, then hand drawText the top.
 
   // Styled-block borders (kakomi boxes, .k-solid-top separator rules). Rects share the glyphs'
   // logical coordinate space; glyph y values are baseline-based while rect y is cell-top-based,
@@ -47,7 +77,7 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
   for (const VerticalBoxRect& b : page.boxes) {
     const bool extendLeft = (b.edges & VerticalBoxRect::EXTEND_LEFT) != 0;
     const bool extendRight = (b.edges & VerticalBoxRect::EXTEND_RIGHT) != 0;
-    const int yTop = b.y + offsetY + globalDownNudge;
+    const int yTop = b.y + offsetY;  // box rects are cell-top based, like the rotated kinds
     const int yBottom = yTop + b.h;
     const int xLeft = extendLeft ? 0 : b.x + offsetX;
     const int xRight = extendRight ? renderer.getScreenWidth() - 1 : b.x + b.w + offsetX;
@@ -59,7 +89,11 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
 
   for (const VerticalGlyph& g : page.glyphs) {
     const int dx = g.x + offsetX;
-    int dy = g.y + offsetY + globalDownNudge;
+    const int cellTop = g.y + offsetY;
+    int dy = cellTop;
+    if (g.renderKind == VerticalGlyph::Upright || g.renderKind == VerticalGlyph::UprightRun) {
+      dy = cellTop + uprightTopAdjust;
+    }
 
     if (g.renderKind == VerticalGlyph::RotatedRun) {
       renderer.drawTextRotated90CCW(fontId, dx, dy, page.glyphText(g), black,
@@ -74,15 +108,13 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
 
     if (g.renderKind == VerticalGlyph::RotatedPunct) {
       const int shiftType = Kinsoku::verticalShiftType(g.codepoint);
-      if (g.codepoint == 0x2025 || g.codepoint == 0x2026) {
-        // 7/8 cell: the dot stack still read high against the character before it (device
-        // check, book 2). Keep in sync with GfxRenderer::verticalPunctInkBox().
-        dy += std::max(1, (cellPx * 7) / 8);
-      } else if (shiftType == 4) {
-        // Dashes/chōonpu sat visibly low in their cell (device photo, kyokasho) -- a
-        // quarter cell less down-shift than the ellipsis dot stack.
-        dy += std::max(1, (cellPx * 3) / 8);
-      }
+      // No per-shape dy nudges here any more: drawCharVerticalRotatedInCell places each shape
+      // from its own measured ink box within the cell it is given. The one exception is JLREQ's
+      // line-head rule: an opening bracket starting a column is set flush to the head, so hand
+      // the renderer a cell half an em higher and its second-half placement lands on the line
+      // head. The layout flags which brackets those are (it knows where columns start, indents
+      // and all) and removes the same half em from the rest of the column.
+      if (g.lineHeadFlush) dy -= cellPx / 2;
       renderer.drawCharVerticalRotatedInCell(fontId, dx, dy, cellPx, g.codepoint, shiftType, black,
                                              static_cast<EpdFontFamily::Style>(g.style));
       continue;
@@ -106,11 +138,10 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
       if (renderer.getGlyphMetrics(fontId, g.codepoint, static_cast<EpdFontFamily::Style>(g.style), &gl, &gw, &gt,
                                    &gh) &&
           gh > 0 && gh < gt) {
-        // Thin glyph (一): ink sits near the middle of the em-box, not the
-        // top. Remove the uniform nudge and instead position so the ink's
-        // vertical center aligns with the cell's vertical center.
-        // ink center = cursorY - top + height/2; cell center ≈ g.y + offsetY
-        uprightDy = g.y + offsetY + gt - gh / 2;
+        // Thin glyph (一): ink sits near the middle of the em-box, not the top, so centre its
+        // ink in the cell instead of using the common baseline. Same space conversion as
+        // uprightTopFor: derive the cell's top, then hand drawText a TOP (it adds the ascender).
+        uprightDy = cellTop + cellPx / 2 + gt - gh / 2 - ascender;
       }
     }
     renderer.drawText(fontId, dx, uprightDy, utf8Char.c_str(), black, static_cast<EpdFontFamily::Style>(g.style));
@@ -134,45 +165,108 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
   drawGlyphs(renderer, page_, fontId, offsetX, offsetY, black);
 
   const int rubyLineH = (renderer.getLineHeight(rubyFontId) + 1) / 2;
-  const int rubyAscender = renderer.getFontAscenderSize(rubyFontId) / 2;
-  const int baseLineH = renderer.getLineHeight(fontId);
   const auto rubyStyle = static_cast<EpdFontFamily::Style>(EpdFontFamily::SUP);
 
   const int cellPxLocal = computeCellPx(renderer, fontId);
   int prevRubyBottom = -9999;
   uint16_t prevRubyColumn = UINT16_MAX;
 
-  for (const VerticalGlyph& g : page_.glyphs) {
+  // JLREQ 3.3.8: when a ruby text is longer than its base, whether the overhang may fall on the
+  // character before, the character after, or both, depends on what those neighbours are. Ruby
+  // may hang over ordinary kana/kanji, but not over punctuation or bracket shapes (their own
+  // half-em placement is what keeps them legible), nor over a character that itself carries ruby.
+  const auto hangoverAllowedOver = [this](const VerticalGlyph* n) {
+    if (!n) return false;                               // page/column edge
+    if (!page_.glyphTextStr(*n).empty()) return false;  // it has ruby of its own
+    if (n->renderKind == VerticalGlyph::RotatedRun || n->renderKind == VerticalGlyph::UprightRun) return false;
+    if (n->codepoint == 0) return false;
+    return Kinsoku::verticalShiftType(n->codepoint) == 0 && !Kinsoku::needsVerticalRotation(n->codepoint);
+  };
+
+  for (size_t gi = 0; gi < page_.glyphs.size(); gi++) {
+    const VerticalGlyph& g = page_.glyphs[gi];
     const std::string& rubyText = page_.glyphTextStr(g);
     if (rubyText.empty() || g.renderKind == VerticalGlyph::RotatedRun || g.renderKind == VerticalGlyph::UprightRun) {
       continue;
     }
 
-    const int rubyX = g.x + offsetX + cellPxLocal - cellPxLocal / 8;
-
+    // Walk the ruby string once: count its characters, and measure how far right its ink can
+    // reach. Every ruby character in the stack is drawn at the same x, so the widest one decides.
     size_t rubyCharCount = 0;
+    int rubyInkRight = 0;
     {
       size_t ri = 0;
       while (ri < rubyText.size()) {
         const auto c0 = static_cast<unsigned char>(rubyText[ri]);
-        if (c0 < 0x80)
-          ri += 1;
-        else if ((c0 & 0xE0) == 0xC0)
-          ri += 2;
-        else if ((c0 & 0xF0) == 0xE0)
-          ri += 3;
-        else
-          ri += 4;
+        size_t len = 1;
+        uint32_t cp = c0;
+        if (c0 >= 0xF0) {
+          len = 4;
+          cp = c0 & 0x07u;
+        } else if (c0 >= 0xE0) {
+          len = 3;
+          cp = c0 & 0x0Fu;
+        } else if (c0 >= 0xC0) {
+          len = 2;
+          cp = c0 & 0x1Fu;
+        }
+        if (ri + len > rubyText.size()) break;
+        for (size_t k = 1; k < len; k++) cp = (cp << 6) | (static_cast<unsigned char>(rubyText[ri + k]) & 0x3Fu);
+        int gl = 0, gw = 0, gt = 0, gh = 0;
+        if (renderer.getGlyphMetrics(rubyFontId, cp, rubyStyle, &gl, &gw, &gt, &gh) && gw > 0) {
+          // SUP draws the glyph at 50%, so its metrics halve too.
+          rubyInkRight = std::max(rubyInkRight, (gl + gw + 1) / 2);
+        }
+        ri += len;
         rubyCharCount++;
       }
     }
 
-    const int rubyBlockH = static_cast<int>(rubyCharCount) * rubyLineH;
-    // Ruby sat a touch high against its base character on device; drop it by another
-    // ~2/5 of a ruby line (device check, Vita Sexualis furigana).
-    const int rubyDownNudge = std::max(3, (rubyLineH * 6) / 5);
-    int rubyY = g.y + offsetY + (baseLineH - rubyBlockH) / 2 - rubyLineH + rubyDownNudge;
+    // Ruby starts where its base character's cell ENDS -- its own virtual body beside the base,
+    // not overlapping it. (It used to be pulled back by an eighth of a cell, which read as ruby
+    // crowding the character it annotates.) For the first column that puts it outside the text
+    // area and into the margin, which is what JLREQ asks for (Fig 2.37). The margin is only a few
+    // px on this screen, so clamp to the panel -- using the measured ink reach rather than a
+    // half-cell guess, which held the edge column's ruby a couple of px further left than needed.
+    const int rubyReach = rubyInkRight > 0 ? rubyInkRight : std::max(1, cellPxLocal / 2);
+    const int rubyX = std::min(g.x + offsetX + cellPxLocal, renderer.getScreenWidth() - rubyReach);
 
+    // JLREQ 3.3.5 nakatsuki (中付き): "attach a ruby character so that its vertical center
+    // matches that of the base character", and with three or more ruby characters on one base,
+    // "position a ruby text so that its vertical center is aligned with that of its base
+    // character". Ruby is set solid, so the text's virtual length is simply N ruby bodies.
+    //
+    // The alignment is on VIRTUAL BODIES, not ink -- so no glyph measuring and no fudge factor.
+    // One renderer detail has to be undone: ruby draws with EpdFontFamily::SUP, which scales the
+    // glyph to 50%, but GfxRenderer::drawText still offsets by the FULL ascender (yPos = y +
+    // getFontAscenderSize). The rendered baseline therefore belongs half an ascender higher than
+    // drawText will put it, which is exactly what the old "ruby sat a touch high, drop it by
+    // ~6/5 of a ruby line" tuning was compensating for from the wrong end.
+    const int rubyBlockH = static_cast<int>(rubyCharCount) * rubyLineH;
+    const int rubyBodyTop = g.y + offsetY + (cellPxLocal - rubyBlockH) / 2;
+    int rubyY = rubyBodyTop - renderer.getFontAscenderSize(rubyFontId) / 2;
+
+    // JLREQ 3.3.8: distribute any overhang according to what the neighbours are. Centring
+    // (nakatsuki) spills half before and half after the base; where a neighbour cannot be hung
+    // over, that share moves to the other side, and where neither can, the ruby stays centred
+    // and simply overlaps as little as possible.
+    const int overhang = rubyBlockH - cellPxLocal;
+    if (overhang > 0) {
+      const VerticalGlyph* before = nullptr;
+      const VerticalGlyph* after = nullptr;
+      if (gi > 0 && page_.glyphs[gi - 1].column == g.column) before = &page_.glyphs[gi - 1];
+      if (gi + 1 < page_.glyphs.size() && page_.glyphs[gi + 1].column == g.column) after = &page_.glyphs[gi + 1];
+      const bool canBefore = hangoverAllowedOver(before);
+      const bool canAfter = hangoverAllowedOver(after);
+      if (canAfter && !canBefore) {
+        rubyY += overhang / 2;  // push it all onto the following character
+      } else if (canBefore && !canAfter) {
+        rubyY -= overhang / 2;  // ... or all onto the preceding one
+      }
+      // both or neither: leave it centred -- "at break-even situation, the hangover is usually
+      // on the character after", which centring already favours once the collision check below
+      // only ever pushes forward.
+    }
     if (g.column == prevRubyColumn && rubyY < prevRubyBottom + 1) {
       rubyY = prevRubyBottom + 1;
     }

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -10,8 +10,12 @@
 namespace {
 constexpr int kNoStyle = 0;
 
-void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
+// Returns the cell size it drew with, so a caller needing the same geometry (ruby) reuses it
+// instead of re-deriving it -- every derivation probes the reference glyph out of the SD font.
+int drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int offsetX, int offsetY, bool black) {
   const int cellPx = verticalCellPx(renderer, fontId);
+  // Hoisted: this was measured per emphasised glyph, inside the loop below.
+  const int inkGapPx = verticalNominalInkGapPx(renderer, fontId, cellPx);
   // VerticalGlyph::y is the cell's TOP for every kind (see layoutPages); the draw calls disagree
   // about what they want, so each converts:
   //   drawText              - a TOP, and it adds the ascender itself, so hand it baseline-ascender
@@ -97,11 +101,12 @@ void drawGlyphs(GfxRenderer& renderer, const VerticalPage& page, int fontId, int
     if (g.emphasis) {
       // Sesame dot beside the character, clear of its cell by the same ink gap a normal pair of
       // characters leaves.
-      const int emX = dx + cellPx + verticalNominalInkGapPx(renderer, fontId, cellPx);
+      const int emX = dx + cellPx + inkGapPx;
       const int emY = dy;
       renderer.drawText(fontId, emX, emY, "\xef\xb9\x85", black, static_cast<EpdFontFamily::Style>(EpdFontFamily::SUP));
     }
   }
+  return cellPx;
 }
 
 }  // namespace
@@ -112,12 +117,11 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int offsetX, i
 
 void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId, int offsetX, int offsetY,
                                bool black) const {
-  drawGlyphs(renderer, page_, fontId, offsetX, offsetY, black);
+  const int cellPxLocal = drawGlyphs(renderer, page_, fontId, offsetX, offsetY, black);
 
   const int rubyLineH = (renderer.getLineHeight(rubyFontId) + 1) / 2;
   const auto rubyStyle = static_cast<EpdFontFamily::Style>(EpdFontFamily::SUP);
 
-  const int cellPxLocal = verticalCellPx(renderer, fontId);
   int prevRubyBottom = -9999;
   uint16_t prevRubyColumn = UINT16_MAX;
 

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -42,6 +42,14 @@ constexpr size_t READ_BUFFER_SIZE = 512;
 // Maximum number of CSS rules to store in the selector map
 // Prevents unbounded memory growth from pathological CSS files
 constexpr size_t MAX_RULES = 1500;
+// Rules the CACHE FILE may hold. Deliberately larger than MAX_RULES: that one bounds the rule map
+// held in RAM, while the cache lives on the SD card and is read back FILTERED -- loadFromCache()
+// keeps only the selectors a chapter's classes actually use, and collectVerticalStyles() streams
+// the file for vertical-block rules. Capping the FILE at the RAM figure truncated in file order,
+// so whether a book's styling survived depended on where it sat in its stylesheet: the EBPAJ
+// template runs past 1500 rules, and everything after that point was silently absent from every
+// book built on it (measured on 変な家２: 1500 of ~1700 rules cached).
+constexpr size_t MAX_CACHED_RULES = 4000;
 
 // Headroom for one selector-map insertion. Cache loads are streamed, so requiring enough
 // contiguous heap for the entire book-wide rule table rejects safe chapter-filtered loads.
@@ -1484,7 +1492,7 @@ bool CssParser::validateCache() const {
 
   uint16_t ruleCount = 0;
   if (file.read(&ruleCount, sizeof(ruleCount)) != sizeof(ruleCount)) return false;
-  if (ruleCount == 0 || ruleCount > MAX_RULES) {
+  if (ruleCount == 0 || ruleCount > MAX_CACHED_RULES) {
     LOG_DBG("CSS", "Invalid cache rule count (%u)", ruleCount);
     return false;
   }
@@ -1523,7 +1531,7 @@ size_t CssParser::collectVerticalStyles(std::vector<std::pair<std::string, Verti
   if (file.read(&version, 1) != 1 || version != CssParser::CSS_CACHE_VERSION) return 0;
   uint16_t ruleCount = 0;
   if (file.read(&ruleCount, sizeof(ruleCount)) != sizeof(ruleCount)) return 0;
-  if (ruleCount > MAX_RULES) return 0;
+  if (ruleCount > MAX_CACHED_RULES) return 0;
 
   auto emOf = [](const float v, const uint8_t unit) -> float {
     return unit == static_cast<uint8_t>(CssUnit::Em) || unit == static_cast<uint8_t>(CssUnit::Rem) ? v : 0.0f;
@@ -1644,8 +1652,8 @@ bool CssParser::beginCacheAppend() {
 bool CssParser::appendRulesToCache() {
   if (!cacheAppendActive_) return false;
   for (const auto& pair : rulesBySelector_) {
-    if (appendedRuleCount_ >= MAX_RULES) {
-      LOG_DBG("CSS", "Reached max rules limit (%zu) while caching, dropping remainder", MAX_RULES);
+    if (appendedRuleCount_ >= MAX_CACHED_RULES) {
+      LOG_DBG("CSS", "Reached max cached rules limit (%zu), dropping remainder", MAX_CACHED_RULES);
       break;
     }
     writeRuleRecord(cacheAppendFile_, pair.first, pair.second);
@@ -1704,8 +1712,8 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
     return false;
   }
 
-  if (ruleCount > MAX_RULES) {
-    LOG_DBG("CSS", "Invalid cache rule count (%u > %zu)", ruleCount, MAX_RULES);
+  if (ruleCount > MAX_CACHED_RULES) {
+    LOG_DBG("CSS", "Invalid cache rule count (%u > %zu)", ruleCount, MAX_CACHED_RULES);
     rulesBySelector_.clear();
     return false;
   }
@@ -1713,7 +1721,10 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
   // A chapter-filtered load keeps only a small subset of a book-wide cache. Reserving the
   // book's full rule count here defeats that filter and can consume the last contiguous block
   // before the first record is even inspected.
-  if (usedClasses == nullptr) rulesBySelector_.reserve(ruleCount);
+  // The cache may hold more rules than the RAM cap allows. An UNFILTERED load is the one path
+  // that would materialise them all, so it reserves -- and below, keeps -- no more than the
+  // resident cap, exactly as it did when the two limits were a single number.
+  if (usedClasses == nullptr) rulesBySelector_.reserve(std::min<size_t>(ruleCount, MAX_RULES));
 
   auto hasRemainingBytes = [&file](const size_t neededBytes) -> bool {
     return static_cast<size_t>(file.available()) >= neededBytes;
@@ -1733,6 +1744,7 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
+    if (usedClasses == nullptr && rulesBySelector_.size() >= MAX_RULES) break;
     // Read selector string
     uint16_t selectorLen = 0;
     if (!hasRemainingBytes(sizeof(selectorLen))) {

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -42,13 +42,12 @@ constexpr size_t READ_BUFFER_SIZE = 512;
 // Maximum number of CSS rules to store in the selector map
 // Prevents unbounded memory growth from pathological CSS files
 constexpr size_t MAX_RULES = 1500;
-// Rules the CACHE FILE may hold. Deliberately larger than MAX_RULES: that one bounds the rule map
-// held in RAM, while the cache lives on the SD card and is read back FILTERED -- loadFromCache()
-// keeps only the selectors a chapter's classes actually use, and collectVerticalStyles() streams
-// the file for vertical-block rules. Capping the FILE at the RAM figure truncated in file order,
-// so whether a book's styling survived depended on where it sat in its stylesheet: the EBPAJ
-// template runs past 1500 rules, and everything after that point was silently absent from every
-// book built on it (measured on 変な家２: 1500 of ~1700 rules cached).
+// Rules the CACHE FILE may hold. Deliberately larger than MAX_RULES, which bounds the rule map held
+// in RAM: the cache lives on the SD card and is read back FILTERED -- loadFromCache() keeps only the
+// selectors a chapter's classes use, and collectVerticalStyles() streams the file for vertical-block
+// rules. Capping the FILE at the RAM figure truncates in file order, so whether a book's styling
+// survives depends on where it sits in its stylesheet: the EBPAJ template runs past 1500 rules, and
+// everything after that point was absent from every book built on it.
 constexpr size_t MAX_CACHED_RULES = 4000;
 
 // Headroom for one selector-map insertion. Cache loads are streamed, so requiring enough

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -1721,9 +1721,9 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
   // A chapter-filtered load keeps only a small subset of a book-wide cache. Reserving the
   // book's full rule count here defeats that filter and can consume the last contiguous block
   // before the first record is even inspected.
-  // The cache may hold more rules than the RAM cap allows. An UNFILTERED load is the one path
-  // that would materialise them all, so it reserves -- and below, keeps -- no more than the
-  // resident cap, exactly as it did when the two limits were a single number.
+  // The cache may hold more rules than the RAM cap allows, so the map is bounded by MAX_RULES on
+  // every path (see the loop below). A filtered load keeps only a small subset anyway; an
+  // unfiltered one would materialise the lot, so it also reserves no more than that cap.
   if (usedClasses == nullptr) rulesBySelector_.reserve(std::min<size_t>(ruleCount, MAX_RULES));
 
   auto hasRemainingBytes = [&file](const size_t neededBytes) -> bool {
@@ -1744,7 +1744,9 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
-    if (usedClasses == nullptr && rulesBySelector_.size() >= MAX_RULES) break;
+    // The RAM bound applies to EVERY load, filtered or not: a chapter touching enough classes
+    // could otherwise pull more than MAX_RULES out of a cache file that may now hold 4000.
+    if (rulesBySelector_.size() >= MAX_RULES) break;
     // Read selector string
     uint16_t selectorLen = 0;
     if (!hasRemainingBytes(sizeof(selectorLen))) {

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -58,7 +58,7 @@ class CssParser {
   //      (82 -> 88 fixed), so a v17 record cannot be read with the v18 framing.
   // v19: the existing border byte now also packs line style + 1..4px width, and display retains
   //      inline-block so close-time heading rules can shrink to their text. Framing is unchanged.
-  static constexpr uint8_t CSS_CACHE_VERSION = 19;
+  static constexpr uint8_t CSS_CACHE_VERSION = 20;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2387,9 +2387,12 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   // when rotated from proportional fonts. Render a centered vertical dot stack
   // directly in the cell to keep stable spacing and avoid overlaps.
   if (cp == 0x2026 || cp == 0x2025) {
+    // Three dots (two for U+2025) evenly spaced across the em, each filling half its slot --
+    // the pitch and the ink both follow from the em, with no separately chosen dot size.
     const int dotCount = (cp == 0x2026) ? 3 : 2;
-    const int dotSize = std::max(1, cellSize / 10);
-    const int gap = std::max(1, cellSize / 10);
+    const int pitch = std::max(2, cellSize / 3);
+    const int dotSize = std::max(1, pitch / 2);
+    const int gap = pitch - dotSize;
     const int totalH = dotCount * dotSize + (dotCount - 1) * gap;
     // Centred in its cell, like the upright glyphs around it.
     const int startY = cellTopY + (cellSize - totalH) / 2;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2391,9 +2391,7 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     const int dotSize = std::max(1, cellSize / 10);
     const int gap = std::max(1, cellSize / 10);
     const int totalH = dotCount * dotSize + (dotCount - 1) * gap;
-    // Centre the stack in its cell. The old placement (a third of a cell down, plus another
-    // third, plus an ascender-percentage "font-adaptive nudge") was chasing upright glyphs that
-    // were themselves drawn an ascender too low; they are centred now, so this is too.
+    // Centred in its cell, like the upright glyphs around it.
     const int startY = cellTopY + (cellSize - totalH) / 2;
     if (inkTopOut) {
       *inkTopOut = startY;
@@ -2421,14 +2419,8 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   const int rotatedW = glyph->height;
   const int rotatedH = glyph->width;
 
-  // Centre the rotated ink box in the cell -- the same rule upright glyphs follow, so
-  // punctuation lands on the column's axis by construction.
-  //
-  // This used to carry three font-adaptive nudges (an `ascender vs cell` percentage push, a
-  // `baselineExcess` term, and a flat cellSize/3 drop). They existed because upright glyphs were
-  // drawn a full ascender too low -- layout stored baselines and GfxRenderer::drawText adds the
-  // ascender itself -- so punctuation had to chase them down the cell. That bug is fixed at the
-  // source, and chasing it now pushes punctuation below the text it belongs to.
+  // Centre the rotated ink box in the cell -- the same rule the upright glyphs follow, so
+  // punctuation lands on the column's axis by construction. Brackets override this below.
   int drawX = cellLeftX + (cellSize - rotatedW) / 2;
   int drawY = cellTopY + (cellSize - rotatedH) / 2;
 
@@ -2437,15 +2429,11 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     // right of the em box, so pull them left onto the column axis. Angle brackets 〉》 are
     // symmetric chevrons -- the same pull pushed them visibly LEFT of the column (device
     // photo, 〈夏〉); leave them ink-centered.
-    // JLREQ: a closing bracket is a half-em glyph occupying the FIRST half of its em box, with
-    // the full em still allocated on the grid. So its ink goes in the cell's leading half --
-    // adjacent to the character it closes, with the slack falling on the far side. Across the
-    // column it sits on the LEFT, mirroring the opening bracket on the right.
+    // JLREQ: a closing bracket is a half-em glyph in the FIRST half of its em, adjacent to the
+    // character it closes, and on the LEFT across the column.
     drawY = cellTopY + (cellSize / 2 - rotatedH) / 2;
-    // Corner/lenticular/tortoise shapes are asymmetric -- their ink hugs one side of the em, so
-    // flushing them to the column's left edge is what puts them on its axis. Round parens and
-    // angle brackets are symmetric chevrons/arcs: flushing those visibly pushes them off-axis, so
-    // they keep the plain ink centring.
+    // Only the asymmetric shapes flush: their ink hugs one side of the em, so the flush is what
+    // puts them on the column axis. Symmetric ones would be pushed off it.
     if (!isSymmetricBracket(cp)) drawX = cellLeftX;
   } else if (shiftType == 3) {  // opening bracket/quote
     // Bias reduced from 2/3 to 1/2 cell and shifted a bit right: dead-centered and pushed too
@@ -2454,9 +2442,9 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     // Round parens and angle brackets stay purely ink-centered: the corner-bracket right
     // shift pushed the paren arc -- and the symmetric 〈《 chevrons (device photo, 〈夏〉) --
     // off the column axis to the RIGHT.
-    // JLREQ: an opening bracket is a half-em glyph occupying the SECOND half of its em box, so
-    // it sits adjacent to the character it opens, and on the RIGHT of the column across it. The
-    // layout measures the result through verticalPunctInkBox(), so spacing follows automatically.
+    // JLREQ: an opening bracket is a half-em glyph in the SECOND half of its em, adjacent to the
+    // character it opens, and on the RIGHT across the column. The layout reads the result back
+    // through verticalPunctInkBox(), so the spacing around it follows.
     drawY = cellTopY + cellSize / 2 + (cellSize / 2 - rotatedH) / 2;
     if (!isSymmetricBracket(cp)) drawX = cellLeftX + cellSize - rotatedW;
   }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2358,6 +2358,27 @@ void GfxRenderer::drawCharVerticalCornerTopRight(const int fontId, const int cel
 // needs the SAME numbers the drawer uses -- rotated punctuation is placed from its cell box with
 // several font-adaptive nudges, and a layout that guessed instead ran embedded Latin words into
 // the brackets around them (device photo, 「Furz」).
+// Round parens, angle brackets and braces are symmetric about the column axis, so they are drawn
+// ink-centred across it. The corner/lenticular/tortoise family is not: its ink hugs one side of
+// the em box, and it is flushed to the matching edge of the cell instead.
+static bool isSymmetricBracket(const uint32_t cp) {
+  switch (cp) {
+    case 0x0028:  // (
+    case 0x0029:  // )
+    case 0xFF08:  // （
+    case 0xFF09:  // ）
+    case 0x3008:  // 〈
+    case 0x3009:  // 〉
+    case 0x300A:  // 《
+    case 0x300B:  // 》
+    case 0xFF5B:  // ｛
+    case 0xFF5D:  // ｝
+      return true;
+    default:
+      return false;
+  }
+}
+
 void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cellLeftX, const int cellTopY,
                                                 const int cellSize, const uint32_t cp, const int shiftType,
                                                 const bool black, const EpdFontFamily::Style style, int* inkTopOut,
@@ -2370,19 +2391,10 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     const int dotSize = std::max(1, cellSize / 10);
     const int gap = std::max(1, cellSize / 10);
     const int totalH = dotCount * dotSize + (dotCount - 1) * gap;
-    // Font-adaptive nudge for ellipsis (same logic as brackets)
-    const auto fontIt2 = fontMap.find(fontId);
-    int ellipsisExtra = 0;
-    if (fontIt2 != fontMap.end()) {
-      const EpdFontData* fd = fontIt2->second.getData(style);
-      if (fd && cellSize > 0) {
-        const int pct = fd->ascender * 100 / cellSize;
-        if (pct > 100) ellipsisExtra = cellSize * (pct - 100) / 30;
-      }
-    }
-    int startY = cellTopY + std::max(1, cellSize / 3) + cellSize / 3 + ellipsisExtra;
-    const int maxStartY = cellTopY + std::max(1, cellSize - totalH - 1) + ellipsisExtra;
-    if (startY > maxStartY) startY = maxStartY;
+    // Centre the stack in its cell. The old placement (a third of a cell down, plus another
+    // third, plus an ascender-percentage "font-adaptive nudge") was chasing upright glyphs that
+    // were themselves drawn an ascender too low; they are centred now, so this is too.
+    const int startY = cellTopY + (cellSize - totalH) / 2;
     if (inkTopOut) {
       *inkTopOut = startY;
       *inkHeightOut = totalH;
@@ -2409,44 +2421,32 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   const int rotatedW = glyph->height;
   const int rotatedH = glyph->width;
 
-  // Font-adaptive nudge: compare the font's ascender to the cell size.
-  // Compact fonts (UDDigiKyokasho, ascender ~cell) need no extra nudge;
-  // taller fonts (Noto Serif/Sans, ascender > cell) need more push to avoid overlap.
-  const EpdFontData* fontData = font.getData(style);
-  const int ascender = fontData ? fontData->ascender : cellSize;
-  const int fontPct = (cellSize > 0) ? (ascender * 100 / cellSize) : 100;
-  const int extraNudge = (fontPct > 100) ? (cellSize * (fontPct - 100) / 30) : 0;
-  // How much lower this font's upright neighbors sit in their cells than a compact font's:
-  // upright glyphs hang from the baseline at `ascender`, and cellSize = em * 7/6, so any
-  // ascender beyond the em height pushes the surrounding ink down by that surplus. Rotated
-  // punctuation is placed by its own ink box and must follow, or it floats high relative to
-  // the column (NotoSansJP asc 34 / cell 33 vs UDDigiKyokasho asc 26 / cell 33).
-  const int baselineExcess = std::max(0, ascender - (cellSize * 6) / 7);
-
+  // Centre the rotated ink box in the cell -- the same rule upright glyphs follow, so
+  // punctuation lands on the column's axis by construction.
+  //
+  // This used to carry three font-adaptive nudges (an `ascender vs cell` percentage push, a
+  // `baselineExcess` term, and a flat cellSize/3 drop). They existed because upright glyphs were
+  // drawn a full ascender too low -- layout stored baselines and GfxRenderer::drawText adds the
+  // ascender itself -- so punctuation had to chase them down the cell. That bug is fixed at the
+  // source, and chasing it now pushes punctuation below the text it belongs to.
   int drawX = cellLeftX + (cellSize - rotatedW) / 2;
-  int drawY = cellTopY + (cellSize - rotatedH) / 2 + cellSize / 3 + extraNudge * 2;
-  if (shiftType == 4) {
-    // Dashes/chōonpu read slightly right of the column axis when purely ink-centered
-    // (device photo, kyokasho) -- bias them a touch left. Tall fonts (Noto) additionally
-    // need one more nudge unit down or the stroke floats high in its cell.
-    drawX -= std::max(1, cellSize / 10);
-    drawY += baselineExcess * 2;
-  }
+  int drawY = cellTopY + (cellSize - rotatedH) / 2;
 
   if (shiftType == 2) {  // closing bracket/quote
     // Corner/lenticular/tortoise brackets (」』】〕) have their rotated ink hugging the
     // right of the em box, so pull them left onto the column axis. Angle brackets 〉》 are
     // symmetric chevrons -- the same pull pushed them visibly LEFT of the column (device
     // photo, 〈夏〉); leave them ink-centered.
-    const bool isSquareBracket = (cp == 0x300D || cp == 0x300F || cp == 0x3011 || cp == 0x3015);
-    if (isSquareBracket) {
-      drawX = cellLeftX + (cellSize - rotatedW) / 2 - cellSize / 3;
-    }
-    // +cellSize/4: the closing bracket read high against the Japanese character it closes
-    // (device check, tuned in two steps). After an embedded Latin word the distance is set by
-    // the run layout instead, so that case is tuned separately in VerticalParsedText.
-    const int closingBias = std::max(1, cellSize / 6 + cellSize / 4 + extraNudge * 2);
-    drawY = cellTopY + cellSize - rotatedH + closingBias;
+    // JLREQ: a closing bracket is a half-em glyph occupying the FIRST half of its em box, with
+    // the full em still allocated on the grid. So its ink goes in the cell's leading half --
+    // adjacent to the character it closes, with the slack falling on the far side. Across the
+    // column it sits on the LEFT, mirroring the opening bracket on the right.
+    drawY = cellTopY + (cellSize / 2 - rotatedH) / 2;
+    // Corner/lenticular/tortoise shapes are asymmetric -- their ink hugs one side of the em, so
+    // flushing them to the column's left edge is what puts them on its axis. Round parens and
+    // angle brackets are symmetric chevrons/arcs: flushing those visibly pushes them off-axis, so
+    // they keep the plain ink centring.
+    if (!isSymmetricBracket(cp)) drawX = cellLeftX;
   } else if (shiftType == 3) {  // opening bracket/quote
     // Bias reduced from 2/3 to 1/2 cell and shifted a bit right: dead-centered and pushed too
     // deep, the bracket read as hanging low/left of the character it opens (device photos with
@@ -2454,28 +2454,18 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     // Round parens and angle brackets stay purely ink-centered: the corner-bracket right
     // shift pushed the paren arc -- and the symmetric 〈《 chevrons (device photo, 〈夏〉) --
     // off the column axis to the RIGHT.
-    const bool inkCentered = (cp == 0xFF08 || cp == 0x3008 || cp == 0x300A);
-    // baselineExcess: tall fonts (Noto) left the opening bracket hanging too high above the
-    // character it opens (kyokasho, baselineExcess 0, is unaffected).
-    // 1/2 -> 3/8 cell: the bracket still read low against the character it opens (device
-    // check). The vertical layout measures this through verticalPunctInkBox(), so the run
-    // and character spacing around it follows automatically.
-    const int openingBias = std::max(1, (cellSize * 3) / 8 + extraNudge + baselineExcess);
-    drawY = cellTopY + cellSize + openingBias;
-    if (!inkCentered) drawX += cellSize / 4;
+    // JLREQ: an opening bracket is a half-em glyph occupying the SECOND half of its em box, so
+    // it sits adjacent to the character it opens, and on the RIGHT of the column across it. The
+    // layout measures the result through verticalPunctInkBox(), so spacing follows automatically.
+    drawY = cellTopY + cellSize / 2 + (cellSize / 2 - rotatedH) / 2;
+    if (!isSymmetricBracket(cp)) drawX = cellLeftX + cellSize - rotatedW;
   }
 
   int minX = cellLeftX;
   int maxX = cellLeftX + cellSize - rotatedW;
-  int minY = cellTopY;
-  int maxY = cellTopY + cellSize * 2;
-  if (shiftType == 2) {
-    minX -= std::max(1, cellSize / 3);
-    minY -= cellSize / 2;
-  }
-  if (shiftType == 3) {
-    maxX += std::max(1, cellSize / 2);
-  }
+  const int minY = cellTopY;
+  // An opening bracket is placed into the following cell on purpose, so the box spans two.
+  const int maxY = cellTopY + cellSize * 2;
   drawX = std::clamp(drawX, minX, maxX);
   drawY = std::clamp(drawY, minY, maxY);
 
@@ -2491,15 +2481,6 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   // Solve for cursor so the rotated bbox starts at (drawX, drawY).
   const int cursorX = (drawX + rotatedW - 1) - glyph->top;
   const int cursorY = drawY - glyph->left;
-
-  // TEMP diagnostics for vertical punctuation tuning (strip with the other telemetry)
-  if (cp == 0x30FC || shiftType == 3) {
-    LOG_DBG("VROT",
-            "cp=%04X shift=%d cell=%d asc=%d pct=%d nudge=%d rotW=%d rotH=%d gTop=%d gLeft=%d cellTopY=%d drawX=%d "
-            "drawY=%d",
-            (unsigned)cp, shiftType, cellSize, ascender, fontPct, extraNudge, rotatedW, rotatedH, glyph->top,
-            glyph->left, cellTopY, drawX, drawY);
-  }
 
   renderCharImpl<TextRotation::Rotated90CCW>(*this, renderMode, font, cp, cursorX, cursorY, black, style);
 }

--- a/lib/Utf8/Utf8.cpp
+++ b/lib/Utf8/Utf8.cpp
@@ -124,22 +124,31 @@ uint32_t utf8NextCodepoint(const unsigned char** string) {
   return cp;
 }
 
-void utf8AppendCodepoint(uint32_t cp, std::string& out) {
+int utf8EncodeCodepoint(uint32_t cp, char out[5]) {
+  int n = 0;
   if (cp < 0x80) {
-    out += static_cast<char>(cp);
+    out[n++] = static_cast<char>(cp);
   } else if (cp < 0x800) {
-    out += static_cast<char>(0xC0 | (cp >> 6));
-    out += static_cast<char>(0x80 | (cp & 0x3F));
+    out[n++] = static_cast<char>(0xC0 | (cp >> 6));
+    out[n++] = static_cast<char>(0x80 | (cp & 0x3F));
   } else if (cp < 0x10000) {
-    out += static_cast<char>(0xE0 | (cp >> 12));
-    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-    out += static_cast<char>(0x80 | (cp & 0x3F));
+    out[n++] = static_cast<char>(0xE0 | (cp >> 12));
+    out[n++] = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out[n++] = static_cast<char>(0x80 | (cp & 0x3F));
   } else {
-    out += static_cast<char>(0xF0 | (cp >> 18));
-    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
-    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-    out += static_cast<char>(0x80 | (cp & 0x3F));
+    out[n++] = static_cast<char>(0xF0 | (cp >> 18));
+    out[n++] = static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+    out[n++] = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+    out[n++] = static_cast<char>(0x80 | (cp & 0x3F));
   }
+  out[n] = '\0';
+  return n;
+}
+
+void utf8AppendCodepoint(uint32_t cp, std::string& out) {
+  char buf[5];
+  const int n = utf8EncodeCodepoint(cp, buf);
+  out.append(buf, static_cast<size_t>(n));
 }
 
 int utf8SafeTruncateBuffer(const char* buf, int len) {

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -5,6 +5,10 @@
 #define REPLACEMENT_GLYPH 0xFFFD
 
 uint32_t utf8NextCodepoint(const unsigned char** string);
+// Encodes a Unicode codepoint into a caller-supplied buffer (>= 5 bytes) as UTF-8, NUL-terminated.
+// Returns the number of bytes written (1-4). For a C-string of a single character this avoids the
+// heap round-trip a std::string would cost.
+int utf8EncodeCodepoint(uint32_t cp, char out[5]);
 // Appends a Unicode codepoint to a std::string in UTF-8 encoding.
 void utf8AppendCodepoint(uint32_t cp, std::string& out);
 // Remove the last UTF-8 codepoint from a std::string and return the new size.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1555,18 +1555,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   orientedMarginLeft += SETTINGS.screenMargin;
   orientedMarginRight += SETTINGS.screenMargin;
 
-  const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
-
-  // The status bar is furniture, not margin: it takes its own height AND the reader's margin
-  // still belongs between it and the text, so these add rather than compete.
-  // reserves space for automatic page turn indicator when no status bar or progress bar only
-  if (automaticPageTurnActive &&
-      (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight())) {
-    orientedMarginBottom +=
-        statusBarHeight + UITheme::getInstance().getMetrics().statusBarVerticalMargin + SETTINGS.screenMargin;
-  } else {
-    orientedMarginBottom += statusBarHeight + SETTINGS.screenMargin;
-  }
+  orientedMarginBottom += readerBottomReserve(useVerticalText());
 
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
   const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
@@ -1851,8 +1840,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       currentPageFootnotes.clear();
       const auto start = millis();
       if (vpage->isImagePage()) {
-        const int reserve = UITheme::getInstance().getStatusBarHeight() +
-                            UITheme::getInstance().getMetrics().statusBarVerticalMargin + SETTINGS.screenMargin;
+        const int reserve = readerBottomReserve(/*verticalMode=*/false);
         // Release ImageBlock's pixel-cache RAM slot on every exit from this branch. renderContents()
         // (the horizontal path) has always had this guard; vertical never did, so any time the slot
         // DID engage here its 6x16KB stayed resident for good. Observed on device: the heap fell
@@ -2697,8 +2685,7 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
     const auto warmVerticalPage = [&](const VerticalPage& page) -> bool {
       if (!page.isImagePage()) return true;  // keep scanning
       if (page.imageRotated) {
-        const int reserve = UITheme::getInstance().getStatusBarHeight() +
-                            UITheme::getInstance().getMetrics().statusBarVerticalMargin + SETTINGS.screenMargin;
+        const int reserve = readerBottomReserve(/*verticalMode=*/false);
         ImageBlock block(page.imagePath, page.imageSrcPath, page.imageWidth, page.imageHeight);
         block.setRotated(true, static_cast<int16_t>(reserve));
         return warmBlock(block);
@@ -3767,6 +3754,20 @@ bool EpubReaderActivity::useVerticalText() const {
   if (verticalOverride == 0) return false;
   if (verticalOverride == 1) return true;
   return true;  // auto: isJapaneseBook() is true here
+}
+
+uint8_t EpubReaderActivity::readerBottomReserve(const bool verticalMode) const {
+  const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
+  // reserves space for automatic page turn indicator when no status bar or progress bar only
+  const bool needsPageTurnLane =
+      automaticPageTurnActive &&
+      (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight());
+  // Everything actually drawn at the bottom of the screen: the status bar, plus a text lane for
+  // the page-turn indicator when nothing else is using one.
+  const auto drawnHeight = static_cast<uint8_t>(
+      statusBarHeight + (needsPageTurnLane ? UITheme::getInstance().getMetrics().statusBarVerticalMargin : 0));
+  return verticalMode ? static_cast<uint8_t>(drawnHeight + SETTINGS.screenMargin)
+                      : std::max(SETTINGS.screenMargin, drawnHeight);
 }
 
 bool EpubReaderActivity::useFurigana() const {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1986,6 +1986,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (!monoBmp) pagesUntilFullRefresh = 1;
         imagePageDisplayed = true;
       } else {
+        renderedVPage_ = verticalSection->currentPage;  // see the post-render warm block below
         const bool vGlyphsWarm = prewarmedVPage_ == verticalSection->currentPage;
         renderVerticalPageBody(*vpage, vGlyphsWarm);
         // Re-assert the claim for the page the body just prewarmed (it cleared it above).
@@ -2008,10 +2009,14 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // Only after a real page change. A re-render of the same page still has its glyphs in the
     // mini cache; warming the neighbour would evict them and make the next re-render pay a full
     // bulk load again, for a neighbour that was already warmed after the first render.
-    const bool pageChanged = verticalSection->currentPage != lastRenderedVPage_;
-    lastRenderedVPage_ = verticalSection->currentPage;
-    const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? verticalSection->currentPage + 1
-                                                                            : verticalSection->currentPage - 1;
+    // Use the page that was just DRAWN, not currentPage. The render takes 100-700ms and a button
+    // press during it advances currentPage, so reading it here overshot the warm target by one:
+    // the warm then loaded a page the reader was not going to next AND evicted the one they were
+    // (the mini-font cache holds one page per style). Measured: "render page=7" followed by "idle
+    // warm target=9", and the turn onto 8 paid a full on-demand page.
+    const bool pageChanged = renderedVPage_ != lastRenderedVPage_;
+    lastRenderedVPage_ = renderedVPage_;
+    const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? renderedVPage_ + 1 : renderedVPage_ - 1;
     if (pageChanged && warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
       prewarmedVPage_ = -1;
       if (const VerticalPage* np = verticalSection->getPage(warmTarget); np && !np->isImagePage()) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1557,14 +1557,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
 
+  // The status bar is furniture, not margin: it occupies its own height AND the reader's margin
+  // still belongs between it and the text. max() made the two compete, so any screenMargin smaller
+  // than the bar (the default 5 vs a 19px bar) was discarded and the last line ended up flush
+  // against it -- measured on device at a 1px gap. Top gets bezel + screenMargin, so with max()
+  // the same setting was honoured at the top of the page and ignored at the bottom.
   // reserves space for automatic page turn indicator when no status bar or progress bar only
   if (automaticPageTurnActive &&
       (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight())) {
     orientedMarginBottom +=
-        std::max(SETTINGS.screenMargin,
-                 static_cast<uint8_t>(statusBarHeight + UITheme::getInstance().getMetrics().statusBarVerticalMargin));
+        statusBarHeight + UITheme::getInstance().getMetrics().statusBarVerticalMargin + SETTINGS.screenMargin;
   } else {
-    orientedMarginBottom += std::max(SETTINGS.screenMargin, statusBarHeight);
+    orientedMarginBottom += statusBarHeight + SETTINGS.screenMargin;
   }
 
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
@@ -1682,7 +1686,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       sectionFootnotes.clear();  // vertical sections don't collect footnotes
 
       const int fontId = effectiveReaderFontId();
-      if (!verticalSection->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
+      if (!verticalSection->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing,
+                                            useFurigana())) {
         LOG_DBG("ERS", "Vertical cache not found, building...");
         GUI.drawPopup(renderer, tr(STR_INDEXING));
         // Same force every horizontal Indexing-popup site applies: the popup paints FAST, and a
@@ -1723,8 +1728,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         earlyPageActuallyDisplayed_ = false;
         earlyDisplayedPage_.store(earlyTarget, std::memory_order_relaxed);
         verticalBuildInProgress_.store(true, std::memory_order_relaxed);
-        const bool built =
-            verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing);
+        const bool built = verticalSection->createSectionFile(fontId, viewportWidth, viewportHeight,
+                                                              SETTINGS.lineSpacing, useFurigana());
         verticalBuildInProgress_.store(false, std::memory_order_relaxed);
         if (!built) {
           LOG_ERR("ERS", "Failed to build vertical section");
@@ -2508,7 +2513,8 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
 
     VerticalSection nextVSection(epub, nextSpineIndex, renderer);
     const int fontId = effectiveReaderFontId();
-    if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) return;
+    if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana()))
+      return;
 
     // The vertical build is the most memory-intensive step in the reader, and this
     // silent path runs it at the worst heap moment: right after a page render, with
@@ -2539,7 +2545,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     silentIndexBackoffUntilMs_ = 0;
 
     LOG_DBG("ERS", "Silently indexing next vertical chapter: %d (maxAlloc=%u)", nextSpineIndex, ESP.getMaxAllocHeap());
-    if (!nextVSection.createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
+    if (!nextVSection.createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana())) {
       LOG_ERR("ERS", "Failed silent indexing for vertical chapter: %d", nextSpineIndex);
     }
     return;
@@ -2678,7 +2684,8 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
       // full-page illustration is its own one-page spine item, so this cross-boundary peek is
       // the common case -- silentIndexNextChapterIfNeeded has already built the section file.
       nextV.emplace(epub, currentSpineIndex + 1, renderer);
-      if (nextV->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing) && nextV->pageCount > 0) {
+      if (nextV->loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana()) &&
+          nextV->pageCount > 0) {
         vp = nextV->getPage(0);
       } else {
         LOG_DBG("IWARM", "boundary peek failed: spine %d section not loadable", currentSpineIndex + 1);  // TEMP
@@ -3163,7 +3170,7 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
       bool probed = false;
       if (vertical) {
         VerticalSection sibling(epub, i, renderer);
-        if (sibling.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing)) {
+        if (sibling.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana())) {
           spinePagesReal[i] = sibling.pageCount;
           probed = true;
         }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1998,8 +1998,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderStatusBar();
       ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
     }
+    // Pre-build the next chapter's cache while this page is on screen. This call was
+    // missing from the vertical path (lost in a refactor -- silentIndexNextChapterIfNeeded
+    // has had a vertical branch all along), so in tategaki books every chapter transition
+    // showed the Indexing popup. JP books make it worse: each full-page illustration is its
+    // own one-page spine item, so a text->image->text sequence popped Indexing twice. Now
+    // the image chapter builds while the last text pages are read, and the next text
+    // chapter builds while the reader looks at the illustration.
+    silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
+
     // Warm the neighbouring page's glyphs while the reader looks at this one, so the next turn
     // renders from a warm cache instead of paying the per-page SD bulk load at button time.
+    // Must stay AFTER the silent index above, which releases all font memory before building and
+    // would discard this warm.
     // getPage(target) also leaves that page in the section's single-page read cache, so the turn
     // skips the SD page read as well.
     //
@@ -2021,14 +2032,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
       }
     }
-    // Pre-build the next chapter's cache while this page is on screen. This call was
-    // missing from the vertical path (lost in a refactor -- silentIndexNextChapterIfNeeded
-    // has had a vertical branch all along), so in tategaki books every chapter transition
-    // showed the Indexing popup. JP books make it worse: each full-page illustration is its
-    // own one-page spine item, so a text->image->text sequence popped Indexing twice. Now
-    // the image chapter builds while the last text pages are read, and the next text
-    // chapter builds while the reader looks at the illustration.
-    silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
     saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
                  furiganaOverride);
 
@@ -2533,11 +2536,23 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana()))
       return;
 
+    // Cheap pre-gate, before paying anything. releaseAllFontMemory() below cannot produce a block
+    // larger than the total free heap, so if free is already under the build's floor the release
+    // is guaranteed not to clear the gate -- and it would still cost the next render a full
+    // font-cache rebuild (~250ms). Skip the whole attempt instead.
+    constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 96 * 1024;
+    if (ESP.getFreeHeap() < SILENT_VBUILD_MIN_ALLOC) {
+      LOG_DBG("ERS", "Silent vertical index skipped, free heap below floor (free=%u)", ESP.getFreeHeap());
+      silentIndexBackoffUntilMs_ = millis() + 5000;
+      return;
+    }
+
     // The vertical build is the most memory-intensive step in the reader, and this
     // silent path runs it at the worst heap moment: right after a page render, with
     // the glyph slab fully warmed AND the current chapter still resident. Hand the
-    // build the font memory first, like the mainline vertical build does. Costs
-    // nothing here: every vertical page render clearCache()s and re-prewarms anyway.
+    // build the font memory first, like the mainline vertical build does. This is why the call
+    // runs BEFORE the idle glyph warm: the release empties the mini-font cache, so warming first
+    // would throw that work away and leave the next turn cold.
     if (auto* fcm = renderer.getFontCacheManager()) {
       fcm->releaseAllFontMemory();
       // The release just emptied the mini-font cache, so the idle warm's page is no longer
@@ -2553,7 +2568,6 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     // also leaves short pages on screen if the reader pages into it this session. Leave the
     // section unbuilt instead: a roomier later tick retries, and the foreground open path
     // (which frees more up front and early-renders) builds it properly on arrival.
-    constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 96 * 1024;
     if (ESP.getMaxAllocHeap() < SILENT_VBUILD_MIN_ALLOC) {
       LOG_DBG("ERS", "Silent vertical index skipped, heap too tight (maxAlloc=%u)", ESP.getMaxAllocHeap());
       silentIndexBackoffUntilMs_ = millis() + 5000;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1632,11 +1632,17 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   // log) is untouched; fonts reload lazily on the next prewarm.
   if (auto* fcm = renderer.getFontCacheManager()) {
     const uint32_t maxAlloc = ESP.getMaxAllocHeap();
-    // Only pay the rebuild when the heap has been shown to be inadequate, not merely low. A
-    // render that served every glyph is proof this level works; releasing anyway just buys the
-    // next render a cold font cache. forceFontReleaseCheck_ keeps the original resume-path
-    // behaviour for the first render after entering the activity, which is the case the floor
-    // was added for (X3: fragmented boot heap -> missing glyph chunks mid-render).
+    // Release only on evidence that the heap is inadequate, not merely low: a render that served
+    // every glyph proves this level works, and releasing anyway hands the next render a cold font
+    // cache. forceFontReleaseCheck_ keeps the unconditional release for the first render after
+    // entering the activity -- the resume path the floor exists for, where a fragmented boot heap
+    // otherwise loses glyph chunks mid-render.
+    //
+    // ...or once the heap has decayed past the point where the bulk prewarm can run. maxAlloc decays
+    // monotonically while reading and never recovers on its own; this release is the only thing that
+    // coalesces it. Below the prewarm floor every page costs ~40 on-demand SD glyph loads (~300ms)
+    // instead of one prewarm (~90-150ms), so one rebuild buys many warm turns. Do not widen this back
+    // to a bare 40K floor: that fires on nearly every turn for no gain.
     bool starvedSinceLastRender = forceFontReleaseCheck_;
     if (auto* fd = fcm->getDecompressor()) {
       const uint32_t starvedNow = fd->getStarvedGlyphCount();
@@ -1644,13 +1650,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       starvedGlyphsAtLastRender_ = starvedNow;
     }
     forceFontReleaseCheck_ = false;
-    // ...and reclaim once the heap has decayed past the point where the bulk prewarm can run.
-    // Measured on device: maxAlloc decays monotonically while reading (20468 -> 11252 over a
-    // dozen turns) and never recovers on its own -- the release is the only thing that coalesces
-    // it. Gating on starvation alone let it decay forever, and every page then paid ~40 on-demand
-    // SD glyph loads (~300ms) instead of prewarming once (~90-150ms). One rebuild buys many warm
-    // turns, so this is the threshold worth paying at -- unlike the bare 40K floor, which fired
-    // on nearly every turn for no gain.
     const bool cannotPrewarm = maxAlloc < PREWARM_MIN_ALLOC_READ;
     if (maxAlloc < RESUME_HEAP_FLOOR && (starvedSinceLastRender || cannotPrewarm)) {
       LOG_INF("ERS", "Low heap before render (maxAlloc=%u < %u); releasing font memory", maxAlloc, RESUME_HEAP_FLOOR);
@@ -1999,21 +1998,20 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderStatusBar();
       ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
     }
-    // Kindle-class turns: load the neighbouring page's glyphs while the reader looks at this
-    // one, so the next turn renders from a warm cache instead of paying the full per-page SD
-    // bulk load at button time. Direction-adaptive: warm the NEXT page after a forward turn,
-    // the PREVIOUS page after a backward turn, so sustained paging in either direction stays
-    // warm -- only the single turn right after a direction reversal is cold (the mini-font
-    // cache holds exactly one page per style). getPage(target) also leaves that page in the
-    // section's single-page read cache, so the turn skips the SD page read too.
-    // Only after a real page change. A re-render of the same page still has its glyphs in the
-    // mini cache; warming the neighbour would evict them and make the next re-render pay a full
-    // bulk load again, for a neighbour that was already warmed after the first render.
-    // Use the page that was just DRAWN, not currentPage. The render takes 100-700ms and a button
-    // press during it advances currentPage, so reading it here overshot the warm target by one:
-    // the warm then loaded a page the reader was not going to next AND evicted the one they were
-    // (the mini-font cache holds one page per style). Measured: "render page=7" followed by "idle
-    // warm target=9", and the turn onto 8 paid a full on-demand page.
+    // Warm the neighbouring page's glyphs while the reader looks at this one, so the next turn
+    // renders from a warm cache instead of paying the per-page SD bulk load at button time.
+    // getPage(target) also leaves that page in the section's single-page read cache, so the turn
+    // skips the SD page read as well.
+    //
+    // Direction-adaptive: the NEXT page after a forward turn, the PREVIOUS after a backward one, so
+    // sustained paging either way stays warm. The mini-font cache holds one page per style, so only
+    // the single turn after a direction reversal is cold -- and for the same reason this runs only
+    // after a REAL page change: warming the neighbour of a re-rendered page evicts glyphs that page
+    // still needs.
+    //
+    // Use renderedVPage_, never currentPage. A render takes 100-700ms and a button press during it
+    // advances currentPage, which overshoots the target by one: that both loads a page the reader
+    // is not going to next and evicts the one they are.
     const bool pageChanged = renderedVPage_ != lastRenderedVPage_;
     lastRenderedVPage_ = renderedVPage_;
     const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? renderedVPage_ + 1 : renderedVPage_ - 1;
@@ -3263,55 +3261,38 @@ int EpubReaderActivity::pageBasedPercent(const int spineIndex, const int section
 }
 
 bool EpubReaderActivity::prewarmVerticalPageGlyphs(const VerticalPage& vpage) {
-  // Bulk-load every glyph this page needs before drawing a single one. Without this, each
-  // draw call for a codepoint that isn't already cached falls through to the on-demand
-  // fallback path (for SD-card fonts: a fresh SD file open + two seeks + two reads per
-  // miss, into an 8-slot ring buffer) -- for a page with hundreds of distinct kanji, that's
-  // hundreds of individual SD round-trips. Confirmed on a real device: this was the entire
-  // cause of vertical page turns taking 1.5-2+ seconds of pure render time with an SD font.
+  // Bulk-load every glyph this page needs before drawing any of them. Otherwise each uncached
+  // codepoint falls through to the on-demand path -- for an SD font, a file open plus two seeks and
+  // two reads per miss into an 8-slot ring -- which for a page of hundreds of distinct kanji means
+  // hundreds of SD round-trips, and 1.5-2s of render time.
   //
-  // clearCache() first is required, not optional: FontDecompressor's prewarmCache() claims
-  // one of only MAX_PAGE_SLOTS (4) page-buffer slots per call and never self-evicts --
-  // "the caller must call freePageBuffer/clearCache to reset" (FontDecompressor.h). Without
-  // this, every page turn permanently claims more slots; confirmed on a real device that
-  // after ~1 page's worth of prewarm calls, all 4 slots were stuck full, "cannot prewarm"
-  // fired for every subsequent page, and glyphs stopped resolving at all (blank pages).
+  // Three constraints, each one a page-blanking bug if broken:
   //
-  // styleMask must reflect only the styles ACTUALLY present on this page, not a blanket "all
-  // 4" request: FontCacheManager::prewarmCache() claims one slot per requested style, PLUS
-  // another slot per style for the family's fallback font if it has one -- up to 8 slot
-  // claims against only 4 slots total. Confirmed on a real device: even right after
-  // clearCache(), a single page still hit "all 4 slots full" because the blanket request
-  // needed more slots than exist, wasting them on styles the page doesn't even use.
-  // Prewarm gated on heap: its page-text string and cache-slot claims are bare allocations,
-  // and this body also runs mid-build (early first render / build-time page turns) where an
-  // OOM aborts under -fno-exceptions. Without prewarm the page still renders correctly via
-  // the per-glyph on-demand path -- slower, but never fatal.
-  // 20K: normal post-build reading always clears this (heap 30K+), so warm turns are
-  // unaffected. The gate only bites during a mid-build serve, and there it MUST stay high:
-  // dropping it to 14K let the prewarm's resident footprint coincide with a dense ruby
-  // page's layout dip and the build dropped glyphs (need 11736 @ 9716 free) -> stale cache.
-  // Build-phase serves rendering on-demand (~2s) is a drop-free, one-time-per-book cost;
-  // content integrity outranks shaving that.
-  // ...but that reasoning is about a build. Once the chapter is built there is no layout to
-  // starve, and the alternative to prewarming is strictly worse for the heap as well as the
-  // clock: 40-74 individual on-demand glyph loads per page through an 8-slot ring, each one an
-  // SD round-trip at ~7ms. Measured on device: ordinary vertical reading sits at maxAlloc
-  // 12-32K, so a flat 20K floor rejected EVERY idle warm (probe: "idle warm ok=0" on all 13
-  // turns) and every page paid the full on-demand path. Keep 20K for the mid-build serve,
-  // where content integrity outranks speed; use the lower floor for reading, where a failed
-  // prewarm costs nothing that isn't already being paid.
+  //   clearCache() first is REQUIRED. FontDecompressor::prewarmCache() claims one of only
+  //   MAX_PAGE_SLOTS (4) page-buffer slots per call and never self-evicts ("the caller must call
+  //   freePageBuffer/clearCache to reset", FontDecompressor.h). Without it every page turn claims
+  //   another slot until all 4 are stuck and no glyph resolves.
+  //
+  //   styleMask must list only the styles PRESENT on this page. FontCacheManager::prewarmCache()
+  //   claims a slot per requested style plus one per style for the family's fallback font -- a
+  //   blanket "all 4" asks for up to 8 slots against the 4 that exist.
+  //
+  //   The heap floor differs by caller. The page-text string and slot claims are bare allocations,
+  //   and this also runs mid-build, where an OOM aborts under -fno-exceptions. Keep 20K there: at
+  //   14K the prewarm's footprint coincided with a dense ruby page's layout dip and the build
+  //   dropped glyphs (needed 11736, 9716 free), staling the cache. Rendering a build-phase page
+  //   on-demand costs ~2s once per book; content integrity outranks that. Reading uses the lower
+  //   floor -- there is no layout left to starve, and the fallback is worse for the heap as well
+  //   as the clock (40-74 on-demand loads per page at ~7ms each, against maxAlloc that sits at
+  //   12-32K, so a 20K floor rejects every prewarm).
   constexpr uint32_t PREWARM_MIN_ALLOC_BUILD = 20 * 1024;
   const uint32_t floorBytes = duringEarlyBuildRender_ ? PREWARM_MIN_ALLOC_BUILD : PREWARM_MIN_ALLOC_READ;
   auto* fcm = renderer.getFontCacheManager();
   if (!fcm || ESP.getMaxAllocHeap() < floorBytes) return false;
-  // The mini-font cache holds exactly one page per style and clearCache() below empties it, so
-  // any page it previously held is gone. Retract the claim BEFORE destroying the evidence for
-  // it: leaving prewarmedVPage_ pointing at a page this call is about to evict made the next
-  // render trust a cache that no longer had it and pay a full on-demand page (device probe:
-  // "render page=9 prewarmed=9" followed by 44 on-demand loads, right after a re-render of
-  // page 10 had prewarmed itself over the idle warm of 11). Callers that know which page they
-  // just warmed re-assert it on success.
+  // The mini-font cache holds one page per style and clearCache() below empties it. Retract the
+  // claim BEFORE destroying what backs it: a prewarmedVPage_ still naming a page this call evicts
+  // makes the next render trust a cache that no longer holds it and pay a full on-demand page.
+  // Callers that know which page they warmed re-assert it on success.
   prewarmedVPage_ = -1;
   fcm->clearCache();
   uint8_t styleMask =
@@ -3354,12 +3335,10 @@ void EpubReaderActivity::earlyRenderVerticalPage(const VerticalPage& page, const
   duringEarlyBuildRender_ = true;  // the build is paused mid-layout; prewarm keeps its high floor
   renderVerticalPageBody(page);
   duringEarlyBuildRender_ = false;
-  // The bar goes into the SAME buffer as the page, before the one displayBuffer() below, so it
-  // costs no extra refresh -- the earlier objection was to redrawing the page for the bar's sake.
-  // Mid-build counts are no longer a reason to skip it either: renderStatusBar() reads
-  // estimatedTotalPages() and marks an estimate with "~". Without this the bar was simply absent
-  // for the first pages of every vertical chapter, until the build finished and ordinary renders
-  // took over (device: reappeared after 3-4 page turns; horizontal has no early-render path).
+  // Into the SAME buffer as the page and before the single displayBuffer() below, so it costs no extra
+  // refresh. Safe mid-build: renderStatusBar() reads estimatedTotalPages() and marks an estimate with
+  // "~". Without it the bar is absent for a vertical chapter's first pages, until the build ends and
+  // ordinary renders take over (horizontal has no early-render path).
   renderStatusBar();
   renderer.displayBuffer();
   earlyPageActuallyDisplayed_ = true;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1628,7 +1628,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   // log) is untouched; fonts reload lazily on the next prewarm.
   if (auto* fcm = renderer.getFontCacheManager()) {
     const uint32_t maxAlloc = ESP.getMaxAllocHeap();
-    if (maxAlloc < RESUME_HEAP_FLOOR) {
+    // Only pay the rebuild when the heap has been shown to be inadequate, not merely low. A
+    // render that served every glyph is proof this level works; releasing anyway just buys the
+    // next render a cold font cache. forceFontReleaseCheck_ keeps the original resume-path
+    // behaviour for the first render after entering the activity, which is the case the floor
+    // was added for (X3: fragmented boot heap -> missing glyph chunks mid-render).
+    bool starvedSinceLastRender = forceFontReleaseCheck_;
+    if (auto* fd = fcm->getDecompressor()) {
+      const uint32_t starvedNow = fd->getStarvedGlyphCount();
+      starvedSinceLastRender = starvedSinceLastRender || starvedNow != starvedGlyphsAtLastRender_;
+      starvedGlyphsAtLastRender_ = starvedNow;
+    }
+    forceFontReleaseCheck_ = false;
+    if (maxAlloc < RESUME_HEAP_FLOOR && starvedSinceLastRender) {
       LOG_INF("ERS", "Low heap before render (maxAlloc=%u < %u); releasing font memory", maxAlloc, RESUME_HEAP_FLOOR);
       fcm->releaseAllFontMemory();
       prewarmedVPage_ = -1;  // the release just emptied the mini-font cache (vertical)

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -64,6 +64,10 @@ constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
 // render()). Chosen above the word-lookup self-heal floor (28K) so the reader hands off a
 // coalesced heap BEFORE the dictionary activity opens on top of it.
 constexpr uint32_t RESUME_HEAP_FLOOR = 40 * 1024;
+// Largest-block floor below which the per-page bulk glyph prewarm gives up (see
+// prewarmVerticalPageGlyphs). Also the point at which reclaiming font memory becomes worth its
+// rebuild cost: below this, every page falls back to 40-70 individual on-demand SD glyph loads.
+constexpr uint32_t PREWARM_MIN_ALLOC_READ = 12 * 1024;
 constexpr size_t initialBookmarkCacheCapacity = 16;
 constexpr float bookmarkProgressEpsilon = 0.0001f;
 // Bump when ReaderPrefs gains/changes fields; stale files fall back to globals.
@@ -1640,7 +1644,15 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       starvedGlyphsAtLastRender_ = starvedNow;
     }
     forceFontReleaseCheck_ = false;
-    if (maxAlloc < RESUME_HEAP_FLOOR && starvedSinceLastRender) {
+    // ...and reclaim once the heap has decayed past the point where the bulk prewarm can run.
+    // Measured on device: maxAlloc decays monotonically while reading (20468 -> 11252 over a
+    // dozen turns) and never recovers on its own -- the release is the only thing that coalesces
+    // it. Gating on starvation alone let it decay forever, and every page then paid ~40 on-demand
+    // SD glyph loads (~300ms) instead of prewarming once (~90-150ms). One rebuild buys many warm
+    // turns, so this is the threshold worth paying at -- unlike the bare 40K floor, which fired
+    // on nearly every turn for no gain.
+    const bool cannotPrewarm = maxAlloc < PREWARM_MIN_ALLOC_READ;
+    if (maxAlloc < RESUME_HEAP_FLOOR && (starvedSinceLastRender || cannotPrewarm)) {
       LOG_INF("ERS", "Low heap before render (maxAlloc=%u < %u); releasing font memory", maxAlloc, RESUME_HEAP_FLOOR);
       fcm->releaseAllFontMemory();
       prewarmedVPage_ = -1;  // the release just emptied the mini-font cache (vertical)
@@ -1974,7 +1986,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (!monoBmp) pagesUntilFullRefresh = 1;
         imagePageDisplayed = true;
       } else {
-        renderVerticalPageBody(*vpage, /*glyphsAlreadyWarm=*/prewarmedVPage_ == verticalSection->currentPage);
+        const bool vGlyphsWarm = prewarmedVPage_ == verticalSection->currentPage;
+        renderVerticalPageBody(*vpage, vGlyphsWarm);
+        // Re-assert the claim for the page the body just prewarmed (it cleared it above).
+        if (!vGlyphsWarm) prewarmedVPage_ = verticalSection->currentPage;
       }
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
     }
@@ -3273,9 +3288,26 @@ bool EpubReaderActivity::prewarmVerticalPageGlyphs(const VerticalPage& vpage) {
   // page's layout dip and the build dropped glyphs (need 11736 @ 9716 free) -> stale cache.
   // Build-phase serves rendering on-demand (~2s) is a drop-free, one-time-per-book cost;
   // content integrity outranks shaving that.
-  constexpr uint32_t PREWARM_MIN_ALLOC = 20 * 1024;
+  // ...but that reasoning is about a build. Once the chapter is built there is no layout to
+  // starve, and the alternative to prewarming is strictly worse for the heap as well as the
+  // clock: 40-74 individual on-demand glyph loads per page through an 8-slot ring, each one an
+  // SD round-trip at ~7ms. Measured on device: ordinary vertical reading sits at maxAlloc
+  // 12-32K, so a flat 20K floor rejected EVERY idle warm (probe: "idle warm ok=0" on all 13
+  // turns) and every page paid the full on-demand path. Keep 20K for the mid-build serve,
+  // where content integrity outranks speed; use the lower floor for reading, where a failed
+  // prewarm costs nothing that isn't already being paid.
+  constexpr uint32_t PREWARM_MIN_ALLOC_BUILD = 20 * 1024;
+  const uint32_t floorBytes = duringEarlyBuildRender_ ? PREWARM_MIN_ALLOC_BUILD : PREWARM_MIN_ALLOC_READ;
   auto* fcm = renderer.getFontCacheManager();
-  if (!fcm || ESP.getMaxAllocHeap() < PREWARM_MIN_ALLOC) return false;
+  if (!fcm || ESP.getMaxAllocHeap() < floorBytes) return false;
+  // The mini-font cache holds exactly one page per style and clearCache() below empties it, so
+  // any page it previously held is gone. Retract the claim BEFORE destroying the evidence for
+  // it: leaving prewarmedVPage_ pointing at a page this call is about to evict made the next
+  // render trust a cache that no longer had it and pay a full on-demand page (device probe:
+  // "render page=9 prewarmed=9" followed by 44 on-demand loads, right after a re-render of
+  // page 10 had prewarmed itself over the idle warm of 11). Callers that know which page they
+  // just warmed re-assert it on success.
+  prewarmedVPage_ = -1;
   fcm->clearCache();
   uint8_t styleMask =
       std::accumulate(vpage.glyphs.begin(), vpage.glyphs.end(), uint8_t{0},
@@ -3314,7 +3346,9 @@ void EpubReaderActivity::earlyRenderVerticalPage(const VerticalPage& page, const
   // (observed on device as the same page rendering twice back-to-back).
   earlyDisplayedPage_.store(pageIndex, std::memory_order_relaxed);
   renderer.clearScreen();
+  duringEarlyBuildRender_ = true;  // the build is paused mid-layout; prewarm keeps its high floor
   renderVerticalPageBody(page);
+  duringEarlyBuildRender_ = false;
   // The bar goes into the SAME buffer as the page, before the one displayBuffer() below, so it
   // costs no extra refresh -- the earlier objection was to redrawing the page for the bar's sake.
   // Mid-build counts are no longer a reason to skip it either: renderStatusBar() reads

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1590,7 +1590,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
                                static_cast<bool>(SETTINGS.embeddedStyle),
                                SETTINGS.imageRendering,
                                static_cast<bool>(SETTINGS.focusReadingEnabled),
-                               static_cast<bool>(SETTINGS.bookCssMargins)};
+                               static_cast<bool>(SETTINGS.bookCssMargins),
+                               SETTINGS.lineSpacing,
+                               useFurigana()};
     if ((section || verticalSection) && currentSig != sectionLayoutSig) {
       LOG_DBG("ERS", "Layout params changed; reflowing section in place");
       if (verticalSection) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1557,11 +1557,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
 
-  // The status bar is furniture, not margin: it occupies its own height AND the reader's margin
-  // still belongs between it and the text. max() made the two compete, so any screenMargin smaller
-  // than the bar (the default 5 vs a 19px bar) was discarded and the last line ended up flush
-  // against it -- measured on device at a 1px gap. Top gets bezel + screenMargin, so with max()
-  // the same setting was honoured at the top of the page and ignored at the bottom.
+  // The status bar is furniture, not margin: it takes its own height AND the reader's margin
+  // still belongs between it and the text, so these add rather than compete.
   // reserves space for automatic page turn indicator when no status bar or progress bar only
   if (automaticPageTurnActive &&
       (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight())) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3303,8 +3303,13 @@ void EpubReaderActivity::earlyRenderVerticalPage(const VerticalPage& page, const
   earlyDisplayedPage_.store(pageIndex, std::memory_order_relaxed);
   renderer.clearScreen();
   renderVerticalPageBody(page);
-  // No status bar here: it derives page counts from a section that is still mid-build. It
-  // appears with the next real page refresh; redrawing this page only for the bar is slower.
+  // The bar goes into the SAME buffer as the page, before the one displayBuffer() below, so it
+  // costs no extra refresh -- the earlier objection was to redrawing the page for the bar's sake.
+  // Mid-build counts are no longer a reason to skip it either: renderStatusBar() reads
+  // estimatedTotalPages() and marks an estimate with "~". Without this the bar was simply absent
+  // for the first pages of every vertical chapter, until the build finished and ordinary renders
+  // took over (device: reappeared after 3-4 page turns; horizontal has no early-render path).
+  renderStatusBar();
   renderer.displayBuffer();
   earlyPageActuallyDisplayed_ = true;
   // The build resumes the moment this returns and needs its headroom back: the prewarm above

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -231,6 +231,15 @@ class EpubReaderActivity final : public Activity {
   // while the reader looks at the current one, so a forward turn renders warm (~200ms)
   // instead of paying the ~500-700ms per-page SD bulk load at button time.
   int prewarmedVPage_ = -1;
+  // Evidence for the pre-render font release (see RESUME_HEAP_FLOOR in render()). The release
+  // costs a full font-cache rebuild -- kern classes, mini kern, advance table, glyph groups --
+  // on the following render. It was written for the resume-into-book path, on the assumption
+  // that normal reading stays above the floor; a vertical book sits at maxAlloc 12-32K, so it
+  // tripped on 6 of 9 measured page turns and taxed each one ~400ms. These two track whether
+  // the previous render actually ran short of glyph memory, which is direct evidence that the
+  // heap at this level is inadequate -- a clean render is evidence that it is not.
+  uint32_t starvedGlyphsAtLastRender_ = 0;
+  bool forceFontReleaseCheck_ = true;  // armed on entry: the resume path this was written for
   // Backoff for the silent next-chapter index when the heap is too tight to build clean:
   // without it the attempt re-fires every tick while the reader sits on a chapter's last two
   // pages, and each attempt releases the font caches (cold glyphs on the next turn) for

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -379,6 +379,15 @@ class EpubReaderActivity final : public Activity {
   int effectiveReaderFontId() const;
   void restoreSavedPosition();
   bool useVerticalText() const;
+  // Space kept clear below the text, in addition to the panel's own bezel.
+  //
+  // Horizontal follows upstream: the status bar and the reader's margin describe the same strip,
+  // so the larger of the two wins. Vertical ADDS them, because tategaki puts ink past its last
+  // row by design -- the row's own ink hang, and 。/、 set past the line end (burasage). Measured
+  // at 6px on a 29px cell, against a default margin that max() collapses to nothing whenever the
+  // status bar is taller (~24px with a clock), which would drop that ink onto the clock.
+  uint8_t readerBottomReserve(bool verticalMode) const;
+
   bool useFurigana() const;
   bool isJapaneseBook() const;
   bool showVerticalToggle() const;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -60,9 +60,9 @@ class EpubReaderActivity final : public Activity {
     uint8_t imageRendering = 0;
     bool focusReadingEnabled = false;
     bool bookCssMargins = false;
-    // Vertical-only inputs. They key the vertical cache FILE, so leaving them out here meant an
-    // in-memory section built with the old values kept being served: changing line spacing mid-book
-    // left the columns at their previous 行間 until the book was reopened.
+    // Vertical-only inputs. These key the vertical cache FILE, so they must be here too -- otherwise a
+    // resident section built with the old values keeps being served and a mid-book line-spacing change
+    // does not take effect until the book is reopened.
     uint8_t lineSpacing = 0;
     bool furigana = false;
     bool operator==(const LayoutSig& o) const {
@@ -239,13 +239,11 @@ class EpubReaderActivity final : public Activity {
   // verticalSection->currentPage can advance mid-render (a button press during a 100-700ms
   // render), so the post-render warm must not re-read it -- see the warm block in render().
   int renderedVPage_ = -1;
-  // Evidence for the pre-render font release (see RESUME_HEAP_FLOOR in render()). The release
-  // costs a full font-cache rebuild -- kern classes, mini kern, advance table, glyph groups --
-  // on the following render. It was written for the resume-into-book path, on the assumption
-  // that normal reading stays above the floor; a vertical book sits at maxAlloc 12-32K, so it
-  // tripped on 6 of 9 measured page turns and taxed each one ~400ms. These two track whether
-  // the previous render actually ran short of glyph memory, which is direct evidence that the
-  // heap at this level is inadequate -- a clean render is evidence that it is not.
+  // Evidence gate for the pre-render font release (see RESUME_HEAP_FLOOR in render()), which costs a
+  // full font-cache rebuild on the next render -- kern classes, mini kern, advance table, glyph
+  // groups, ~400ms. These track whether the PREVIOUS render ran short of glyph memory: a clean render
+  // means the heap is adequate at this level, so do not release. Needed because vertical reading sits
+  // at maxAlloc 12-32K, where a bare floor test is true almost always.
   uint32_t starvedGlyphsAtLastRender_ = 0;
   bool forceFontReleaseCheck_ = true;  // armed on entry: the resume path this was written for
   // Backoff for the silent next-chapter index when the heap is too tight to build clean:

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -235,6 +235,10 @@ class EpubReaderActivity final : public Activity {
   // while the reader looks at the current one, so a forward turn renders warm (~200ms)
   // instead of paying the ~500-700ms per-page SD bulk load at button time.
   int prewarmedVPage_ = -1;
+  // The vertical page index actually drawn by the last render, captured BEFORE the draw.
+  // verticalSection->currentPage can advance mid-render (a button press during a 100-700ms
+  // render), so the post-render warm must not re-read it -- see the warm block in render().
+  int renderedVPage_ = -1;
   // Evidence for the pre-render font release (see RESUME_HEAP_FLOOR in render()). The release
   // costs a full font-cache rebuild -- kern classes, mini kern, advance table, glyph groups --
   // on the following render. It was written for the resume-into-book path, on the assumption

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -222,6 +222,10 @@ class EpubReaderActivity final : public Activity {
   // false when the heap was too tight to prewarm -- rendering still works via the slower
   // per-glyph on-demand path.
   bool prewarmVerticalPageGlyphs(const VerticalPage& vpage);
+  // True only while a mid-build early render is running (the build is paused mid-layout and
+  // resumes the moment it returns). Selects the conservative prewarm heap floor there, and the
+  // reading floor everywhere else -- see prewarmVerticalPageGlyphs().
+  bool duringEarlyBuildRender_ = false;
   // Draws one vertical TEXT page into the framebuffer; shared by the normal render path and
   // the early-first-render hook. Does not touch the display. glyphsAlreadyWarm skips the
   // prewarm when the page's glyphs were pre-loaded during idle (see prewarmedVPage_).

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -60,12 +60,18 @@ class EpubReaderActivity final : public Activity {
     uint8_t imageRendering = 0;
     bool focusReadingEnabled = false;
     bool bookCssMargins = false;
+    // Vertical-only inputs. They key the vertical cache FILE, so leaving them out here meant an
+    // in-memory section built with the old values kept being served: changing line spacing mid-book
+    // left the columns at their previous 行間 until the book was reopened.
+    uint8_t lineSpacing = 0;
+    bool furigana = false;
     bool operator==(const LayoutSig& o) const {
       return fontId == o.fontId && viewportWidth == o.viewportWidth && viewportHeight == o.viewportHeight &&
              lineCompression == o.lineCompression && paragraphAlignment == o.paragraphAlignment &&
              extraParagraphSpacing == o.extraParagraphSpacing && hyphenationEnabled == o.hyphenationEnabled &&
              embeddedStyle == o.embeddedStyle && imageRendering == o.imageRendering &&
-             focusReadingEnabled == o.focusReadingEnabled && bookCssMargins == o.bookCssMargins;
+             focusReadingEnabled == o.focusReadingEnabled && bookCssMargins == o.bookCssMargins &&
+             lineSpacing == o.lineSpacing && furigana == o.furigana;
     }
     bool operator!=(const LayoutSig& o) const { return !(*this == o); }
   };


### PR DESCRIPTION
Vertical (tategaki) glyph positions were a pile of constants tuned by eye. This replaces them with **measured font metrics** or a **stated JLREQ rule**. Additionally, the code was refactored to avoid duplication and make rules easier to debug.

**Foundational document**: https://www.w3.org/TR/jlreq

## Constants removed

| removed | replaced by |
|---|---|
| `3/8`-cell global down nudge | measured 中 ink box centred in the cell |
| two-cell bottom reserve | the last row's measured ink hang |
| `2 * ascender - gt` run intrusion | `baselineInCell - gt` |
| ruby `max(3, rubyLineH * 6/5)` | JLREQ nakatsuki on virtual bodies |
| `max(5, cellPx/4)` before Latin runs | the predecessor's measured ink bottom |
| ellipsis `1/3 + 1/3 cell + ascender-%` | dot stack centred in its cell |
| bracket `1/6+1/4`, `3/8` cell, `extraNudge`, `baselineExcess` | JLREQ half-em placement |
| dash / square-bracket X shifts | ink centring, flush only where asymmetric |
| `cellPx/8` and half-cell kana biases | placement from the glyph's ink box |
| `max(screenMargin, statusBarHeight)` | status bar **+** margin (for vertical text only) |

## Column gap

Gaps are defined in **ems** instead of line heights now.

| Line spacing | Furigana ON | Furigana OFF |
|---|---|---|
| Tight | 1/2 em | 1/4 em |
| Normal | 3/4 em | 1/2 em |
| Wide | 1 em | 3/4 em |

Furigana is part of the vertical cache key for this reason, toggling it re-lays the chapter out.

## JLREQ rules implemented

- **Ruby** — nakatsuki (3.3.5): virtual bodies centred on the base, with the renderer's `SUP` behaviour (50% glyph, full-ascender offset) undone exactly. Hangover per 3.3.8, favouring the character after. At the text edge ruby hangs into the margin (Fig 2.37) rather than reserving a strip inside the text area, clamped to the panel so none is lost.
- **Brackets** — half-em: opening in the second half of its em and right of the column, closing in the first half and left; symmetric shapes (parens, chevrons) stay ink-centred. An opening bracket at a line head is set flush (tentsuki), keyed off *first glyph in the column* so indented dialogue is included.
- **Adjacent punctuation** (3.1.4) — closes up by a half em, which reproduces all seven cases in the figure. `。` and `、` take their own ink height plus a half em rather than a whole cell.
- **Line adjustment** (3.8) — oikomi takes a quarter em from each half-em mark, and from an Aozora U+3000 indent, which is often a short column's only slack. Need-aware: a closing bracket is a half-em glyph and asks for half a cell, not a whole one. The same three rules (hang / half-em pair / squeeze) run at a page boundary too. Spreading is the counterpart — a column short of the foot by less than one cell returns the leftover to its own gaps; paragraph ends and burasage columns stay ragged.
- **Kinsoku** — oikomi only while the column has a row spare, otherwise oidashi carries the preceding character forward. A small kana arriving at a full column used to be written one row past the bottom, printing over the status bar.
- **Rows** come from the full text height; a 2px ink-hang reserve was costing a whole character per column whenever the height divided evenly.
- **Digits** — fullwidth (U+FF10–FF19) are East Asian Wide, so they are set upright. Gathering them into a rotated run laid １９３８年 on its side.

## Issues Fixed

### Overview
| symptom | cause |
|---|---|
| re-index on every open, occasional empty chapter | `HEADER_PAGECOUNT_OFFSET` one byte short; it's a *seek*, so it overwrote the furigana flag. Every vertical cache since was corrupt |
| reader froze on a page turn | oidashi re-placed the popped glyph in the cell it just freed — livelock holding the render lock |
| `。」` / `』」` split across columns | half-em pairing accepted only `。`/`、` first; brackets are half-em too |
| `。` dragging its neighbour to a new column | now hangs (ぶら下げ) — partly closes that item above |
| columns drifting apart | leftover width spread into the gaps, overriding the table (21→25px on a 29px em) |
| a column lost per page | N columns occupy `N*advance - gap`, not `N*advance` |
| a lone `」` on its own page | the squeeze demanded a whole em for a half-em glyph |
| `１９３８` set as 19 over 38 | a soft flush cut mid-number; fullwidth digits are not ASCII word bytes |
| an embedded Latin word split as `au` / `thority` | a run is gathered within one batch; the tail is carried to the next |
| boxed blocks unstyled past ~1500 rules | one cap did RAM and SD duty, truncating the cache in file order (EBPAJ template: 1500 of ~1700 rules) |
| no status bar on a chapter's first pages | the early-render path never drew one |

### Performance
`漢`/`中` were probed per paragraph: 27% of all SD glyph loads per build, each evicting two real glyphs. Memoized, measured values only. Same for `。`/`、`, small kana, the probe inside the draw loop, and a `std::string` per glyph.

Vertical page turns on device, **~440ms → ~86ms**:

| | before | after |
|---|---|---|
| on-demand SD glyph loads | 40–74 per page | 1–2 per page |
| median render | ~440ms | ~108ms |
| steady warm turn | — | 77–88ms |

| symptom | cause |
|---|---|
| 6.8s stall mid-build, 203 identical log lines | a failed hot-group allocation was re-probed once per glyph, and each retry also freed the group later glyphs would have hit |
| every page paid the on-demand path | the prewarm's 20K floor protects a *build*; ordinary reading sits at 12–32K, so it was never met |
| a warm page rendering cold | `prewarmedVPage_` named a page `clearCache()` had already evicted |
| the warm loading the wrong page | the post-render block re-read `currentPage`, which a button press advances mid-render |

### Refactor
`layoutPages` 1152 → 801 lines, 20 lambdas → 0 (`LayoutCursor` owns the page state and its rules, `ColumnGeometry` the grid). Removed: UTF-8 encoder ×4 beside the shared one it duplicated (a copy dropped 4-byte codepoints), cell size ×2, 13 four-out-param probes, 2 heap ladders, and the cache field list written twice.

## Still open

- [x] Punctuation adjustments
- [x] Spacing before/after Latin text
- [x] small kana placement
- [x] ぶら下げ (hanging `。`/`、` below the line end) and §3.8 line adjustment as both are line-breaking work rather than glyph placement.
- [x] reset font metrics after font family changed
- [x] heap pressure and page-turn cost on device
- [x] a forward turn paying two prewarms — the silent chapter index discarded the idle warm

Remaining performance work is split out to #54 so this can land: heap decay during reading, the
prewarm temp-buffer retry storm, and ~1s chapter transitions.

By design, not open: the single turn at a direction reversal is cold, because the mini-font cache
holds one page per style. Measured 403ms for the reversal itself, 88ms and 77ms for the turns after.

## Verification

* Emulator
* XTEINK X4
* Various books with Latin heavy, CSS heavy, Furigana heavy, dialog heavy and generally dense books (`ムーミン全集［新版］２ たのしいムーミン一家`, `一次元の挿し木 - 松下龍之介`, `[森鴎外] ヰタ・セクスアリス`, `世にもふしぎなＳＣＰガチャ！（１）　かわいい猫にご用心`,`変な家２ ～11の間取り図～`

## AI Usage
Claude Code, Opus 5
