### PR TITLE
perf: vertical reading heap and page-turn cost

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -560,12 +560,14 @@ int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8
 
   // Step 4: For each unique group, decompress to temp buffer and extract needed glyphs.
   //
-  // ONE buffer, sized to the largest needed group, serves every group. Per-group malloc/free of
-  // ~16KB blocks was both a fragmentation source and a retry storm: a heap too tight for one group
-  // is too tight for the next, so a failure repeated once per group (measured: 16 in a burst) and
-  // the page's prewarm silently produced nothing. If the shared allocation fails there is no
-  // smaller thing worth trying -- every group needs its own full uncompressedSize -- so the loop
-  // stops rather than re-probing.
+  // ONE buffer, sized to the largest needed group, serves every group. Do not go back to a
+  // per-group malloc/free: a reading page needs up to 128 groups, so that churned ~16KB blocks
+  // 128x per page turn (a measurable fragmentation source), and on a tight heap it failed once
+  // per group rather than once per page.
+  //
+  // A failed allocation ends the loop instead of continuing: every group needs its own full
+  // uncompressedSize, so there is nothing smaller left to try. Unextracted glyphs keep
+  // bufferOffset == UINT32_MAX and fall through to the hot-group path in getBitmap().
   uint32_t writeOffset = 0;
   int missed = 0;
 

--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -591,7 +591,13 @@ int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8
     const EpdFontGroup& group = fontData->groups[groupIdx];
 
     if (!decompressGroup(fontData, groupIdx, tempBuf, group.uncompressedSize)) {
-      missed++;
+      // The return value is a GLYPH count (see the header), so charge every glyph this group
+      // owed, not 1 for the group. Those glyphs keep bufferOffset == UINT32_MAX and fall through
+      // to the hot-group path in getBitmap().
+      for (uint16_t i = 0; i < slot.glyphCount; i++) {
+        if (slot.glyphs[i].bufferOffset == UINT32_MAX && getGroupIndex(fontData, slot.glyphs[i].glyphIndex) == groupIdx)
+          missed++;
+      }
       continue;
     }
 

--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -558,26 +558,37 @@ int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8
     }
   }
 
-  // Step 4: For each unique group, decompress to temp buffer and extract needed glyphs
+  // Step 4: For each unique group, decompress to temp buffer and extract needed glyphs.
+  //
+  // ONE buffer, sized to the largest needed group, serves every group. Per-group malloc/free of
+  // ~16KB blocks was both a fragmentation source and a retry storm: a heap too tight for one group
+  // is too tight for the next, so a failure repeated once per group (measured: 16 in a burst) and
+  // the page's prewarm silently produced nothing. If the shared allocation fails there is no
+  // smaller thing worth trying -- every group needs its own full uncompressedSize -- so the loop
+  // stops rather than re-probing.
   uint32_t writeOffset = 0;
   int missed = 0;
+
+  uint32_t maxGroupBytes = 0;
+  for (uint8_t g = 0; g < groupCount; g++) {
+    const uint32_t sz = fontData->groups[neededGroups[g]].uncompressedSize;
+    if (sz > maxGroupBytes) maxGroupBytes = sz;
+  }
+
+  auto* tempBuf = static_cast<uint8_t*>(malloc(maxGroupBytes));
+  if (!tempBuf) {
+    LOG_ERR("FDC", "Failed to allocate temp buffer (%u bytes) for %u groups", maxGroupBytes, groupCount);
+    return glyphCount;
+  }
+  if (maxGroupBytes > stats.peakTempBytes) {
+    stats.peakTempBytes = maxGroupBytes;
+  }
 
   for (uint8_t g = 0; g < groupCount; g++) {
     uint16_t groupIdx = neededGroups[g];
     const EpdFontGroup& group = fontData->groups[groupIdx];
 
-    auto* tempBuf = static_cast<uint8_t*>(malloc(group.uncompressedSize));
-    if (!tempBuf) {
-      LOG_ERR("FDC", "Failed to allocate temp buffer (%u bytes) for group %u", group.uncompressedSize, groupIdx);
-      missed++;
-      continue;
-    }
-    if (group.uncompressedSize > stats.peakTempBytes) {
-      stats.peakTempBytes = group.uncompressedSize;
-    }
-
     if (!decompressGroup(fontData, groupIdx, tempBuf, group.uncompressedSize)) {
-      free(tempBuf);
       missed++;
       continue;
     }
@@ -601,9 +612,9 @@ int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8
       }
       writeOffset += glyph.dataLength;
     }
-
-    free(tempBuf);
   }
+
+  free(tempBuf);
 
   LOG_DBG("FDC", "Prewarm: %u glyphs in %u bytes from %u groups (%d missed)", glyphCount, writeOffset, groupCount,
           missed);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2000,7 +2000,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
       // TEMP (issue #54): open = ctor + loadSectionFile (+ build); read = page record off SD;
       // draw = glyph prewarm + rasterise. fresh=1 marks a chapter transition.
-      LOG_DBG("VPHASE", "fresh=%d open=%ums read=%ums draw=%ums total=%ums maxAlloc=%u free=%u", vFreshSection ? 1 : 0,
+      // spine/page log EVERY render, unlike "Progress saved" which is now skipped while skimming
+      // -- a position jump that happens mid-skim leaves no other trace.
+      LOG_DBG("VPHASE", "spine=%d page=%d/%d fresh=%d open=%ums read=%ums draw=%ums total=%ums maxAlloc=%u free=%u",
+              currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, vFreshSection ? 1 : 0,
               tVOpenDone - tVEnter, tVPageRead - tVOpenDone, millis() - start, millis() - tVEnter,
               ESP.getMaxAllocHeap(), ESP.getFreeHeap());
     }
