### PR TITLE
fix: make the per-book stats screen behave like the other two

### DIFF
--- a/src/activities/home/BookStatsActivity.cpp
+++ b/src/activities/home/BookStatsActivity.cpp
@@ -42,7 +42,19 @@ void BookStatsActivity::onEnter() {
 void BookStatsActivity::onExit() { Activity::onExit(); }
 
 void BookStatsActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  // Tap steps back, hold goes home, as on the other two stats screens.
+  if (backLongPressFired) {
+    if (!mappedInput.isPressed(MappedInputManager::Button::Back)) backLongPressFired = false;
+    return;
+  }
+  if (mappedInput.isPressed(MappedInputManager::Button::Back) &&
+      mappedInput.getHeldTime() >= StatsWidgets::HOME_HOLD_MS) {
+    backLongPressFired = true;
+    onGoHome();
+    return;
+  }
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) &&
+      mappedInput.getHeldTime() < StatsWidgets::HOME_HOLD_MS) {
     finish();
     return;
   }
@@ -121,7 +133,14 @@ void BookStatsActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
                  bookTitle.c_str());
 
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT));
+  // Hints name the months Left/Right land on, as on the other two stats screens.
+  char prevBuf[16], nextBuf[16];
+  uint16_t py = calYear, ny = calYear;
+  uint8_t pm = calMonth, nm = calMonth;
+  StatsWidgets::stepMonth(py, pm, -1);
+  StatsWidgets::stepMonth(ny, nm, +1);
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", StatsWidgets::monthAbbrev(pm, prevBuf, sizeof(prevBuf)),
+                                            StatsWidgets::monthAbbrev(nm, nextBuf, sizeof(nextBuf)));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   renderer.displayBuffer();

--- a/src/activities/home/BookStatsActivity.h
+++ b/src/activities/home/BookStatsActivity.h
@@ -13,6 +13,8 @@ class BookStatsActivity final : public Activity {
   std::string bookTitle;
   // Held for the activity's life: a few hundred bytes, and re-reading it would hit SD per frame.
   BookStats stats;
+  // Swallows the release that ends a long Back press, so going home does not also finish().
+  bool backLongPressFired = false;
   int scrollOffset = 0;
   int maxScrollOffset = 0;
   uint16_t calYear = 0;


### PR DESCRIPTION
Two inconsistencies on the per-book stats screen, both oversights rather than decisions.

**Month hints.** Left/Right step the calendar, and Insights and the per-language screen name the month those buttons move to ("Jul" / "Sep"). This screen still said "Left" and "Right", which is visible in any screenshot of the three side by side.

**Hold Back for home.** It was the only stats screen where holding Back did not go home. Same latch as the others, so the release that ends the hold does not also fire the tap.

Both now use the shared `StatsWidgets` helpers the other screens use, so there is one implementation rather than three.

Firmware builds, cppcheck clean, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)