### PR TITLE
feat: keep the reading position in sync across a vertical/horizontal switch

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -816,6 +816,11 @@ bool Section::finalizeBuild() {
     }
   }
 
+  // See the matching "chapter spans" line in VerticalSection: these two numbers come from
+  // independent parsers that must count visible characters identically.
+  if (build_ && !build_->lut.empty()) {
+    LOG_DBG("SCT", "Chapter spans %u chars over %u pages", build_->lut.back().visibleTextOffset, pageCount);
+  }
   const bool committed = commitBuildFile(SECTION_FILE_VERSION, 0, 0);
   if (build_->cssParser) build_->cssParser->clear();
   build_.reset();

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -909,11 +909,19 @@ std::unique_ptr<Page> Section::loadPageDuringBuild(const int page) {
   // The .bin is open O_RDWR for the build. Read the already-written page, then restore
   // the write cursor so the next onPageComplete keeps appending where it left off.
   const uint32_t writePos = file.position();
+  const uint32_t fileSize = static_cast<uint32_t>(file.size());
   file.seek(pos);
   auto p = Page::deserialize(file);
   file.seek(writePos);
   if (p) {
     p->visibleTextOffset = build_->lut[page].visibleTextOffset;
+  }
+  // A page read back out of the tmp .bin should never come up empty: the offset comes from the
+  // build's own LUT and those bytes were written earlier in this same build. Empty means either
+  // the handle cannot read (it must be opened O_RDWR) or the file is damaged, and the reader
+  // would otherwise just draw a blank page with no clue why.
+  if (!p || p->elements.empty()) {
+    LOG_ERR("SCT", "Build-time page read empty: page %d at %u (file %u bytes)", page, pos, fileSize);
   }
   return p;
 }

--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -502,7 +502,10 @@ void VerticalParsedText::addParagraph(const std::string& utf8Text) {
       continue;
     }
     if (!canPushStreamChar()) return;
-    stream_.push_back(PendingChar{cp, paragraphIndex, static_cast<uint32_t>(i), 0, false, {}});
+    // visibleTextOffset stays 0: this overload takes plain text with no extractor context, so
+    // there is no chapter-wide position to attribute it to. Only the annotated path (the one
+    // the real chapter build uses) carries offsets.
+    stream_.push_back(PendingChar{cp, paragraphIndex, static_cast<uint32_t>(i), 0, false, {}, 0});
     i += consumed;
   }
 }
@@ -565,14 +568,23 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
     // memory, only removes the many small alloc/realloc/free cycles getting there.
     std::vector<size_t> baseOffsets;
     std::vector<uint32_t> baseCps;
+    // Source codepoint index of each kept base character, relative to the run's first codepoint.
+    // Counted over EVERY decoded codepoint, including the newlines/tabs dropped below and the
+    // second half of a composed kana diacritic -- the extractor's visible-text counter advances
+    // for those too, so skipping them here would drift the two counts apart character by
+    // character. Parallel to baseCps/baseOffsets.
+    std::vector<uint32_t> baseCpIndex;
     std::vector<size_t> breakBeforeBaseIndex;
     baseOffsets.reserve(run.baseText.size());
     baseCps.reserve(run.baseText.size());
+    baseCpIndex.reserve(run.baseText.size());
     {
       size_t i = 0;
+      uint32_t cpIndex = 0;
       while (i < run.baseText.size()) {
         size_t consumed = 1;
         const uint32_t cp = decodeUtf8At(run.baseText, i, &consumed);
+        const uint32_t thisCpIndex = cpIndex++;
         if ((cp == 0x3099 || cp == 0x309A) && !baseCps.empty()) {
           const uint32_t composed = composeKanaDiacritic(baseCps.back(), cp);
           if (composed != 0) {
@@ -594,6 +606,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
         }
         baseOffsets.push_back(i);
         baseCps.push_back(cp);
+        baseCpIndex.push_back(thisCpIndex);
         i += consumed;
       }
     }
@@ -615,8 +628,13 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
     if (run.rubyText.empty()) {
       for (size_t k = 0; k < baseCps.size(); k++) {
         if (!canPushStreamChar()) return;
-        stream_.push_back(PendingChar{
-            baseCps[k], paragraphIndex, static_cast<uint32_t>(baseOffsets[k]), run.style, run.emphasis, {}});
+        stream_.push_back(PendingChar{baseCps[k],
+                                      paragraphIndex,
+                                      static_cast<uint32_t>(baseOffsets[k]),
+                                      run.style,
+                                      run.emphasis,
+                                      {},
+                                      run.visibleTextOffset + baseCpIndex[k]});
       }
     } else {
       // Decode ruby codepoints to distribute evenly across base characters.
@@ -643,7 +661,7 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
         for (size_t r = rubyStart; r < rubyEnd; r++) utf8AppendCodepoint(rubyCps[r], slice);
         if (!canPushStreamChar()) return;
         stream_.push_back(PendingChar{baseCps[k], paragraphIndex, static_cast<uint32_t>(baseOffsets[k]), run.style,
-                                      run.emphasis, std::move(slice)});
+                                      run.emphasis, std::move(slice), run.visibleTextOffset + baseCpIndex[k]});
       }
     }
 