@@ -2071,13 +2074,14 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
       }
     }
-    // Skipped while skimming: this is an SD write per page turn, and the render that settles
-    // saves the position the reader actually stops on. Progress durability is unaffected -- the
-    // only pages not persisted are ones passed through on the way somewhere else.
-    if (!skimming) {
-      saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
-                   furiganaOverride);
-    }
+    // NOT gated on `skimming`. It was, on the reasoning that the render which settles would save
+    // the final position anyway -- but the saved record is not write-only: the progress-sync path
+    // in this same function restores from it (`verticalSection->currentPage = targetPage`). Leave
+    // it stale through a skim and a sync arriving mid-skim snaps the reader back to wherever the
+    // last write happened, which after skimming a chapter is near its start. One SD write per turn
+    // is the wrong thing to trade for that.
+    saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
+                 furiganaOverride);
 
     // End of the overlap window. Everything past this point may draw: the popups below, the
     // screenshot's framebuffer read, and the image warm's cache decode.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2037,7 +2037,14 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // own one-page spine item, so a text->image->text sequence popped Indexing twice. Now
     // the image chapter builds while the last text pages are read, and the next text
     // chapter builds while the reader looks at the illustration.
-    if (!skimming) silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
+    // NOT gated on `skimming`, unlike the tail work below. This is the one task here that is not
+    // speculative for the current page: skipping it does not save work, it defers a chapter build
+    // from the background into the reader's path, where it costs ~17s with an Indexing popup.
+    // Gating it cost exactly that (device log: "boundary peek failed: spine 7 section not
+    // loadable" followed by a 17302ms foreground build) because it only fires on a chapter's last
+    // two pages -- precisely the pages a reader skims through on the way to the next chapter.
+    // Cheap to leave in: on every other page of the chapter it returns immediately.
+    silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
 
     // Warm the neighbouring page's glyphs while the reader looks at this one, so the next turn
     // renders from a warm cache instead of paying the per-page SD bulk load at button time.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1662,10 +1662,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   // --- Vertical text mode path ---
   if (useVerticalText()) {
-    // TEMP (issue #54): phase timing for the turn. Chapter transitions measure ~1s against a
-    // 117ms steady turn and the split between section open, page read and draw is unknown.
-    const uint32_t tVEnter = millis();
-    const bool vFreshSection = !verticalSection;
     if (failedVerticalSpineIndex == currentSpineIndex) {
       // This spine index already failed to build this session (typically a transient low-heap
       // allocation failure) -- show a real error instead of silently re-attempting the same
@@ -1842,10 +1838,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     updateBookmarkFlag();
 
     bool imagePageDisplayed = false;
-    const uint32_t tVOpenDone = millis();  // TEMP (issue #54)
     {
       const auto* vpage = verticalSection->getPage();
-      const uint32_t tVPageRead = millis();  // TEMP (issue #54)
       if (!vpage) {
         if (verticalSection->lastReadHeapRefused()) {
           // Transient low heap, NOT corruption: the on-disk cache is valid. Clearing it here
@@ -1998,14 +1992,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (!vGlyphsWarm) prewarmedVPage_ = verticalSection->currentPage;
       }
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
-      // TEMP (issue #54): open = ctor + loadSectionFile (+ build); read = page record off SD;
-      // draw = glyph prewarm + rasterise. fresh=1 marks a chapter transition.
-      // spine/page log EVERY render, unlike "Progress saved" which is now skipped while skimming
-      // -- a position jump that happens mid-skim leaves no other trace.
-      LOG_DBG("VPHASE", "spine=%d page=%d/%d fresh=%d open=%ums read=%ums draw=%ums total=%ums maxAlloc=%u free=%u",
-              currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, vFreshSection ? 1 : 0,
-              tVOpenDone - tVEnter, tVPageRead - tVOpenDone, millis() - start, millis() - tVEnter,
-              ESP.getMaxAllocHeap(), ESP.getFreeHeap());
     }
 
     // Start the waveform and return, so the post-render work below (next-chapter index, glyph
@@ -2018,70 +2004,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       renderStatusBar();
       ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh, overlapRefresh);
     }
-    // Skimming: when a render is ALREADY queued (button held, or presses stacked up while this
-    // page drew), the reader is hunting for a position and will leave this page immediately.
-    // Every tail task below is speculative work for a page that is about to be replaced, and it
-    // runs on the render task, so it delays the very render the reader is waiting for -- measured
-    // at ~430ms per turn, most of it the mini-kern build for a neighbour never visited.
-    // The pending-notification read is the same signal imageWarmShouldCancel() uses (see the
-    // comment there on why ulTaskNotifyValueClear with no bits is the side-effect-free read), but
-    // spelled out rather than reusing that helper: its input-stamp comparison is only valid once
-    // warmNextPageImageCache() has taken its snapshot, which has not happened yet here.
-    // Nothing below is required for correctness: the warm is an optimisation, the silent index
-    // retries on the next settled page, and the progress save is repeated by whichever render
-    // finally settles.
-    const bool skimming = mappedInput.anyButtonDownRaw() || ulTaskNotifyValueClear(nullptr, 0) > 0;
-    if (skimming) LOG_DBG("VSKIM", "tail skipped: render already queued");  // TEMP (issue #54)
-
-    // Pre-build the next chapter's cache while this page is on screen. This call was
-    // missing from the vertical path (lost in a refactor -- silentIndexNextChapterIfNeeded
-    // has had a vertical branch all along), so in tategaki books every chapter transition
-    // showed the Indexing popup. JP books make it worse: each full-page illustration is its
-    // own one-page spine item, so a text->image->text sequence popped Indexing twice. Now
-    // the image chapter builds while the last text pages are read, and the next text
-    // chapter builds while the reader looks at the illustration.
-    // NOT gated on `skimming`, unlike the tail work below. This is the one task here that is not
-    // speculative for the current page: skipping it does not save work, it defers a chapter build
-    // from the background into the reader's path, where it costs ~17s with an Indexing popup.
-    // Gating it cost exactly that (device log: "boundary peek failed: spine 7 section not
-    // loadable" followed by a 17302ms foreground build) because it only fires on a chapter's last
-    // two pages -- precisely the pages a reader skims through on the way to the next chapter.
-    // Cheap to leave in: on every other page of the chapter it returns immediately.
-    silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
-
-    // Warm the neighbouring page's glyphs while the reader looks at this one, so the next turn
-    // renders from a warm cache instead of paying the per-page SD bulk load at button time.
-    // Must stay AFTER the silent index above, which releases all font memory before building and
-    // would discard this warm.
-    // getPage(target) also leaves that page in the section's single-page read cache, so the turn
-    // skips the SD page read as well.
-    //
-    // Direction-adaptive: the NEXT page after a forward turn, the PREVIOUS after a backward one, so
-    // sustained paging either way stays warm. The mini-font cache holds one page per style, so only
-    // the single turn after a direction reversal is cold -- and for the same reason this runs only
-    // after a REAL page change: warming the neighbour of a re-rendered page evicts glyphs that page
-    // still needs.
-    //
-    // Use renderedVPage_, never currentPage. A render takes 100-700ms and a button press during it
-    // advances currentPage, which overshoots the target by one: that both loads a page the reader
-    // is not going to next and evicts the one they are.
-    const bool pageChanged = renderedVPage_ != lastRenderedVPage_;
-    lastRenderedVPage_ = renderedVPage_;
-    const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? renderedVPage_ + 1 : renderedVPage_ - 1;
-    if (!skimming && pageChanged && warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
-      prewarmedVPage_ = -1;
-      if (const VerticalPage* np = verticalSection->getPage(warmTarget); np && !np->isImagePage()) {
-        if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
-      }
-    }
-    // NOT gated on `skimming`. It was, on the reasoning that the render which settles would save
-    // the final position anyway -- but the saved record is not write-only: the progress-sync path
-    // in this same function restores from it (`verticalSection->currentPage = targetPage`). Leave
-    // it stale through a skim and a sync arriving mid-skim snaps the reader back to wherever the
-    // last write happened, which after skimming a chapter is near its start. One SD write per turn
-    // is the wrong thing to trade for that.
-    saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
-                 furiganaOverride);
+    runPostRenderTail(viewportWidth, viewportHeight, /*vertical=*/true, 0, 0);
 
     // End of the overlap window. Everything past this point may draw: the popups below, the
     // screenshot's framebuffer read, and the image warm's cache decode.
