### PR TITLE
feat: tighten horizontal line spacing when furigana is off

### DIFF
--- a/lib/Epub/Epub/ReaderRenderSpec.h
+++ b/lib/Epub/Epub/ReaderRenderSpec.h
@@ -24,4 +24,14 @@ struct ReaderRenderSpec {
   // Matcha: honour the book's own horizontal CSS margins. Part of the spec because the
   // section cache keys on it -- a book laid out with and without them differs.
   bool honorBookInsets = false;
+  // Matcha: furigana is drawn above the ascender, so a ruby-carrying line reserves extra
+  // leading for it. With furigana off that room is empty, and the page reads looser than it
+  // needs to -- vertical already tightens for the same reason (see the two column-gap tables
+  // in VerticalSection::streamParseAndLayout). Part of the spec because the layout changes:
+  // toggling it has to rebuild the section, not just stop drawing the annotations.
+  //
+  // Per-book (the reader's furigana override), so callers set it like fontId rather than
+  // taking it from the store. Layout and drawing must agree on it: TextBlock::render shifts
+  // words down by exactly the reserve this adds.
+  bool furiganaEnabled = true;
 };

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -152,7 +152,10 @@ namespace {
 // v72: no format change -- CssPropertyFlags::anySet() omitted `border`, so every border-only
 //      rule was discarded before it was stored and no bordered block ever picked up its edges.
 //      Cached pages were laid out without those borders.
-constexpr uint8_t SECTION_FILE_VERSION = 72;
+// v73: the header records whether furigana is on, and a ruby-carrying line only reserves the
+//      leading its annotation needs when it is. With furigana off, pages now hold more lines,
+//      so the toggle re-lays the chapter out instead of only suppressing the annotations.
+constexpr uint8_t SECTION_FILE_VERSION = 73;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects
@@ -172,8 +175,8 @@ constexpr uint8_t SECTION_FILE_INCOMPLETE_VERSION = 0;
 constexpr uint8_t SECTION_FILE_PARTIAL_VERSION = 0xFE - (SECTION_FILE_VERSION - 28);
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
-                                 sizeof(uint8_t) + sizeof(bool) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +
-                                 sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
+                                 sizeof(uint8_t) + sizeof(bool) + sizeof(bool) + sizeof(bool) + sizeof(uint32_t) +
+                                 sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
 }  // namespace
 
 // Out-of-line so the unique_ptr<ChapterHtmlSlimParser> in BuildContext can be
@@ -221,8 +224,8 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
                                    sizeof(spec.viewportWidth) + sizeof(spec.viewportHeight) + sizeof(pageCount) +
                                    sizeof(spec.hyphenationEnabled) + sizeof(spec.embeddedStyle) +
                                    sizeof(spec.imageRendering) + sizeof(spec.focusReadingEnabled) +
-                                   sizeof(spec.honorBookInsets) + sizeof(uint32_t) + sizeof(uint32_t) +
-                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
+                                   sizeof(spec.honorBookInsets) + sizeof(spec.furiganaEnabled) + sizeof(uint32_t) +
+                                   sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t),
                 "Header size mismatch");
   // Written as the incomplete sentinel; finalizeBuild() patches it to
   // SECTION_FILE_VERSION as the last step, committing the file.
@@ -238,6 +241,7 @@ void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
   serialization::writePod(file, spec.imageRendering);
   serialization::writePod(file, spec.focusReadingEnabled);
   serialization::writePod(file, spec.honorBookInsets);
+  serialization::writePod(file, spec.furiganaEnabled);
   serialization::writePod(file, pageCount);  // Placeholder for page count (will be initially 0, patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for LUT offset (patched later)
   serialization::writePod(file, static_cast<uint32_t>(0));  // Placeholder for anchor map offset (patched later)
@@ -278,6 +282,7 @@ bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
     uint8_t fileImageRendering;
     bool fileFocusReadingEnabled;
     bool fileHonorBookInsets;
+    bool fileFuriganaEnabled;
     serialization::readPod(file, fileFontId);
     serialization::readPod(file, fileLineCompression);
     serialization::readPod(file, fileExtraParagraphSpacing);
@@ -289,13 +294,14 @@ bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
     serialization::readPod(file, fileImageRendering);
     serialization::readPod(file, fileFocusReadingEnabled);
     serialization::readPod(file, fileHonorBookInsets);