@@ -1071,6 +1089,10 @@ struct VerticalParsedText::LayoutCursor {
       page = VerticalPage{};
       page.columnCount = geom.columnsPerPage;
       page.rowsPerColumn = geom.rowsPerColumn;
+      // A break decided while placing a character opens this page WITH that character on it, so
+      // the page starts at its position. The per-character stamp cannot supply this: it runs
+      // before the break, against the page being closed.
+      page.visibleTextOffset = o.lastCharOffset_;
       reservePageGlyphs(page);
       column = 0;
       row = 0;
@@ -1523,6 +1545,13 @@ std::vector<VerticalPage> VerticalParsedText::layoutPages(void* ctx, PageReadyCa
     }
 
     const PendingChar& pc = stream_[idx];
+
+    // Stamp the page with its first character's position. "No glyphs yet" stands in for "nothing
+    // placed yet", so a page continuing across a batch boundary keeps the stamp it opened with.
+    // A page opened by a break later in this iteration is seeded from lastCharOffset_ instead --
+    // see finalizePageIfNeeded().
+    lastCharOffset_ = pc.visibleTextOffset;
+    if (page.glyphs.empty()) page.visibleTextOffset = pc.visibleTextOffset;
 
     // Force a fresh column at the start of every paragraph after the
     // first, the same way horizontal layout starts a new line per

--- a/lib/Epub/Epub/VerticalParsedText.h
+++ b/lib/Epub/Epub/VerticalParsedText.h
@@ -126,6 +126,11 @@ struct VerticalBlockParams {
 };
 
 struct VerticalPage {
+  // Codepoint index, within the chapter's visible character data, of this page's first
+  // character -- the vertical counterpart of Page::visibleTextOffset, counted by the same rule
+  // so the two are directly comparable. This is what makes a vertical/horizontal switch land on
+  // the page holding the same sentence rather than on a proportional guess.
+  uint32_t visibleTextOffset = 0;
   std::vector<VerticalGlyph> glyphs;
   std::vector<VerticalBoxRect> boxes;
   // Variable-length glyph texts (ruby annotations, rotated/upright run strings), referenced
@@ -196,6 +201,12 @@ class VerticalParsedText {
     std::string rubyText;
     uint8_t style = 0;
     bool emphasis = false;
+    // Codepoint index, within the chapter's visible character data, of this run's FIRST base
+    // character. Counted by the extractor over the same rule the horizontal parser uses
+    // (VisibleTextUtils::isNonVisibleElement), so the number means the same thing in both
+    // layouts -- that shared meaning is the whole point: it is what lets a reading position
+    // survive a vertical/horizontal switch. See VerticalPage::visibleTextOffset.
+    uint32_t visibleTextOffset = 0;
   };
 
   // continuesPreviousParagraph: pass true when this call carries the NEXT CHUNK of a paragraph
@@ -327,6 +338,10 @@ class VerticalParsedText {
     uint8_t style;
     bool emphasis;
     std::string rubyText;
+    // See RubyRun::visibleTextOffset. Carried per character so the page that a character
+    // opens can be stamped with it; NOT carried on VerticalGlyph, which is deliberately a
+    // fixed-size POD (4 bytes x ~500 glyphs/page is a page buffer this device cannot spare).
+    uint32_t visibleTextOffset = 0;
   };
 
   // Flattened, paragraph-tagged codepoint stream built up by addParagraph()
@@ -393,6 +408,10 @@ class VerticalParsedText {
   // vector alone isn't enough once pages can be streamed out mid-call and earlier batches may
   // already have produced real pages.
   bool anyPageEverProduced_ = false;
+  // Source position of the character being placed. finalizePageIfNeeded() seeds a page opened
+  // mid-character from it, which the empty-page stamp cannot reach. See
+  // VerticalPage::visibleTextOffset.
+  uint32_t lastCharOffset_ = 0;
 
   // Call before every stream_.push_back(). Only checks free heap when the vector is actually
   // about to reallocate (size == capacity) -- cheap in the common case where capacity headroom

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -68,7 +68,13 @@ namespace {
 // rule, and a bordered block is separated from both neighbours by a blank column -- so
 // pagination inside and around a box changes too. (127-130 were consumed by intermediate box
 // geometries during development; caches carrying those numbers must not be trusted.)
-constexpr uint8_t VSECTION_FILE_VERSION = 131;
+// v134: every page record begins with the source position of its first character
+// (VerticalPage::visibleTextOffset), counted the same way the horizontal parser counts it. It is
+// what lets a vertical/horizontal switch resolve the reading position by content instead of by
+// proportion. Format change: a v131 record starts with the image flag. (132-133 were consumed
+// during development by builds that computed those positions wrongly; such records parse cleanly,
+// so caches carrying those numbers must not be trusted.)
+constexpr uint8_t VSECTION_FILE_VERSION = 134;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -89,7 +95,10 @@ struct ParagraphSink {
   // runs seamlessly continue the previously delivered paragraph (streaming cadence) -- no
   // paragraph break must be recorded before them.
   virtual void onParagraph(std::vector<RubyRun>& runs, bool continuesPrevious) = 0;
-  virtual void onImage(const std::string& src) = 0;
+  // visibleTextOffset: the source position the image occupies, so its page can be stamped
+  // like a text page and the page-start sequence stays non-decreasing for the binary search
+  // in getPageForVisibleTextOffset(). An image contributes no visible characters of its own.
+  virtual void onImage(const std::string& src, uint32_t visibleTextOffset) = 0;
   // Styled-block boundaries -- a block element whose CSS carries vertical layout parameters
   // (border box, start offset, hanging indent, centering, before/after gaps).
   virtual void onBlockStyleStart(const VerticalBlockParams& /*params*/) {}
@@ -125,6 +134,32 @@ struct TextExtractor {
   bool inRp = false;
   std::string rubyBase;
   std::string rubyAnnotation;
+
+  // Position tracking, so a reading position survives a vertical/horizontal switch.
+  //
+  // visibleTextOffset counts codepoints of visible character data in document order, under the
+  // SAME rule the horizontal parser applies (ChapterHtmlSlimParser::characterData): inside
+  // <body>, outside head/style/script/title/rp, entity expansions excluded. Both layouts must
+  // agree character for character -- the number is only useful because it means the same thing
+  // on both sides -- so any change here needs the horizontal counter changed with it.
+  //
+  // <rt> text IS counted (rp is the excluded one), matching isNonVisibleElement().
+  uint32_t visibleTextOffset = 0;
+  bool insideBody = false;
+  // Offset of the first character of currentText / rubyBase, captured when each goes from
+  // empty to non-empty. That is what a RubyRun is stamped with.
+  uint32_t currentTextOffset = 0;
+  uint32_t rubyBaseOffset = 0;
+
+  // Stamp where a run begins. Synthetic text (entity expansion, <br/>, a gaiji replacement)
+  // occupies no counted source position -- the horizontal parser does not count it either --
+  // so a run it opens is attributed to the position the next real character will take.
+  void beginTextRunIfEmpty() {
+    if (currentText.empty()) currentTextOffset = visibleTextOffset;
+  }
+  void beginRubyBaseIfEmpty() {
+    if (rubyBase.empty()) rubyBaseOffset = visibleTextOffset;
+  }
 
   // Furigana-glossary harvest (owned by the layout sink; see RubyGlossary). Mono-ruby
   // elements (小<rt>こ</rt>林<rt>ばやし</rt>) additionally record the whole-element pair
@@ -196,7 +231,7 @@ struct TextExtractor {
       // (alloc-copy-free per step, hundreds of times per chapter) -- the main planter of the
       // persistent fragments that shredded maxAlloc on long single-file books. The copy is a
       // transient that coalesces back; currentText's capacity now lives for the whole build.
-      currentRuns.push_back(RubyRun{currentText, {}, currentStyle(), hasEmphasis()});
+      currentRuns.push_back(RubyRun{currentText, {}, currentStyle(), hasEmphasis(), currentTextOffset});
       currentText.clear();
     }
   }
@@ -336,6 +371,7 @@ struct TextExtractor {
       self->skipDepth++;
       return;
     }
+    if (strcasecmp(name, "body") == 0) self->insideBody = true;
     if (isSkipTag(name)) {
       self->skipDepth = 1;
       return;
@@ -411,6 +447,7 @@ struct TextExtractor {
         // Routing it through onImage would split the paragraph and insert a
         // near-empty full image page per gaiji; keep the text flowing with
         // replacement text instead (alt / filename codepoint / geta mark).
+        self->beginTextRunIfEmpty();
         self->currentText += gaijiReplacementText(src ? src : "", alt ? alt : "");
       } else if (src && src[0] != '\0') {
         // Complete the paragraph built so far, then emit the image in document order. (For the
@@ -418,11 +455,12 @@ struct TextExtractor {
         // accumulate-then-interleave code placed the image before the whole paragraph; identical
         // for the usual block-level images.)
         self->flushParagraph();
-        if (self->sink) self->sink->onImage(std::string(src));
+        if (self->sink) self->sink->onImage(std::string(src), self->visibleTextOffset);
       }
     }
     if (strcasecmp(name, "br") == 0 || strcasecmp(name, "br/") == 0) {
       if (!self->inRuby) {
+        self->beginTextRunIfEmpty();
         self->currentText.push_back('\n');
       }
     }
@@ -458,7 +496,7 @@ struct TextExtractor {
           self->rubyElemRunCount++;
         }
         self->currentRuns.push_back(RubyRun{std::move(self->rubyBase), std::move(self->rubyAnnotation),
-                                            self->currentStyle(), self->hasEmphasis()});
+                                            self->currentStyle(), self->hasEmphasis(), self->rubyBaseOffset});
         self->rubyBase.clear();
         self->rubyBase.reserve(RUBY_RESERVE_HINT);
       }
@@ -469,7 +507,8 @@ struct TextExtractor {
     if (strcasecmp(name, "ruby") == 0) {
       // Flush any remaining base text that had no <rt> (malformed markup).
       if (!self->rubyBase.empty()) {
-        self->currentRuns.push_back(RubyRun{std::move(self->rubyBase), {}, self->currentStyle(), self->hasEmphasis()});
+        self->currentRuns.push_back(
+            RubyRun{std::move(self->rubyBase), {}, self->currentStyle(), self->hasEmphasis(), self->rubyBaseOffset});
         self->rubyBase.clear();
         self->rubyBase.reserve(RUBY_RESERVE_HINT);
       }
@@ -514,11 +553,27 @@ struct TextExtractor {
   static void XMLCALL characterData(void* userData, const char* s, int len) {
     auto* self = static_cast<TextExtractor*>(userData);
     self->checkHeap("characterData");
+    // Position bookkeeping first, and independent of every layout-side early return below:
+    // the count must track the DOCUMENT, not what this layout chooses to render. Dropped
+    // inter-tag whitespace and text past a forced split still occupy source positions, and
+    // the horizontal parser counts them.
+    const uint32_t offsetOfThisRun = self->visibleTextOffset;
+    if (self->insideBody && self->skipDepth < 0 && !self->inRp) {
+      const auto* p = reinterpret_cast<const unsigned char*>(s);
+      const auto* end = p + len;
+      while (p < end) {
+        // Advance one UTF-8 sequence: a lead byte plus its continuation bytes.
+        p++;
+        while (p < end && (*p & 0xC0) == 0x80) p++;
+        self->visibleTextOffset++;
+      }
+    }
     if (self->skipDepth >= 0) return;
     if (self->inRp) return;
     if (self->inRt) {
       self->rubyAnnotation.append(s, static_cast<size_t>(len));
     } else if (self->inRuby) {
+      if (self->rubyBase.empty()) self->rubyBaseOffset = offsetOfThisRun;
       self->rubyBase.append(s, static_cast<size_t>(len));
     } else {
       // Forced split for markup-less mega-paragraphs; see MAX_PARAGRAPH_BYTES. (Not applied
@@ -541,6 +596,9 @@ struct TextExtractor {
         if (firstInk == len) return;
         s += firstInk;
         len -= firstInk;
+        // The dropped whitespace was counted above, so the surviving text starts that many
+        // codepoints later. All of it is ASCII, so bytes and codepoints agree here.
+        self->currentTextOffset = offsetOfThisRun + static_cast<uint32_t>(firstInk);
       }
       self->currentText.append(s, static_cast<size_t>(len));
       // Streaming cadence: hand the buffered text onward as a seamless continuation well
@@ -580,8 +638,10 @@ struct TextExtractor {
       if (self->inRt) {
         self->rubyAnnotation.append(resolved);
       } else if (self->inRuby) {
+        self->beginRubyBaseIfEmpty();
         self->rubyBase.append(resolved);
       } else {
+        self->beginTextRunIfEmpty();
         self->currentText.append(resolved);
       }
     }
@@ -651,6 +711,10 @@ void visitBoxFields(Ar& ar, R& r) {
 // (whole page into RAM, flushed with one file.write) -- identical byte layout.
 template <typename Sink>
 bool writePage(Sink& file, const VerticalPage& page) {
+  // First field, before the image/text split, so every page record carries it. Lets the reader
+  // learn the current page's source position from the page it already loaded, with no extra
+  // seek per turn (the reverse direction uses the index table -- see readPageStartOffsets).
+  serialization::writePod(file, page.visibleTextOffset);
   const bool isImg = page.isImagePage();
   serialization::writePod(file, isImg);
   if (isImg) {
@@ -697,6 +761,7 @@ bool writePage(Sink& file, const VerticalPage& page) {
 enum class ReadResult { Ok, HeapRefused, Corrupt };
 
 ReadResult readPage(HalFile& file, VerticalPage& page) {
+  serialization::readPod(file, page.visibleTextOffset);
   page.glyphs.clear();
   page.boxes.clear();
   page.texts.clear();
@@ -961,6 +1026,10 @@ struct LayoutPageSink final : ParagraphSink {
       if (run.rubyText.empty() && utf8Chars(run.baseText) > RUN_SLICE_CHARS) {
         const std::string base = std::move(run.baseText);
         size_t pos = 0;
+        // Codepoints of this run already emitted as earlier slices. addAnnotatedParagraph()
+        // counts positions from the start of the run it is handed, so each slice must carry its
+        // own start or they all claim the original run's.
+        uint32_t cpConsumed = 0;
         while (pos < base.size() && !failed) {
           size_t end = pos;
           size_t chars = 0;
@@ -975,6 +1044,8 @@ struct LayoutPageSink final : ParagraphSink {
           slice.baseText = base.substr(pos, end - pos);
           slice.style = run.style;
           slice.emphasis = run.emphasis;
+          slice.visibleTextOffset = run.visibleTextOffset + cpConsumed;
+          cpConsumed += static_cast<uint32_t>(chars);
           pushRun(std::move(slice));
           pos = end;
         }
@@ -990,7 +1061,7 @@ struct LayoutPageSink final : ParagraphSink {
     if (layout.pendingCount() >= BATCH_CHARS) flushText();
   }
 
-  void onImage(const std::string& src) override {
+  void onImage(const std::string& src, const uint32_t visibleTextOffset) override {
     if (failed) return;
     // Lay out any buffered text, then FINALIZE the in-progress page before the image page is
     // written. Without this, the image page was written while the half-filled text page stayed
@@ -1000,7 +1071,9 @@ struct LayoutPageSink final : ParagraphSink {
     flushText();
     VerticalPage pendingTail;
     if (layout.finalizePendingPage(pendingTail)) writeOne(pendingTail);
-    writeOne(makeImagePage(src));
+    VerticalPage imagePage = makeImagePage(src);
+    imagePage.visibleTextOffset = visibleTextOffset;
+    writeOne(imagePage);
   }
 
   static void writePageCallback(void* ctx, VerticalPage&& page) { static_cast<LayoutPageSink*>(ctx)->writeOne(page); }
@@ -1541,7 +1614,12 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   }
   file.close();
 
-  LOG_DBG("VSC", "Cached %u vertical pages (streamed)", pageCount);
+  // Last page's source position. The horizontal build logs the same number ("SCT: chapter
+  // spans"), and the two counters are supposed to agree character for character -- if these
+  // diverge by more than roughly one page's worth of text, the two parsers have drifted and
+  // cross-mode position restore is silently landing on the wrong page.
+  const auto lastStart = getVisibleTextOffsetForPage(static_cast<int>(pageCount) - 1);
+  LOG_DBG("VSC", "Cached %u vertical pages (streamed); chapter spans %u chars", pageCount, lastStart.value_or(0));
   return true;
 }
 
@@ -1632,6 +1710,52 @@ bool VerticalSection::clearCache() const {
   }
   LOG_DBG("VSC", "Cache cleared");
   return true;
+}
+
+std::optional<uint32_t> VerticalSection::getVisibleTextOffsetForPage(const int page) const {
+  if (page < 0 || page >= static_cast<int>(pageOffsets_.size())) return std::nullopt;
+  // Already resident: the loaded page carries the value, no SD access at all. This is the
+  // common case (the reader asks about the page it is showing, on every progress save).
+  if (loadedPageIndex_ == page) return loadedPage_.visibleTextOffset;
+  HalFile file;
+  if (!Storage.openFileForRead("VSC", filePath, file)) return std::nullopt;
+  if (!file.seek(pageOffsets_[static_cast<size_t>(page)])) return std::nullopt;
+  uint32_t offset = 0;
+  if (file.read(reinterpret_cast<uint8_t*>(&offset), sizeof(offset)) != static_cast<int>(sizeof(offset))) {
+    return std::nullopt;
+  }
+  return offset;
+}
+
+std::optional<int> VerticalSection::getPageForVisibleTextOffset(const uint32_t offset) const {
+  if (pageOffsets_.empty()) return std::nullopt;
+  HalFile file;
+  if (!Storage.openFileForRead("VSC", filePath, file)) return std::nullopt;
+  // Reads the first field of one page record. Returns nullopt on a bad read so a truncated
+  // file degrades to "cannot resolve" (the caller falls back) rather than to a wrong page.
+  auto pageStart = [&](const int page) -> std::optional<uint32_t> {
+    if (!file.seek(pageOffsets_[static_cast<size_t>(page)])) return std::nullopt;
+    uint32_t v = 0;
+    if (file.read(reinterpret_cast<uint8_t*>(&v), sizeof(v)) != static_cast<int>(sizeof(v))) return std::nullopt;
+    return v;
+  };
+  // Page starts are non-decreasing (pages are laid out in document order), so a plain binary
+  // search finds the last page starting at or before `offset`.
+  int lo = 0;
+  int hi = static_cast<int>(pageOffsets_.size()) - 1;
+  int best = 0;
+  while (lo <= hi) {
+    const int mid = lo + (hi - lo) / 2;
+    const auto start = pageStart(mid);
+    if (!start) return std::nullopt;
+    if (*start <= offset) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
 }
 
 const VerticalPage* VerticalSection::getPage() const { return getPage(currentPage); }

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -475,6 +475,10 @@ struct TextExtractor {
       if (self->skipDepth == 0) self->skipDepth = -1;
       return;
     }
+    // Mirrors the set in startElement, and ChapterHtmlSlimParser's own reset. Anything after
+    // </body> occupies no visible position, and the two counters only mean the same thing while
+    // they agree on where the body ends.
+    if (strcasecmp(name, "body") == 0) self->insideBody = false;
     if (self->boxOpenedAtDepth >= 0 && self->elementDepth == self->boxOpenedAtDepth - 1) {
       self->flushParagraph();
       if (self->sink) self->sink->onBlockStyleEnd();

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -107,6 +108,21 @@ class VerticalSection {
   bool createSectionFile(int fontId, uint16_t viewportWidth, uint16_t viewportHeight, uint8_t lineSpacing,
                          bool furiganaEnabled);
   bool clearCache() const;
+
+  // Position of a page's first character within the chapter's visible character data, in the
+  // same units Section::getVisibleTextOffsetForPage() reports -- which is what makes a reading
+  // position portable between the two layouts. See VerticalPage::visibleTextOffset.
+  //
+  // Read straight from the page record on SD (its first field). No table is held in RAM and
+  // none is written: the reverse lookup binary-searches the page records through the offset
+  // table that loadSectionFile already keeps, which costs ~9 four-byte reads on a 500-page
+  // chapter and, unlike a second index, nothing at all during the build -- where this layout
+  // is already fighting for every contiguous KB.
+  std::optional<uint32_t> getVisibleTextOffsetForPage(int page) const;
+
+  // The page holding `offset`: the last page whose own offset is <= it. nullopt if the chapter
+  // has no pages or the records cannot be read.
+  std::optional<int> getPageForVisibleTextOffset(uint32_t offset) const;
   const VerticalPage* getPage() const;
   const VerticalPage* getPage(int pageIndex) const;
   // True when the most recent getPage() returned nullptr only because the page's glyph vector

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3261,6 +3261,18 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
     }
   }
 
+  // Nothing real to build a model from. A mode switch drops every cached count AND the live
+  // section, and no cache probe for the new mode can succeed until its first chapter is built,
+  // so for that window every spine would fall back to the one-page placeholder below. That is
+  // what produced "~228/228 7600%": book progress is (pages before + page) / total, and total
+  // was 3 for a 3-spine book. Leave the model empty instead, so callers fall back to byte
+  // weighting and per-section numbering until real counts arrive.
+  if (knownPages == 0) {
+    LOG_DBG("ERS", "No real page counts yet (spine %d, %s), using byte-weighted progress", currentSpineIndex,
+            vertical ? "vertical" : "horizontal");
+    return;
+  }
+
   // Effective counts: real where known, byte-share estimate (against the known chapters'
   // pages-per-byte ratio) where not.
   spinePagesEffective.assign(spineCount, 1);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2334,6 +2334,19 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
   // For an in-progress incremental build, make sure the page we're about to show has been laid out.
   if (section->isBuilding()) {
+    // Same reasoning as the partial extension above: a catch-up of a page or two is quick and
+    // stays silent, but a long one is a multi-second freeze on a blank screen and needs to say
+    // what it is doing. Toggling a book between vertical and horizontal is exactly that case:
+    // the two modes use different viewport heights, so the cache fails its parameter check and
+    // the rebuild starts at page 0 while the reader is deep in the chapter. That path showed no
+    // indexing popup at all.
+    constexpr int kSilentCatchUpPages = 4;
+    if (section->currentPage - static_cast<int>(section->pageCount) > kSilentCatchUpPages) {
+      GUI.drawPopup(renderer, tr(STR_INDEXING));
+      // The popup refreshes FAST, so force the page replacing it onto the HALF ghost-cleanup
+      // path or "INDEXING" ghosts under the text.
+      pagesUntilFullRefresh = 1;
+    }
     while (!section->isBuildComplete() && section->currentPage >= static_cast<int>(section->pageCount)) {
       if (!section->buildSomeMore(BUILD_PAGES_PER_CHUNK)) {
         LOG_ERR("ERS", "Failed during incremental section build");

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2477,16 +2477,12 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
     pageLoadRetryCount = 0;  // Reset the retry counter once a page loads cleanly
 
-    // TEMPORARY (blank-page investigation): a page that loads without error but draws nothing
-    // is indistinguishable from a render fault on screen. Say which it is.
+    // A page that loads without error but draws nothing is indistinguishable from a render
+    // fault on screen, so name it. Only the fault is logged -- this runs on every page turn.
     if (p->elements.empty()) {
-      LOG_ERR("ERS", "BLANK: page %d of %u loaded with 0 elements (building=%d partial=%d complete=%d offset=%u)",
-              section->currentPage, static_cast<unsigned>(section->pageCount), section->isBuilding() ? 1 : 0,
-              section->isPartial() ? 1 : 0, section->isBuildComplete() ? 1 : 0, p->visibleTextOffset);
-    } else {
-      LOG_DBG("ERS", "page %d of %u: %u elements (building=%d partial=%d)", section->currentPage,
-              static_cast<unsigned>(section->pageCount), static_cast<unsigned>(p->elements.size()),
-              section->isBuilding() ? 1 : 0, section->isPartial() ? 1 : 0);
+      LOG_ERR("ERS", "Page %d of %u loaded with 0 elements (building=%d partial=%d complete=%d)", section->currentPage,
+              static_cast<unsigned>(section->pageCount), section->isBuilding() ? 1 : 0, section->isPartial() ? 1 : 0,
+              section->isBuildComplete() ? 1 : 0);
     }
 
     // Cache this page's content offset (read alongside the page, no extra file open) so

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -971,8 +971,9 @@ void EpubReaderActivity::jumpToPercent(int percent) {
 }
 
 void EpubReaderActivity::openReaderMenu() {
-  const int sectionPage = verticalSection ? verticalSection->currentPage + 1 : section ? section->currentPage + 1 : 0;
-  const int sectionPageCount = verticalSection ? verticalSection->pageCount : section ? section->pageCount : 0;
+  const auto span = sectionPageSpan();
+  const int sectionPage = span.page;
+  const int sectionPageCount = span.count;
   // The menu header shows the same ToC-chapter-wide numbering and page-based book
   // progress as the status bar.
   updateChapterPageSpan(lastViewportWidth, lastViewportHeight);
@@ -3300,6 +3301,22 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   chapterPagesTotal = std::max(1, total);
 }
 
+EpubReaderActivity::SectionPageSpan EpubReaderActivity::sectionPageSpan() const {
+  const int rawPage = verticalSection ? verticalSection->currentPage : section ? section->currentPage : 0;
+  // estimatedTotalPages() rather than pageCount: while a giant spine builds, pageCount is only
+  // the watermark reached so far, so "page X of Y" would count against a total that keeps moving.
+  const int rawCount = verticalSection ? verticalSection->pageCount : section ? section->estimatedTotalPages() : 0;
+  if (rawCount <= 0) return {1, 1};  // empty chapter: one skippable page beats 65536/0
+
+  // Loud rather than silently clamped. An out-of-range page here is a real bug somewhere in the
+  // positioning path, and the clamp below is what hides it from the screen.
+  if (rawPage < 0 || rawPage >= rawCount) {
+    LOG_ERR("ERS", "section page out of range: %d of %d (spine %d, %s)", rawPage, rawCount, currentSpineIndex,
+            verticalSection ? "vertical" : "horizontal");
+  }
+  return {std::clamp(rawPage + 1, 1, rawCount), rawCount};
+}
+
 int EpubReaderActivity::pageBasedPercent(const int spineIndex, const int sectionPage) const {
   if (bookPagesTotal <= 0 || spinePagesEffective.empty()) {
     // Model unavailable (e.g. no section loaded yet) -- fall back to byte weighting.
@@ -3412,15 +3429,10 @@ void EpubReaderActivity::earlyRenderVerticalPage(const VerticalPage& page, const
 
 void EpubReaderActivity::renderStatusBar() const {
   // Calculate progress in book
-  const int rawCurrentPage = verticalSection ? verticalSection->currentPage : section ? section->currentPage : 0;
-  // The estimated total while a giant spine is still building, so "page X of Y" and the
-  // progress bar don't read off the small build watermark.
-  const int rawPageCount = verticalSection ? verticalSection->pageCount : section ? section->estimatedTotalPages() : 0;
-
-  // Keep status bar sane on empty chapters: show a single skippable page (1/1)
-  // instead of sentinel/underflow values like 65536/0.
-  const int sectionPage = (rawPageCount > 0) ? std::clamp(rawCurrentPage + 1, 1, rawPageCount) : 1;
-  const int sectionPageCount = (rawPageCount > 0) ? rawPageCount : 1;
+  const auto span = sectionPageSpan();
+  const int rawPageCount = span.count;
+  const int sectionPage = span.page;
+  const int sectionPageCount = span.count;
 
   // Display page numbering spans the ToC chapter, not just this spine file; book progress is
   // page-based (pages read / total pages) with byte weighting only as a bootstrap fallback.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1051,6 +1051,28 @@ void EpubReaderActivity::applyVerticalFuriganaOverride(const int8_t verticalOver
       // still be inside its (multi-second, section-touching) warm tail when this result
       // lands, and freeing the section under it is a use-after-free.
       RenderLock lock(*this);
+      // Carry the reading position across the mode change. The two modes paginate the same
+      // chapter differently, so the page NUMBER means nothing on the other side; what survives
+      // is the fraction through the chapter. Recording page + count here is what lets the
+      // rebuild remap proportionally (vertical: the cachedChapterTotalPageCount block in
+      // render(); horizontal: applyDeferredReposition()). Without it the rebuild started from
+      // whatever nextPageNumber happened to hold and the position jumped.
+      if (verticalSection) {
+        cachedSpineIndex = currentSpineIndex;
+        nextPageNumber = verticalSection->currentPage;
+        cachedChapterTotalPageCount = verticalSection->pageCount;
+      } else if (section) {
+        cachedSpineIndex = currentSpineIndex;
+        nextPageNumber = section->currentPage;
+        // estimatedTotalPages(), not pageCount: mid-build pageCount is only the watermark of
+        // what has been laid out, which is barely ahead of currentPage -- the fraction would
+        // come out near 1.0 and drop the reader at the end of the chapter.
+        cachedChapterTotalPageCount = section->estimatedTotalPages();
+      }
+      // A content offset only resolves against a horizontal Section, and it was captured under
+      // the outgoing layout. Leaving it set would win over the remap above and, going back to
+      // horizontal, silently re-anchor to a stale position.
+      cachedVisibleTextOffset.reset();
       section.reset();
       verticalSection.reset();
     }
@@ -1781,25 +1803,28 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         }
         pendingPageJump.reset();
       } else {
+        // Left UNCLAMPED on purpose: nextPageNumber is numbered in whatever pagination saved it
+        // (a horizontal layout, or this one before a settings change), and vertical pagination is
+        // typically much shorter. Clamping first would collapse "page 204 of 213" onto the last
+        // vertical page and the remap below would then read that as ~96% of the OLD count -- the
+        // position drifted backwards on every switch. Clamp once, after the remap.
         verticalSection->currentPage = nextPageNumber;
-        if (verticalSection->pageCount == 0) {
-          verticalSection->currentPage = 0;
-        } else if (verticalSection->currentPage < 0) {
-          verticalSection->currentPage = 0;
-        } else if (verticalSection->currentPage >= verticalSection->pageCount) {
-          verticalSection->currentPage = verticalSection->pageCount - 1;
-        }
       }
       pendingAnchor.clear();
 
       if (cachedChapterTotalPageCount > 0) {
         if (currentSpineIndex == cachedSpineIndex && verticalSection->pageCount != cachedChapterTotalPageCount) {
-          float progress =
+          const float progress =
               static_cast<float>(verticalSection->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
-          int newPage = static_cast<int>(progress * verticalSection->pageCount);
-          verticalSection->currentPage = newPage;
+          verticalSection->currentPage = static_cast<int>(progress * verticalSection->pageCount);
         }
         cachedChapterTotalPageCount = 0;
+      }
+
+      if (verticalSection->pageCount == 0 || verticalSection->currentPage < 0) {
+        verticalSection->currentPage = 0;
+      } else if (verticalSection->currentPage >= verticalSection->pageCount) {
+        verticalSection->currentPage = verticalSection->pageCount - 1;
       }
 
       if (pendingPercentJump && verticalSection->pageCount > 0) {
@@ -3359,7 +3384,16 @@ EpubReaderActivity::SectionPageSpan EpubReaderActivity::sectionPageSpan() const 
   // estimatedTotalPages() rather than pageCount: while a giant spine builds, pageCount is only
   // the watermark reached so far, so "page X of Y" would count against a total that keeps moving.
   const int rawCount = verticalSection ? verticalSection->pageCount : section ? section->estimatedTotalPages() : 0;
-  if (rawCount <= 0) return {1, 1};  // empty chapter: one skippable page beats 65536/0
+  if (rawCount <= 0) {
+    // No pages laid out yet -- a chapter mid-rebuild, typically right after a vertical/horizontal
+    // switch. Publishing {1, 1} here is what made the status bar read "1/1 0%" for a reader who
+    // was 95% through the chapter a moment earlier. Hold the position being carried into the
+    // rebuild instead; the real span replaces it as soon as the section has pages.
+    if (cachedChapterTotalPageCount > 0 && currentSpineIndex == cachedSpineIndex) {
+      return {std::clamp(nextPageNumber + 1, 1, cachedChapterTotalPageCount), cachedChapterTotalPageCount};
+    }
+    return {1, 1};  // empty chapter: one skippable page beats 65536/0
+  }
 
   // Loud rather than silently clamped. An out-of-range page here is a real bug somewhere in the
   // positioning path, and the clamp below is what hides it from the screen.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -589,9 +589,15 @@ void EpubReaderActivity::loop() {
   // partial's watermark until the build catches up, so the window check would wrongly read
   // "far enough ahead" and stall the build at 0 pages -- then the first turn past the
   // watermark re-parses the whole chapter synchronously. Keep ticking until it finalizes.
-  if (section && section->isBuilding() && !RenderLock::peek() &&
-      (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD) &&
-      buildTickHeapGate()) {
+  //
+  // No window condition any more. Stopping once the build was BUILD_WINDOW_AHEAD pages past the
+  // reader left isBuilding() true for the rest of the session, so the chapter never finalized:
+  // the total stayed an estimate and the status bar kept its "~" forever. Vertical has always
+  // built the whole chapter and shown an exact count, so horizontal was the odd one out.
+  // Finishing the chapter is what partials already did ("Keep ticking until it finalizes"), and
+  // it stays cheap: two pages per loop tick, only when the render lock is free and the heap gate
+  // is open.
+  if (section && section->isBuilding() && !RenderLock::peek() && buildTickHeapGate()) {
     RenderLock lock;
     // Re-check under the lock: render() (which also holds the RenderLock) may have finalized the
     // build between the outer isBuilding() check and acquiring the lock here, in which case
@@ -2425,6 +2431,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
     pageLoadRetryCount = 0;  // Reset the retry counter once a page loads cleanly
 
+    // TEMPORARY (blank-page investigation): a page that loads without error but draws nothing
+    // is indistinguishable from a render fault on screen. Say which it is.
+    if (p->elements.empty()) {
+      LOG_ERR("ERS", "BLANK: page %d of %u loaded with 0 elements (building=%d partial=%d complete=%d offset=%u)",
+              section->currentPage, static_cast<unsigned>(section->pageCount), section->isBuilding() ? 1 : 0,
+              section->isPartial() ? 1 : 0, section->isBuildComplete() ? 1 : 0, p->visibleTextOffset);
+    } else {
+      LOG_DBG("ERS", "page %d of %u: %u elements (building=%d partial=%d)", section->currentPage,
+              static_cast<unsigned>(section->pageCount), static_cast<unsigned>(p->elements.size()),
+              section->isBuilding() ? 1 : 0, section->isPartial() ? 1 : 0);
+    }
+
     // Cache this page's content offset (read alongside the page, no extra file open) so
     // saveProgress and addBookmark can use it without reopening section.bin.
     currentPageVisibleOffset = p->visibleTextOffset;
@@ -3212,19 +3230,27 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   // building, every one of those opens queues behind the build's own SD traffic on the shared
   // storage mutex, so anything that calls this -- opening the reader menu, drawing the status
   // bar -- stalls for as long as the build holds the card (reported on device: buttons feel
-  // unresponsive during indexing). Keep the previous numbers until the build is done; they are
-  // recomputed on the next call, and page counts are transient during a build anyway.
-  if (verticalBuildInProgress_.load(std::memory_order_relaxed) || (section && section->isBuilding())) return;
+  // unresponsive during indexing).
+  //
+  // Only the probes are expensive, so only they are skipped. Bailing out of the whole function
+  // used to leave the numbers at the per-section fallback for as long as the build ran, which
+  // after a mode switch is the entire rebuild: the status bar showed "203/203" where the other
+  // mode showed "228/258". The live chapter's own count costs nothing, and the byte-share
+  // estimate for the rest is arithmetic, so the chapter-wide numbers are available immediately.
+  const bool buildActive =
+      verticalBuildInProgress_.load(std::memory_order_relaxed) || (section && section->isBuilding());
 
   const int livePages = verticalSection ? verticalSection->pageCount : (section ? section->pageCount : 0);
   const bool vertical = useVerticalText();
-  if (chapterSpanSpine == currentSpineIndex && chapterSpanLivePages == livePages && chapterSpanVertical == vertical) {
+  if (chapterSpanSpine == currentSpineIndex && chapterSpanLivePages == livePages && chapterSpanVertical == vertical &&
+      chapterSpanBuildActive == buildActive) {
     return;
   }
   const bool spanModeChanged = chapterSpanVertical != vertical;
   chapterSpanSpine = currentSpineIndex;
   chapterSpanLivePages = livePages;
   chapterSpanVertical = vertical;
+  chapterSpanBuildActive = buildActive;
   chapterPagesBefore = 0;
   chapterPagesTotal = std::max(1, livePages);
   bookPagesBefore = 0;
@@ -3247,10 +3273,12 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   for (int i = 0; i < spineCount; i++) {
     if (i == currentSpineIndex && livePages > 0) {
       spinePagesReal[i] = static_cast<uint16_t>(std::min(livePages, 0xFFFF));
-    } else if (spinePagesReal[i] == 0) {
+    } else if (spinePagesReal[i] == 0 && !buildActive) {
       // A failed probe is remembered for the session (kSpineProbeFailed): without this, every
       // menu open / status-bar refresh after a cache-version bump re-opened (and re-discarded)
       // all N stale section files -- a visible seconds-long delay on a 39-spine book.
+      // Skipped entirely while a build holds the card; those spines fall to the byte estimate
+      // and are probed for real once the build finishes.
       bool probed = false;
       if (vertical) {
         VerticalSection sibling(epub, i, renderer);
@@ -3469,7 +3497,13 @@ void EpubReaderActivity::renderStatusBar() const {
   if (bookPagesTotal > 0) {
     bookProgress = 100.0f * static_cast<float>(bookPagesBefore + sectionPage) / static_cast<float>(bookPagesTotal);
   } else {
-    const float sectionChapterProg = (rawPageCount > 0) ? (static_cast<float>(sectionPage) / sectionPageCount) : 0.0f;
+    // sectionPage is 1-based, so the fraction is of the pages BEHIND you: page 1 of 10 is 0.0
+    // through the chapter, not 0.1. Using it raw also read 100% through the chapter in the one
+    // case this branch exists for, a chapter with no pages laid out yet, where the span falls
+    // back to {1, 1}. Switching a book to vertical then reported 99% of the book, since spine 1
+    // of 3 ends there. The reader menu has always computed it this way.
+    const float sectionChapterProg =
+        (rawPageCount > 0) ? (static_cast<float>(sectionPage - 1) / sectionPageCount) : 0.0f;
     bookProgress = epub->calculateProgress(currentSpineIndex, sectionChapterProg) * 100;
   }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1051,28 +1051,28 @@ void EpubReaderActivity::applyVerticalFuriganaOverride(const int8_t verticalOver
       // still be inside its (multi-second, section-touching) warm tail when this result
       // lands, and freeing the section under it is a use-after-free.
       RenderLock lock(*this);
-      // Carry the reading position across the mode change. The two modes paginate the same
-      // chapter differently, so the page NUMBER means nothing on the other side; what survives
-      // is the fraction through the chapter. Recording page + count here is what lets the
-      // rebuild remap proportionally (vertical: the cachedChapterTotalPageCount block in
-      // render(); horizontal: applyDeferredReposition()). Without it the rebuild started from
-      // whatever nextPageNumber happened to hold and the position jumped.
+      // Carry the reading position across the mode change; the rebuild on the other side has
+      // nothing else to resume from. A page NUMBER does not survive: the two modes paginate the
+      // same chapter differently. Two things that do are recorded here, in order of preference:
+      //   - the content offset, an exact anchor, since both layouts count source positions
+      //     identically (VerticalPage::visibleTextOffset);
+      //   - page + chapter total, whose ratio the rebuild remaps proportionally when no offset
+      //     can be read (vertical: the cachedChapterTotalPageCount block in render();
+      //     horizontal: applyDeferredReposition()).
+      cachedVisibleTextOffset.reset();
       if (verticalSection) {
         cachedSpineIndex = currentSpineIndex;
         nextPageNumber = verticalSection->currentPage;
         cachedChapterTotalPageCount = verticalSection->pageCount;
+        cachedVisibleTextOffset = verticalSection->getVisibleTextOffsetForPage(verticalSection->currentPage);
       } else if (section) {
         cachedSpineIndex = currentSpineIndex;
         nextPageNumber = section->currentPage;
-        // estimatedTotalPages(), not pageCount: mid-build pageCount is only the watermark of
-        // what has been laid out, which is barely ahead of currentPage -- the fraction would
-        // come out near 1.0 and drop the reader at the end of the chapter.
+        // estimatedTotalPages(), not pageCount: mid-build the watermark sits barely ahead of
+        // currentPage, so the ratio would be ~1.0 and land the reader at the chapter's end.
         cachedChapterTotalPageCount = section->estimatedTotalPages();
+        cachedVisibleTextOffset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(section->currentPage));
       }
-      // A content offset only resolves against a horizontal Section, and it was captured under
-      // the outgoing layout. Leaving it set would win over the remap above and, going back to
-      // horizontal, silently re-anchor to a stale position.
-      cachedVisibleTextOffset.reset();
       section.reset();
       verticalSection.reset();
     }
@@ -1631,6 +1631,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
                                useFurigana()};
     if ((section || verticalSection) && currentSig != sectionLayoutSig) {
       LOG_DBG("ERS", "Layout params changed; reflowing section in place");
+      // Anchor the position by content before the sections go: a reflow re-paginates, so the
+      // page number about to be recorded below is only the fallback. Vertical can answer this
+      // now too, so a font or spacing change no longer costs vertical readers their place.
+      rememberCurrentContentOffset();
       if (verticalSection) {
         cachedSpineIndex = currentSpineIndex;
         cachedChapterTotalPageCount = verticalSection->pageCount;
@@ -1793,6 +1797,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         LOG_DBG("ERS", "Vertical cache found");
       }
 
+      // An explicit jump (bookmark, chapter list, percent) is a deliberate navigation and must
+      // outrank the position being carried across a re-pagination. Recorded before the branch
+      // below consumes it.
+      const bool hadExplicitPageJump = pendingPageJump.has_value();
       if (pendingPageJump.has_value()) {
         if (verticalSection->pageCount == 0) {
           verticalSection->currentPage = 0;
@@ -1812,8 +1820,21 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       }
       pendingAnchor.clear();
 
+      // Content anchor first, page fraction only as the fallback. The offset names an exact
+      // character and is immune to re-pagination; the fraction is a guess that lands the reader
+      // up to a page away and drifts a little further on every switch.
+      bool resolvedByOffset = false;
+      if (currentSpineIndex == cachedSpineIndex && cachedVisibleTextOffset.has_value() && !hadExplicitPageJump &&
+          !pendingPercentJump) {
+        if (const auto page = verticalSection->getPageForVisibleTextOffset(*cachedVisibleTextOffset)) {
+          verticalSection->currentPage = *page;
+          resolvedByOffset = true;
+        }
+      }
+      cachedVisibleTextOffset.reset();
       if (cachedChapterTotalPageCount > 0) {
-        if (currentSpineIndex == cachedSpineIndex && verticalSection->pageCount != cachedChapterTotalPageCount) {
+        if (!resolvedByOffset && currentSpineIndex == cachedSpineIndex &&
+            verticalSection->pageCount != cachedChapterTotalPageCount) {
           const float progress =
               static_cast<float>(verticalSection->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
           verticalSection->currentPage = static_cast<int>(progress * verticalSection->pageCount);
@@ -2901,7 +2922,13 @@ bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
                                       int8_t furiOverride) {
   const uint8_t percent = static_cast<uint8_t>(pageBasedPercent(spineIndex, currentPage + 1));
   std::optional<uint32_t> offset;
-  if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
+  if (verticalSection && spineIndex == currentSpineIndex && currentPage >= 0 &&
+      currentPage < verticalSection->pageCount) {
+    // Vertical records the same content offset horizontal does, so progress saved while
+    // reading vertically resolves exactly when the book is next opened horizontally (and the
+    // other way round). Without this the two modes could only meet through page proportions.
+    offset = verticalSection->getVisibleTextOffsetForPage(currentPage);
+  } else if (section && spineIndex == currentSpineIndex && currentPage >= 0 && currentPage < section->pageCount) {
     // The on-screen page's offset was captured at load; reuse it to avoid a fresh section-file
     // open on every page turn. Any other page (rare) falls back to a direct lookup.
     offset = (currentPage == section->currentPage && currentPageVisibleOffset.has_value())
@@ -2914,7 +2941,10 @@ bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
 
 void EpubReaderActivity::rememberCurrentContentOffset() {
   cachedVisibleTextOffset.reset();
-  if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
+  if (verticalSection && verticalSection->currentPage >= 0 &&
+      verticalSection->currentPage < verticalSection->pageCount) {
+    cachedVisibleTextOffset = verticalSection->getVisibleTextOffsetForPage(verticalSection->currentPage);
+  } else if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
     cachedVisibleTextOffset = section->getVisibleTextOffsetForPage(static_cast<uint16_t>(section->currentPage));
   }
 }
@@ -3265,7 +3295,15 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   const bool buildActive =
       verticalBuildInProgress_.load(std::memory_order_relaxed) || (section && section->isBuilding());
 
+  // Memo key: the raw watermark, which advances as the build lays pages out.
   const int livePages = verticalSection ? verticalSection->pageCount : (section ? section->pageCount : 0);
+  // Model input: the chapter's estimated total, the same number sectionPageSpan() shows. The
+  // watermark makes a half-built chapter look only as long as the pages laid out so far, which
+  // shrinks the X/Y span and, through spinePagesReal, the whole-book percentage with it. Vertical
+  // builds in one pass, so its pageCount is already the total.
+  const int liveTotalPages = verticalSection ? verticalSection->pageCount
+                             : section       ? section->estimatedTotalPages()
+                                             : 0;
   const bool vertical = useVerticalText();
   if (chapterSpanSpine == currentSpineIndex && chapterSpanLivePages == livePages && chapterSpanVertical == vertical &&
       chapterSpanBuildActive == buildActive) {
@@ -3277,7 +3315,7 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   chapterSpanVertical = vertical;
   chapterSpanBuildActive = buildActive;
   chapterPagesBefore = 0;
-  chapterPagesTotal = std::max(1, livePages);
+  chapterPagesTotal = std::max(1, liveTotalPages);
   bookPagesBefore = 0;
   bookPagesTotal = 0;
   spinePagesEffective.clear();
@@ -3296,8 +3334,8 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
   size_t knownBytes = 0;
   uint32_t knownPages = 0;
   for (int i = 0; i < spineCount; i++) {
-    if (i == currentSpineIndex && livePages > 0) {
-      spinePagesReal[i] = static_cast<uint16_t>(std::min(livePages, 0xFFFF));
+    if (i == currentSpineIndex && liveTotalPages > 0) {
+      spinePagesReal[i] = static_cast<uint16_t>(std::min(liveTotalPages, 0xFFFF));
     } else if (spinePagesReal[i] == 0 && !buildActive) {
       // A failed probe is remembered for the session (kSpineProbeFailed): without this, every
       // menu open / status-bar refresh after a cache-version bump re-opened (and re-discarded)

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -409,6 +409,9 @@ class EpubReaderActivity final : public Activity {
   mutable int chapterSpanSpine = -1;
   mutable int chapterSpanLivePages = -1;
   mutable bool chapterSpanVertical = false;
+  // Part of the memo key: a span computed while a build held the card skipped the per-spine
+  // probes, so it must be recomputed once the build releases it, even if nothing else changed.
+  mutable bool chapterSpanBuildActive = false;
   mutable int chapterPagesBefore = 0;
   mutable int chapterPagesTotal = 0;
   mutable std::vector<uint16_t> spinePagesReal;       // 0 = not indexed yet
@@ -455,7 +458,15 @@ class EpubReaderActivity final : public Activity {
   // it from page 0. Reverts to normal power behavior the moment the build finishes,
   // and while the build is heap-paused (no work is happening, so spinning at full
   // speed would only burn battery; the paused gate still retries every loop pass).
-  bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
+  // Full CPU only while the build is still near or behind the reader, where the wait is in front
+  // of the user. Once it is BUILD_WINDOW_AHEAD pages clear it keeps going (the chapter has to
+  // finalize, or the page total stays an estimate forever) but at the ordinary loop cadence, so
+  // the CPU can drop back to power saving. Pinning it for the whole chapter would cost battery
+  // for work nobody is waiting on.
+  bool skipLoopDelay() override {
+    return section && section->isBuilding() && !buildHeapPaused &&
+           static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD;
+  }
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
     {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -396,6 +396,15 @@ class EpubReaderActivity final : public Activity {
   // byte model lags several percent behind the rendered-page position on Japanese books.
   // Real counts come from section-cache headers; unindexed chapters are estimated from their
   // byte share of the already-indexed ones and refine as sections get built.
+  // Page within the loaded section, 1-based, with that section's page count. Clamped, because a
+  // section whose currentPage is briefly out of range must not reach the UI: a mode switch drops
+  // both sections and render() repositions afterwards, and anything drawn in between was showing
+  // the raw value.
+  struct SectionPageSpan {
+    int page;
+    int count;
+  };
+  SectionPageSpan sectionPageSpan() const;
   int pageBasedPercent(int spineIndex, int sectionPage) const;  // sectionPage is 1-based
   mutable int chapterSpanSpine = -1;
   mutable int chapterSpanLivePages = -1;


### PR DESCRIPTION
Fixes #61.

Switching a book between vertical and horizontal re-paginates the chapter, so the page number the reader was on means nothing on the other side. The position was previously carried over as a fraction of the chapter, which lands up to a page away and drifts further on every switch — and in several cases was not carried at all.

## What changed

Vertical now records, per page, the source position of its first character, counted by the same rule the horizontal parser uses. A switch resolves the exact page holding the same sentence, in both directions, and progress saved in one mode restores correctly in the other. The page fraction remains as the fallback when no offset can be read.

Two bugs had to be fixed before those offsets were usable:

- Runs longer than `RUN_SLICE_CHARS` are sliced before layout, and each slice was built as a fresh `RubyRun` without the run's position, so every slice claimed the run's start. Pages then recorded an index *inside a slice* rather than a chapter offset.
- A page break decided while placing a character opens the next page with that character already on it, so the "stamp the page while it is still empty" rule never saw it and the page kept offset 0. Restoring onto such a page sent the reader to the top of the chapter.

Separately, the chapter page model took the live section's raw `pageCount`, which mid-build is only the pages laid out so far. A chapter a fifth built looked a fifth as long, showing `~42/51 82%` where the reader was 17% in. It now uses `estimatedTotalPages()`, the same number the status bar's numerator already used.

Cache version 134. Versions 132-133 parse cleanly but hold wrong offsets, so the bump is the only thing that retires them; vertical chapters rebuild once on first open.

## Verification

Measured on a 227-page vertical / 255-page horizontal chapter:

- page-offset audit went from **46 of 227 pages zero or regressing** to **0**, spanning 61,461 of 61,706 counted characters
- switching in both directions lands on the page carrying the same passage, confirmed by comparing rendered pages side by side
- percentage matches across the switch; page counts differ as expected, since vertical fits more text per page

Local gates: `clang-format` clean, `pio run` SUCCESS, `pio check --fail-on-defect low` no defects, `ctest -j8` 154/154 passed.

Not yet tested on hardware.

## AI Usage: YES
Claude Code, Opus 5