@@ -2518,34 +2441,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
   }
 
-  // Idle next-page prewarm (Kindle-class turns): while the reader looks at this page, scan the
-  // page they'll turn to next (direction-adaptive) and warm its glyphs into the font cache, so
-  // the next turn renders warm (~30ms) instead of paying the scan + SD bulk load at button
-  // time. The scan pass draws nothing (GfxRenderer skips drawing while scanning), so it never
-  // touches the displayed framebuffer. Heap-gated: warming loads an extra page transiently, so
-  // skip it when the largest free block is tight and take the classic cold turn instead.
-  prewarmedHPage_ = -1;
-  constexpr uint32_t IDLE_WARM_MIN_ALLOC = 32 * 1024;
-  if (auto* fcm = renderer.getFontCacheManager(); fcm && ESP.getMaxAllocHeap() >= IDLE_WARM_MIN_ALLOC) {
-    const int warmTarget =
-        lastTurnForward_.load(std::memory_order_relaxed) ? section->currentPage + 1 : section->currentPage - 1;
-    if (warmTarget >= 0 && warmTarget < section->pageCount) {
-      if (auto np = section->loadPageAt(warmTarget)) {
-        // createPrewarmScope() clears the cache in its constructor (FontCacheManager::clearCache
-        // -> FontDecompressor::clearCache), which frees the MAX_PAGE_SLOTS page-buffer slots.
-        // So each idle warm REPLACES the previous page's glyphs rather than consuming a new
-        // slot -- slots do not accumulate across turns even with release() keeping the result.
-        auto scope = fcm->createPrewarmScope();
-        np->render(renderer, effectiveReaderFontId(), orientedMarginLeft, orientedMarginTop, !useFurigana());
-        scope.endScanAndPrewarm();
-        scope.release();  // keep the warm resident for the upcoming turn
-        prewarmedHPage_ = warmTarget;
-      }
-    }
-  }
-
-  silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
-  saveProgress(currentSpineIndex, section->currentPage, section->pageCount, verticalOverride, furiganaOverride);
+  runPostRenderTail(viewportWidth, viewportHeight, /*vertical=*/false, orientedMarginLeft, orientedMarginTop);
 
   showPendingSyncSaveError();
 
@@ -2719,6 +2615,88 @@ bool EpubReaderActivity::applyDeferredReposition() {
   return changed;
 }
 