+    serialization::readPod(file, fileFuriganaEnabled);
 
     if (spec.fontId != fileFontId || spec.lineCompression != fileLineCompression ||
         spec.extraParagraphSpacing != fileExtraParagraphSpacing || spec.paragraphAlignment != fileParagraphAlignment ||
         spec.viewportWidth != fileViewportWidth || spec.viewportHeight != fileViewportHeight ||
         spec.hyphenationEnabled != fileHyphenationEnabled || spec.embeddedStyle != fileEmbeddedStyle ||
         spec.imageRendering != fileImageRendering || spec.focusReadingEnabled != fileFocusReadingEnabled ||
-        spec.honorBookInsets != fileHonorBookInsets) {
+        spec.honorBookInsets != fileHonorBookInsets || spec.furiganaEnabled != fileFuriganaEnabled) {
       file.close();
       LOG_ERR("SCT", "Deserialization failed: Parameters do not match");
       clearCache();
@@ -553,7 +559,7 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   ctx->parser = makeUniqueNoThrow<ChapterHtmlSlimParser>(
       epub, ctxPtr->parsePath, renderer, spec.fontId, spec.lineCompression, spec.extraParagraphSpacing,
       spec.paragraphAlignment, spec.viewportWidth, spec.viewportHeight, spec.hyphenationEnabled,
-      spec.focusReadingEnabled,
+      spec.focusReadingEnabled, spec.furiganaEnabled,
       [this, ctxPtr](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
                      const uint32_t visibleTextOffset) {
         // An empty page in the LUT reads back as a blank screen the reader can't skip past.

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -288,7 +288,12 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
 
   // Loop-invariant: hoisted out of the word loop so rubyTexts is scanned once,
   // not once per word.
-  const int rubyShift = getRubyShift(ascender);
+  //
+  // The shift makes room ABOVE the words for the annotation, and the layout reserved exactly
+  // this much in the line's height. When the annotation is suppressed the layout reserves
+  // nothing (see ChapterHtmlSlimParser::addLineToPage), so shifting here would push the words
+  // out of their own line box and into the one below.
+  const int rubyShift = suppressRuby ? 0 : getRubyShift(ascender);
 
   for (uint16_t i = 0; i < numWords; i++) {
     const char* word = wordText(i);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -2343,8 +2343,12 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const
   // setting produced (see cssLineHeightPercent: it is a clamped percentage OF that value, so
   // the user's setting stays inside the result). It is applied BEFORE the ruby headroom, which
   // is not part of the book's line box -- it is room the annotation needs above the ascender.
+  // ...and none of it is needed when the annotation will not be drawn: with furigana off the
+  // headroom is empty and the page reads looser than it should. Vertical tightens for the same
+  // reason (VerticalSection::streamParseAndLayout keeps a second, narrower column-gap table).
+  // TextBlock::render() drops its matching shift on the same condition.
   const int lineFontId = line->getBlockStyle().resolveFontId(fontId);
-  const int rubyExtra = line->getRubyShift(renderer.getFontAscenderSize(lineFontId));
+  const int rubyExtra = furiganaEnabled ? line->getRubyShift(renderer.getFontAscenderSize(lineFontId)) : 0;
   // A word enlarged by an inline font-size (span) needs the line's advance to cover its taller
   // glyphs, or it collides with the next line. Only lines that actually carry per-word fonts
   // pay the scan; the base font for the leading stays the block's own.

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -109,6 +109,9 @@ class ChapterHtmlSlimParser {
   uint16_t viewportHeight;
   bool hyphenationEnabled;
   bool focusReadingEnabled;
+  // Reserve the leading a ruby annotation needs above the ascender only when it will be drawn.
+  // See ReaderRenderSpec::furiganaEnabled.
+  bool furiganaEnabled;
   const CssParser* cssParser;
   // Chain of open elements, for descendant (`.callout p`) and child (`div > p`) selectors.
   // Pushed at the top of startElement and popped at the top of endElement -- one push per
@@ -254,7 +257,7 @@ class ChapterHtmlSlimParser {
       std::shared_ptr<Epub> epub, const std::string& filepath, GfxRenderer& renderer, const int fontId,
       const float lineCompression, const bool extraParagraphSpacing, const uint8_t paragraphAlignment,
       const uint16_t viewportWidth, const uint16_t viewportHeight, const bool hyphenationEnabled,
-      const bool focusReadingEnabled,
+      const bool focusReadingEnabled, const bool furiganaEnabled,
       const std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>& completePageFn,
       const bool embeddedStyle, const std::string& contentBase, const std::string& imageBasePath,
       const uint8_t imageRendering = 0, std::vector<std::string> tocAnchors = {},
@@ -272,6 +275,7 @@ class ChapterHtmlSlimParser {
         viewportHeight(viewportHeight),
         hyphenationEnabled(hyphenationEnabled),
         focusReadingEnabled(focusReadingEnabled),
+        furiganaEnabled(furiganaEnabled),
         completePageFn(completePageFn),
         popupFn(popupFn),
         cssParser(cssParser),

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -542,7 +542,10 @@ void EpubReaderActivity::loop() {
             // each line's word x-positions, so scanning with a different font rewrites the
             // page's layout. With a CJK-only family selected (UDDigiKyokasho) every Latin
             // glyph and the space measure zero, which collapsed all word gaps on the page.
-            p->render(renderer, effectiveReaderFontId(), 0, 0);  // scan only, no pixels
+            // Same suppressRuby the real render will use: the point of this scan is to warm
+            // exactly the glyphs the next page turn draws, and with furigana off the annotation
+            // glyphs are never drawn -- scanning them spends SD reads and cache RAM on nothing.
+            p->render(renderer, effectiveReaderFontId(), 0, 0, !useFurigana());  // scan only, no pixels
             scope.endScanAndPrewarm();
             LOG_DBG("ERS", "Idle prewarm: page %d in %lums", nextPage, millis() - t0);
           }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -562,12 +562,7 @@ void EpubReaderActivity::loop() {
       section->currentPage + PARTIAL_REBUILD_START_MARGIN >= static_cast<int>(section->pageCount)) {
     RenderLock lock;
     // Reuse the last render's viewport so the extension paginates identically to the partial.
-    // readerRenderSpec() takes fontId straight from settings; the reader may be
-    // substituting a different font for this book (effectiveReaderFontId: a Latin book
-    // read with a CJK-only family). The LAYOUT must be measured with the font that will
-    // actually draw it, or word widths and spaces come from a font with no Latin glyphs.
-    ReaderRenderSpec buildSpec = SETTINGS.readerRenderSpec(buildViewportWidth, buildViewportHeight);
-    buildSpec.fontId = effectiveReaderFontId();
+    const ReaderRenderSpec buildSpec = readerSpec(buildViewportWidth, buildViewportHeight);
     if (!section->startBuild(buildSpec)) {
       // Not fatal: the partial keeps serving its pages; crossing the watermark falls back to
       // the blocking extension in render(). Don't retry every tick.
@@ -1601,12 +1596,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   buildViewportWidth = viewportWidth;
   buildViewportHeight = viewportHeight;
 
-  // readerRenderSpec() takes fontId straight from settings; the reader may be
-  // substituting a different font for this book (effectiveReaderFontId: a Latin book
-  // read with a CJK-only family). The LAYOUT must be measured with the font that will
-  // actually draw it, or word widths and spaces come from a font with no Latin glyphs.
-  ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
-  renderSpec.fontId = effectiveReaderFontId();
+  const ReaderRenderSpec renderSpec = readerSpec(viewportWidth, viewportHeight);
 
   // Reflow a resident section when a layout-affecting setting changed under it.
   // The reader menu is pushed on top of this activity, so editing e.g. screenMargin
@@ -2621,12 +2611,7 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     return;
   }
 
-  // readerRenderSpec() takes fontId straight from settings; the reader may be
-  // substituting a different font for this book (effectiveReaderFontId: a Latin book
-  // read with a CJK-only family). The LAYOUT must be measured with the font that will
-  // actually draw it, or word widths and spaces come from a font with no Latin glyphs.
-  ReaderRenderSpec spec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
-  spec.fontId = effectiveReaderFontId();
+  const ReaderRenderSpec spec = readerSpec(viewportWidth, viewportHeight);
   Section nextSection(epub, nextSpineIndex, renderer);
   if (nextSection.loadSectionFile(spec) && !nextSection.isPartial()) {
     return;
@@ -2901,8 +2886,7 @@ void EpubReaderActivity::warmNextPageImageCache(const uint16_t viewportWidth, co
   const int adjacentSpine = currentSpineIndex + direction;
   if (warmedAhead < IMAGE_WARM_LOOKAHEAD_PAGES && adjacentSpine >= 0 && adjacentSpine < epub->getSpineItemsCount()) {
     Section adjacentSection(epub, adjacentSpine, renderer);
-    if (adjacentSection.loadSectionFile(SETTINGS.readerRenderSpec(viewportWidth, viewportHeight)) &&
-        adjacentSection.pageCount > 0) {
+    if (adjacentSection.loadSectionFile(readerSpec(viewportWidth, viewportHeight)) && adjacentSection.pageCount > 0) {
       for (int pageIndex = forward ? 0 : adjacentSection.pageCount - 1;
            pageIndex >= 0 && pageIndex < adjacentSection.pageCount && warmedAhead < IMAGE_WARM_LOOKAHEAD_PAGES;
            pageIndex += direction, warmedAhead++) {
@@ -3347,7 +3331,7 @@ void EpubReaderActivity::updateChapterPageSpan(const uint16_t viewportWidth, con
         }
       } else {
         Section sibling(epub, i, renderer);
-        if (sibling.loadSectionFile(SETTINGS.readerRenderSpec(viewportWidth, viewportHeight))) {
+        if (sibling.loadSectionFile(readerSpec(viewportWidth, viewportHeight))) {
           spinePagesReal[i] = sibling.pageCount;
           probed = true;
         }
@@ -3608,6 +3592,13 @@ void EpubReaderActivity::renderStatusBar() const {
   const bool building = section && section->isBuilding();
   GUI.drawStatusBar(renderer, bookProgress, currentPage, pageCount, title, 0, textYOffset, true, currentPageBookmarked,
                     building);
+}
+
+ReaderRenderSpec EpubReaderActivity::readerSpec(const uint16_t viewportWidth, const uint16_t viewportHeight) const {
+  ReaderRenderSpec spec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+  spec.fontId = effectiveReaderFontId();
+  spec.furiganaEnabled = useFurigana();
+  return spec;
 }
 
 int EpubReaderActivity::effectiveReaderFontId() const {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -426,6 +426,12 @@ class EpubReaderActivity final : public Activity {
   // measurement and the vertical engine's font-adaptive positioning all derive from one font
   // that really contains the glyphs -- per-glyph fallback stays only for rare stragglers.
   int effectiveReaderFontId() const;
+  // The horizontal layout spec for THIS book. SETTINGS.readerRenderSpec() knows only the
+  // global store; two fields are per-book and have to be applied on top of it -- the
+  // substituted font, and the furigana toggle's override. Both are cache-key fields, so a spec
+  // built without them silently fails every parameter check and rebuilds the chapter. Build
+  // every horizontal spec through here rather than repeating the fixups at each call site.
+  ReaderRenderSpec readerSpec(uint16_t viewportWidth, uint16_t viewportHeight) const;
   void restoreSavedPosition();
   bool useVerticalText() const;
   // Space kept clear below the text, in addition to the panel's own bezel.


### PR DESCRIPTION
Fixes #62.

> Use the similar furigana on/off tightening mechanism for horizontal that is currently used for vertical

## What was wrong

A ruby-carrying line reserves extra leading above its ascender so the annotation has somewhere to go (`ChapterHtmlSlimParser::addLineToPage`). Nothing gated that on the furigana setting, so with furigana **off** the room stayed on every such line, empty.

It could not have worked as things stood: `ReaderRenderSpec` carried no furigana field, so the section cache did not key on it and toggling furigana never re-ran the layout at all. `suppressRuby` only stopped the annotation being drawn — `TextBlock::render` still shifted every word down by `getRubyShift(ascender)`, into room the reader could not see.

Vertical already tightens for exactly this reason, with a second column-gap table (`kGapQuarterEmsPlain` vs `kGapQuarterEmsWithRuby`): a quarter em narrower at every line-spacing setting.

## What changed

- Furigana joins `ReaderRenderSpec`: written into the section header, checked on load. Toggling it now re-lays the chapter out rather than only suppressing annotations. Cache version 72 → 73.
- The layout takes the ruby reserve only when the annotation will be drawn.
- `TextBlock::render` drops its matching shift under `suppressRuby`. The two have to move together — reserving nothing while still shifting would push the words out of their own line box and into the one below.

The gain scales with how ruby-dense the book is; a chapter with no furigana is unchanged.

## Incidental fix

Every horizontal spec now goes through a new `EpubReaderActivity::readerSpec()` rather than five hand-assembled copies. Two of those copies — the image pre-warm and the sibling-spine page probe — were building specs **without** the substituted-font fixup. `fontId` is a cache-key field, so on any book using a substituted font (a Latin book read with a CJK-only family, or the reverse) both silently failed their parameter check on every call: the pre-warm never found its section, and the page-count probe always fell back to the byte estimate. Pre-existing and unrelated to furigana, but the helper is what stops it recurring.

## Verification

Local gates: `clang-format` clean, `pio run` SUCCESS, `pio check --fail-on-defect low` no defects, `ctest -j8` 154/154 passed. Toggling furigana in the emulator rebuilds the chapter to a smaller page count.

Not yet tested on hardware.

## Note for review

Stacked on #63 (base is that branch, not `develop`) because both touch `EpubReaderActivity.cpp`. Retarget to `develop` once #63 merges; review only the top commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)