+// Speculative + bookkeeping work that runs while the finished page is on screen. Order and gating
+// here are load-bearing; see nextTurnAlreadyRequested() in the header for the rule.
+void EpubReaderActivity::runPostRenderTail(const uint16_t viewportWidth, const uint16_t viewportHeight,
+                                           const bool vertical, const int marginLeft, const int marginTop) {
+  const bool skimming = nextTurnAlreadyRequested();
+
+  // FIRST, and never gated. Builds the next chapter's section cache while the last pages of this
+  // one are on screen; without it a chapter transition pays a multi-second foreground build with
+  // an Indexing popup. It only does work on a chapter's closing pages -- which are exactly the
+  // pages a reader skims through, so gating it on `skimming` suppressed it whenever it mattered.
+  //
+  // Must precede the warm below: it calls releaseAllFontMemory() before building, which empties
+  // the mini-font cache and would discard a warm done first.
+  silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
+
+  // Warm the neighbouring page's glyphs so the next turn renders from RAM instead of paying the
+  // scan plus SD bulk load at button time. Direction-adaptive: the next page after a forward
+  // turn, the previous after a backward one, so sustained paging either way stays warm. The
+  // mini-font cache holds one page per style, so only the turn after a direction REVERSAL is
+  // cold; that is inherent, not a defect.
+  //
+  // Gated on `skimming`: this prepares a page a rapidly-paging reader will skip past, and it runs
+  // on the render task, so it delays the turn being waited on (~430ms, mostly the mini-kern
+  // build).
+  //
+  // Runs only after a REAL page change -- warming the neighbour of a re-rendered page evicts
+  // glyphs that page still needs.
+  const bool forward = lastTurnForward_.load(std::memory_order_relaxed);
+  if (vertical) {
+    // renderedVPage_, never currentPage: a render takes 100-700ms and a button press during it
+    // advances currentPage, so the target would overshoot by one -- loading a page the reader is
+    // not going to next and evicting the one they are.
+    const bool pageChanged = renderedVPage_ != lastRenderedVPage_;
+    lastRenderedVPage_ = renderedVPage_;
+    const int warmTarget = forward ? renderedVPage_ + 1 : renderedVPage_ - 1;
+    if (!skimming && pageChanged && warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
+      prewarmedVPage_ = -1;
+      // getPage() also leaves the page in the section's single-page read cache, so the turn skips
+      // the SD page read as well.
+      if (const VerticalPage* np = verticalSection->getPage(warmTarget); np && !np->isImagePage()) {
+        if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
+      }
+    }
+  } else {
+    prewarmedHPage_ = -1;
+    // Warming loads an extra page transiently, so take the classic cold turn when the largest
+    // free block is tight.
+    constexpr uint32_t IDLE_WARM_MIN_ALLOC = 32 * 1024;
+    const int warmTarget = forward ? section->currentPage + 1 : section->currentPage - 1;
+    if (auto* fcm = renderer.getFontCacheManager(); fcm && !skimming && ESP.getMaxAllocHeap() >= IDLE_WARM_MIN_ALLOC &&
+                                                    warmTarget >= 0 && warmTarget < section->pageCount) {
+      if (auto np = section->loadPageAt(warmTarget)) {
+        // createPrewarmScope() clears the cache in its constructor, freeing the MAX_PAGE_SLOTS
+        // page-buffer slots, so each warm REPLACES the previous page's glyphs -- slots do not
+        // accumulate across turns even though release() keeps the result. The scan pass draws
+        // nothing (GfxRenderer skips drawing while scanning), so the displayed framebuffer is
+        // untouched and this is safe inside an async refresh window.
+        auto scope = fcm->createPrewarmScope();
+        np->render(renderer, effectiveReaderFontId(), marginLeft, marginTop, !useFurigana());
+        scope.endScanAndPrewarm();
+        scope.release();  // keep the warm resident for the upcoming turn
+        prewarmedHPage_ = warmTarget;
+      }
+    }
+  }
+
+  // Never gated. The saved record is not write-only -- render()'s progress-sync path restores
+  // position from it, so leaving it stale through a skim lets a sync snap the reader back to the
+  // last page actually written.
+  const int page = vertical ? verticalSection->currentPage : section->currentPage;
+  const int pageCount = vertical ? verticalSection->pageCount : section->pageCount;
+  saveProgress(currentSpineIndex, page, pageCount, verticalOverride, furiganaOverride);
+}
+
+bool EpubReaderActivity::nextTurnAlreadyRequested() const {
+  // Reading this task's own notification VALUE without side effects: ulTaskNotifyValueClear with
+  // zero bits to clear is a pure read (xTaskNotifyAndQuery is NOT -- even with eNoAction it
+  // stamps the notification state). Same signal imageWarmShouldCancel() uses, minus its input
+  // stamp, which is only meaningful once warmNextPageImageCache() has taken its snapshot.
+  return mappedInput.anyButtonDownRaw() || ulTaskNotifyValueClear(nullptr, 0) > 0;
+}
+
 bool EpubReaderActivity::imageWarmShouldCancel(const void* ctx) {
   const auto* self = static_cast<const EpubReaderActivity*>(ctx);
   if (self->mappedInput.anyButtonDownRaw()) return true;
@@ -2736,11 +2714,9 @@ bool EpubReaderActivity::imageWarmShouldCancel(const void* ctx) {
 void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, const uint16_t viewportHeight) {
   imageWarmStampSnapshot_ = imageWarmInputStamp_.load(std::memory_order_relaxed);
   if (imageWarmShouldCancel(this)) {
-    LOG_DBG("IWARM", "skip: render already queued");  // TEMP diagnostics (slow-books hunt)
-    return;                                           // another render is already queued -- stay out of its way
+    return;  // another render is already queued -- stay out of its way
   }
   if (ESP.getMaxAllocHeap() < IMAGE_WARM_MIN_ALLOC) {
-    LOG_DBG("IWARM", "skip: maxAlloc %u < %u floor", ESP.getMaxAllocHeap(), IMAGE_WARM_MIN_ALLOC);  // TEMP
     return;
   }
 
@@ -2780,7 +2756,9 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
           nextV->pageCount > 0) {
         vp = nextV->getPage(0);
       } else {
-        LOG_DBG("IWARM", "boundary peek failed: spine %d section not loadable", currentSpineIndex + 1);  // TEMP
+        // Kept: this line means the next chapter has no section file, i.e. the silent index did
+        // not build it and the reader is one turn from a multi-second foreground build.
+        LOG_DBG("IWARM", "boundary peek failed: spine %d section not loadable", currentSpineIndex + 1);
       }
     }
     // Warm the image on the next page and, if that one is already cached, keep looking ahead

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1662,6 +1662,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   // --- Vertical text mode path ---
   if (useVerticalText()) {
+    // TEMP (issue #54): phase timing for the turn. Chapter transitions measure ~1s against a
+    // 117ms steady turn and the split between section open, page read and draw is unknown.
+    const uint32_t tVEnter = millis();
+    const bool vFreshSection = !verticalSection;
     if (failedVerticalSpineIndex == currentSpineIndex) {
       // This spine index already failed to build this session (typically a transient low-heap
       // allocation failure) -- show a real error instead of silently re-attempting the same
@@ -1838,8 +1842,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     updateBookmarkFlag();
 
     bool imagePageDisplayed = false;
+    const uint32_t tVOpenDone = millis();  // TEMP (issue #54)
     {
       const auto* vpage = verticalSection->getPage();
+      const uint32_t tVPageRead = millis();  // TEMP (issue #54)
       if (!vpage) {
         if (verticalSection->lastReadHeapRefused()) {
           // Transient low heap, NOT corruption: the on-disk cache is valid. Clearing it here
@@ -1992,6 +1998,11 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (!vGlyphsWarm) prewarmedVPage_ = verticalSection->currentPage;
       }
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
+      // TEMP (issue #54): open = ctor + loadSectionFile (+ build); read = page record off SD;
+      // draw = glyph prewarm + rasterise. fresh=1 marks a chapter transition.
+      LOG_DBG("VPHASE", "fresh=%d open=%ums read=%ums draw=%ums total=%ums maxAlloc=%u free=%u", vFreshSection ? 1 : 0,
+              tVOpenDone - tVEnter, tVPageRead - tVOpenDone, millis() - start, millis() - tVEnter,
+              ESP.getMaxAllocHeap(), ESP.getFreeHeap());
     }
 
     if (!imagePageDisplayed) {  // image pages already displayed (double-fast + grayscale planes)
@@ -2536,17 +2547,15 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     if (nextVSection.loadSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana()))
       return;
 
-    // Cheap pre-gate, before paying anything. releaseAllFontMemory() below cannot produce a block
-    // larger than the total free heap, so if free is already under the build's floor the release
-    // is guaranteed not to clear the gate -- and it would still cost the next render a full
-    // font-cache rebuild (~250ms). Skip the whole attempt instead.
     constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 96 * 1024;
-    if (ESP.getFreeHeap() < SILENT_VBUILD_MIN_ALLOC) {
-      LOG_DBG("ERS", "Silent vertical index skipped, free heap below floor (free=%u)", ESP.getFreeHeap());
-      silentIndexBackoffUntilMs_ = millis() + 5000;
-      return;
-    }
 
+    // There is deliberately NO pre-gate on the heap here. One existed, testing free heap against
+    // this same floor before the release below, and it rejected every attempt ever made: it
+    // measured the heap BEFORE the release that produces the memory. Free during reading sits
+    // around 95K and the release is worth ~40-50K, so the only honest reading is the post-release
+    // one below. The rebuild the pre-gate was avoiding costs ~250ms; the foreground build it lets
+    // through instead costs 5-13s.
+    //
     // The vertical build is the most memory-intensive step in the reader, and this
     // silent path runs it at the worst heap moment: right after a page render, with
     // the glyph slab fully warmed AND the current chapter still resident. Hand the

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2005,10 +2005,31 @@ void EpubReaderActivity::render(RenderLock&& lock) {
               ESP.getMaxAllocHeap(), ESP.getFreeHeap());
     }
 
+    // Start the waveform and return, so the post-render work below (next-chapter index, glyph
+    // warm, progress save) runs DURING the panel's ~500ms refresh instead of after it. Sustained
+    // paging was device-bound at ~1030ms per turn: 50ms draw + 502ms blocking refresh + ~430ms
+    // warm. None of the overlapped work touches the framebuffer -- the glyph warm renders in scan
+    // mode, which draws nothing. Everything that DOES touch it waits first; see below.
+    const bool overlapRefresh = !imagePageDisplayed && renderer.supportsAsyncRefresh();
     if (!imagePageDisplayed) {  // image pages already displayed (double-fast + grayscale planes)
       renderStatusBar();
-      ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+      ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh, overlapRefresh);
     }
+    // Skimming: when a render is ALREADY queued (button held, or presses stacked up while this
+    // page drew), the reader is hunting for a position and will leave this page immediately.
+    // Every tail task below is speculative work for a page that is about to be replaced, and it
+    // runs on the render task, so it delays the very render the reader is waiting for -- measured
+    // at ~430ms per turn, most of it the mini-kern build for a neighbour never visited.
+    // The pending-notification read is the same signal imageWarmShouldCancel() uses (see the
+    // comment there on why ulTaskNotifyValueClear with no bits is the side-effect-free read), but
+    // spelled out rather than reusing that helper: its input-stamp comparison is only valid once
+    // warmNextPageImageCache() has taken its snapshot, which has not happened yet here.
+    // Nothing below is required for correctness: the warm is an optimisation, the silent index
+    // retries on the next settled page, and the progress save is repeated by whichever render
+    // finally settles.
+    const bool skimming = mappedInput.anyButtonDownRaw() || ulTaskNotifyValueClear(nullptr, 0) > 0;
+    if (skimming) LOG_DBG("VSKIM", "tail skipped: render already queued");  // TEMP (issue #54)
+
     // Pre-build the next chapter's cache while this page is on screen. This call was
     // missing from the vertical path (lost in a refactor -- silentIndexNextChapterIfNeeded
     // has had a vertical branch all along), so in tategaki books every chapter transition
@@ -2016,7 +2037,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // own one-page spine item, so a text->image->text sequence popped Indexing twice. Now
     // the image chapter builds while the last text pages are read, and the next text
     // chapter builds while the reader looks at the illustration.
-    silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
+    if (!skimming) silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
 
     // Warm the neighbouring page's glyphs while the reader looks at this one, so the next turn
     // renders from a warm cache instead of paying the per-page SD bulk load at button time.
@@ -2037,14 +2058,23 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     const bool pageChanged = renderedVPage_ != lastRenderedVPage_;
     lastRenderedVPage_ = renderedVPage_;
     const int warmTarget = lastTurnForward_.load(std::memory_order_relaxed) ? renderedVPage_ + 1 : renderedVPage_ - 1;
-    if (pageChanged && warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
+    if (!skimming && pageChanged && warmTarget >= 0 && warmTarget < verticalSection->pageCount) {
       prewarmedVPage_ = -1;
       if (const VerticalPage* np = verticalSection->getPage(warmTarget); np && !np->isImagePage()) {
         if (prewarmVerticalPageGlyphs(*np)) prewarmedVPage_ = warmTarget;
       }
     }
-    saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
-                 furiganaOverride);
+    // Skipped while skimming: this is an SD write per page turn, and the render that settles
+    // saves the position the reader actually stops on. Progress durability is unaffected -- the
+    // only pages not persisted are ones passed through on the way somewhere else.
+    if (!skimming) {
+      saveProgress(currentSpineIndex, verticalSection->currentPage, verticalSection->pageCount, verticalOverride,
+                   furiganaOverride);
+    }
+
+    // End of the overlap window. Everything past this point may draw: the popups below, the
+    // screenshot's framebuffer read, and the image warm's cache decode.
+    if (overlapRefresh) renderer.waitRefreshComplete();
 
     showPendingSyncSaveError();
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2429,19 +2429,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
     lastRenderCompleteMs = millis();
   }
-  // Only persist when the position actually changed. render() also runs on menu,
-  // bookmark and screenshot re-renders, and writeAtomic is several FAT ops for 6 bytes.
-  // Every real page turn changes currentPage, so progress durability is unaffected.
-  if (currentSpineIndex != lastSavedSpineIndex || section->currentPage != lastSavedPage ||
-      section->pageCount != lastSavedPageCount) {
-    if (saveProgress(currentSpineIndex, section->currentPage, section->estimatedTotalPages(), verticalOverride,
-                     furiganaOverride)) {
-      lastSavedSpineIndex = currentSpineIndex;
-      lastSavedPage = section->currentPage;
-      lastSavedPageCount = section->estimatedTotalPages();
-    }
-  }
-
   runPostRenderTail(viewportWidth, viewportHeight, /*vertical=*/false, orientedMarginLeft, orientedMarginTop);
 
   showPendingSyncSaveError();
@@ -2678,12 +2665,26 @@ void EpubReaderActivity::runPostRenderTail(const uint16_t viewportWidth, const u
     }
   }
 
-  // Never gated. The saved record is not write-only -- render()'s progress-sync path restores
-  // position from it, so leaving it stale through a skim lets a sync snap the reader back to the
-  // last page actually written.
+  // Never gated on `skimming`. The saved record is not write-only -- render()'s progress-sync path
+  // restores position from it, so leaving it stale through a skim lets a sync snap the reader back
+  // to the last page actually written.
+  //
+  // It IS gated on the position having changed: writeAtomic() is several FAT ops for 6 bytes, and
+  // render() also runs for menu, bookmark and screenshot re-renders, which move nothing. Every
+  // real page turn changes `page`, so durability is unaffected.
+  //
+  // Horizontal reports estimatedTotalPages(), not pageCount: during a partial build the estimate
+  // is the meaningful total, and it moving is itself worth persisting. Compare against the same
+  // value that gets stored, or the guard never settles.
   const int page = vertical ? verticalSection->currentPage : section->currentPage;
-  const int pageCount = vertical ? verticalSection->pageCount : section->pageCount;
-  saveProgress(currentSpineIndex, page, pageCount, verticalOverride, furiganaOverride);
+  const int pageCount = vertical ? verticalSection->pageCount : section->estimatedTotalPages();
+  if (currentSpineIndex != lastSavedSpineIndex || page != lastSavedPage || pageCount != lastSavedPageCount) {
+    if (saveProgress(currentSpineIndex, page, pageCount, verticalOverride, furiganaOverride)) {
+      lastSavedSpineIndex = currentSpineIndex;
+      lastSavedPage = page;
+      lastSavedPageCount = pageCount;
+    }
+  }
 }
 
 bool EpubReaderActivity::nextTurnAlreadyRequested() const {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1994,11 +1994,12 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       LOG_DBG("ERS", "Rendered vertical page in %dms", millis() - start);
     }
 
-    // Start the waveform and return, so the post-render work below (next-chapter index, glyph
-    // warm, progress save) runs DURING the panel's ~500ms refresh instead of after it. Sustained
-    // paging was device-bound at ~1030ms per turn: 50ms draw + 502ms blocking refresh + ~430ms
-    // warm. None of the overlapped work touches the framebuffer -- the glyph warm renders in scan
-    // mode, which draws nothing. Everything that DOES touch it waits first; see below.
+    // Async: start the waveform and return, so runPostRenderTail() below runs DURING the panel's
+    // ~500ms refresh rather than after it. Worth ~450ms per turn.
+    //
+    // Contract: nothing between here and waitRefreshComplete() may touch the framebuffer. The tail
+    // is safe (its glyph warm renders in scan mode, which draws nothing); popups, screenshots and
+    // the image warm are not, and run after the wait.
     const bool overlapRefresh = !imagePageDisplayed && renderer.supportsAsyncRefresh();
     if (!imagePageDisplayed) {  // image pages already displayed (double-fast + grayscale planes)
       renderStatusBar();
@@ -2469,11 +2470,10 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     // one page each -- with the old penultimate-page-only trigger a run of them showed the
     // Indexing popup on every page turn).
     //
-    // The window is 5 pages, not 2, because the heap gate below rejects on a bad fragmentation
-    // moment and a 2-page window gave it ONE attempt: a rejection there (device log:
-    // "heap too tight (maxAlloc=69620)" on the last page but one) meant the chapter was never
-    // built and the transition paid a 7.6s foreground build. Several attempts across several
-    // turns sample several heap states, and only the first to pass does any work.
+    // The window must be wide enough for SEVERAL attempts, not one. The heap gate below rejects
+    // on transient fragmentation (observed: maxAlloc 69620 on one turn, 114676 two turns later),
+    // so a single-attempt window loses the chapter to that sampling noise and the transition pays
+    // a multi-second foreground build. Only the first attempt to pass does any work.
     constexpr int SILENT_INDEX_WINDOW_PAGES = 5;
     if (!epub || !verticalSection || verticalSection->pageCount < 1) return;
     if (verticalSection->currentPage < verticalSection->pageCount - SILENT_INDEX_WINDOW_PAGES) return;
@@ -2493,12 +2493,10 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
 
     constexpr uint32_t SILENT_VBUILD_MIN_ALLOC = 96 * 1024;
 
-    // There is deliberately NO pre-gate on the heap here. One existed, testing free heap against
-    // this same floor before the release below, and it rejected every attempt ever made: it
-    // measured the heap BEFORE the release that produces the memory. Free during reading sits
-    // around 95K and the release is worth ~40-50K, so the only honest reading is the post-release
-    // one below. The rebuild the pre-gate was avoiding costs ~250ms; the foreground build it lets
-    // through instead costs 5-13s.
+    // Do NOT add a heap pre-gate above the release below. Free heap while reading sits near this
+    // floor (~95K) and the release is worth ~40-50K, so any pre-release check rejects attempts
+    // that would have passed. The post-release gate is the only meaningful reading. Skipping a
+    // release costs ~250ms; the foreground build a missed index causes costs 5-13s.
     //
     // The vertical build is the most memory-intensive step in the reader, and this
     // silent path runs it at the worst heap moment: right after a page render, with
@@ -2523,10 +2521,9 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     // (which frees more up front and early-renders) builds it properly on arrival.
     if (ESP.getMaxAllocHeap() < SILENT_VBUILD_MIN_ALLOC) {
       LOG_DBG("ERS", "Silent vertical index skipped, heap too tight (maxAlloc=%u)", ESP.getMaxAllocHeap());
-      // Short backoff: at ~600ms per turn a 5s window swallowed the whole trigger range, so one
-      // rejection ended the chapter's chances. A rejected attempt costs the font rebuild the
-      // release above forces (~250-400ms on the next render), which is worth paying a few times
-      // against a 7.6s foreground build.
+      // Backoff must stay well under WINDOW * turn duration (~600ms/turn), or one rejection
+      // consumes the whole window. A rejected attempt costs the font rebuild the release above
+      // forces (~250-400ms on the next render) -- cheap against the foreground build it avoids.
       silentIndexBackoffUntilMs_ = millis() + 1500;
       return;
     }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2565,11 +2565,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
 void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportWidth, const uint16_t viewportHeight) {
   if (useVerticalText()) {
-    // Fire on the last two pages, and on single-page chapters (image-only illustration
-    // chapters are one page each -- with the old penultimate-page-only trigger a run of
-    // them showed the Indexing popup on every page turn).
+    // Fire over the last few pages, and on short chapters (image-only illustration chapters are
+    // one page each -- with the old penultimate-page-only trigger a run of them showed the
+    // Indexing popup on every page turn).
+    //
+    // The window is 5 pages, not 2, because the heap gate below rejects on a bad fragmentation
+    // moment and a 2-page window gave it ONE attempt: a rejection there (device log:
+    // "heap too tight (maxAlloc=69620)" on the last page but one) meant the chapter was never
+    // built and the transition paid a 7.6s foreground build. Several attempts across several
+    // turns sample several heap states, and only the first to pass does any work.
+    constexpr int SILENT_INDEX_WINDOW_PAGES = 5;
     if (!epub || !verticalSection || verticalSection->pageCount < 1) return;
-    if (verticalSection->currentPage < verticalSection->pageCount - 2) return;
+    if (verticalSection->currentPage < verticalSection->pageCount - SILENT_INDEX_WINDOW_PAGES) return;
 
     const int nextSpineIndex = currentSpineIndex + 1;
     if (nextSpineIndex < 0 || nextSpineIndex >= epub->getSpineItemsCount()) return;
@@ -2616,7 +2623,11 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     // (which frees more up front and early-renders) builds it properly on arrival.
     if (ESP.getMaxAllocHeap() < SILENT_VBUILD_MIN_ALLOC) {
       LOG_DBG("ERS", "Silent vertical index skipped, heap too tight (maxAlloc=%u)", ESP.getMaxAllocHeap());
-      silentIndexBackoffUntilMs_ = millis() + 5000;
+      // Short backoff: at ~600ms per turn a 5s window swallowed the whole trigger range, so one
+      // rejection ended the chapter's chances. A rejected attempt costs the font rebuild the
+      // release above forces (~250-400ms on the next render), which is worth paying a few times
+      // against a 7.6s foreground build.
+      silentIndexBackoffUntilMs_ = millis() + 1500;
       return;
     }
     silentIndexBackoffUntilMs_ = 0;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -195,6 +195,22 @@ class EpubReaderActivity final : public Activity {
   std::atomic<uint32_t> requestedHorizontalImageRefine_{NO_IMAGE_REFINE};
   void warmNextPageImageCache(uint16_t viewportWidth, uint16_t viewportHeight);
   static bool imageWarmShouldCancel(const void* ctx);
+  // True when the next turn has already been requested: a button is physically down, or a render
+  // is queued on this task. Call from the render task only.
+  //
+  // Gate SPECULATIVE tail work on this -- work whose only value is to make the NEXT render
+  // faster. It runs on the render task, so it delays the render it is preparing for; when the
+  // reader is paging rapidly the page it prepared is skipped past anyway.
+  //
+  // Do NOT gate work whose absence has a cost of its own. Two that must stay unconditional, both
+  // learned the hard way: silentIndexNextChapterIfNeeded() (skipping defers a chapter build into
+  // the reader's path, seconds with an Indexing popup) and saveProgress() (the record is restored
+  // from by the progress-sync path, so a stale one snaps the reader backwards mid-skim).
+  bool nextTurnAlreadyRequested() const;
+  // Shared tail of both render paths: next-chapter index, neighbour-page glyph warm, progress
+  // save. `vertical` selects the section type; the margins are used by the horizontal warm only.
+  // Safe to call inside an async refresh window -- nothing here touches the framebuffer.
+  void runPostRenderTail(uint16_t viewportWidth, uint16_t viewportHeight, bool vertical, int marginLeft, int marginTop);
   // Viewport of the last render(), captured so loop()'s lazy partial-extension start
   // builds with IDENTICAL layout parameters to the pages already rendered (a mismatch
   // would paginate differently than the partial being extended). 0 = no render yet.


### PR DESCRIPTION
Closes #54 (items 1–3; 4 is moot, see below).

Measured on X4 across several reading sessions, warm caches.

| | before | after |
|---|---|---|
| steady turn, draw | 117ms median | **52ms** median |
| panel refresh wait | 502ms every turn | **124ms** median |
| chapter transition | 5–13s foreground build | **~30ms** (`open`) |
| prewarm temp-buffer failures | 16 in a burst | 0 |
| `maxAlloc` low-water | 6900 | 24564 |

## What was wrong

**The prewarm allocated per group.** `prewarmCache` malloc'd and freed a group-sized (~16KB) temp buffer once per group, up to 128 times per page — a fragmentation source, and on a tight heap it failed once per group rather than once per page, so a whole page's prewarm silently produced nothing. One buffer sized to the largest group now serves all of them.

**The silent chapter index never ran.** Its heap pre-gate tested free heap against the build's *post*-release floor — before the release that produces the memory. Free while reading sits at ~95K against a 96K floor, so it rejected every attempt ever made, and every chapter transition paid a full foreground build. Removed; the post-release gate was correct all along.

**One attempt was not enough.** The gate rejects on transient fragmentation (69620 on one turn, 114676 two turns later) and the trigger window was a chapter's last two pages, so a single rejection lost the chapter. Window widened to 5 pages, backoff cut from 5s to 1.5s.

**The refresh blocked.** The vertical path displayed synchronously, so the CPU idled through the panel's ~500ms waveform while the post-render tail waited to run after it. Now async, with the tail inside that window.

**The tail ran while skimming.** With a turn already queued, the reader is hunting for a position — but the neighbour-page glyph warm ran anyway, on the render task, delaying the very turn being waited on (~430ms, mostly a mini-kern build for a page never visited).

## Shape

`runPostRenderTail()` is now shared by both reader paths. Two things fall out of that:

- **English books get the skim gate too.** Reported from device as "perfect for normal reading but not great when turning pages rapidly while looking for what page you were on".
- **The horizontal path had its warm before the silent index**, which calls `releaseAllFontMemory()` and discarded it. The shared order puts the index first, as vertical already did.

Gating rule, documented on `nextTurnAlreadyRequested()`: gate work whose only value is making the *next* render faster. Do not gate work whose absence has a cost of its own — the silent index (skipping it defers a chapter build into the reader's path) and the progress save (the record is restored from by the progress-sync path, so a stale one snaps the reader backwards mid-skim). Both were learned by getting them wrong.

## Item 4

The 8-slot overflow ring is a consequence of a bypassed prewarm, not a cause. With the prewarm running it no longer thrashes, so I'd close it unless it resurfaces.

## Testing

Device only, on X4. Vertical Japanese across six flash-and-read cycles; horizontal English confirmed on the final build (the report above was what prompted the shared tail). Not tested: the four orientations, image-heavy chapters.

Known remaining: `maxAlloc` still decays over a session (51188 → 24564) and only a font release recovers it; roughly one turn in five after a skim costs ~300ms because its warm was deliberately skipped.
