### PR TITLE
feat: page turns after cache clearance

### DIFF
--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1443,7 +1443,6 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   sink.backTurnFlag = &backTurnDuringBuild_;
   sink.buildNoticeFn = buildNoticeFn_;
   sink.buildNoticeCtx = buildNoticeCtx_;
-  backTurnDuringBuild_.store(false, std::memory_order_relaxed);
 
   // Styled blocks (borders, start offsets, hanging indents, centering, gaps): collect the
   // vertical-relevant selectors. Streams the on-disk CSS cache -- does NOT materialize the

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -947,6 +947,9 @@ struct LayoutPageSink final : ParagraphSink {
   void (*earlyRenderFn)(void*, const VerticalPage&, int) = nullptr;
   void* earlyRenderCtx = nullptr;
   std::atomic<int>* pageRequest = nullptr;
+  std::atomic<bool>* backTurnFlag = nullptr;
+  void (*buildNoticeFn)(void*) = nullptr;
+  void* buildNoticeCtx = nullptr;
   uint64_t lastRefusedAttemptKey = 0;  // see servePageRequest()
   int fontReleasedForReq_ = -1;        // one font-cache release per starved request; see servePageRequest()
 
@@ -1144,6 +1147,11 @@ struct LayoutPageSink final : ParagraphSink {
   // mid-build -- the page appears normally once the build completes).
   void servePageRequest(const VerticalPage& justWritten, const int lastBuilt) {
     if (!pageRequest || !earlyRenderFn) return;
+    // A backward turn the build cannot serve. Drawn here rather than where the press is read:
+    // the framebuffer has one owner, and mid-build that is this task.
+    if (backTurnFlag && backTurnFlag->exchange(false, std::memory_order_relaxed) && buildNoticeFn) {
+      buildNoticeFn(buildNoticeCtx);
+    }
     const int req = pageRequest->load(std::memory_order_relaxed);
     if (req < 0 || req > lastBuilt) return;
     // Serving renders a page mid-build, and parts of that path allocate bare -- under
@@ -1209,6 +1217,16 @@ struct LayoutPageSink final : ParagraphSink {
         // unset so the very next page write retries against the roomier heap.
         fontReleasedForReq_ = req;
         if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
+        return;
+      }
+      if (okRead == ReadResult::HeapRefused) {
+        // Even after the font release there is not enough contiguous heap, and there will not
+        // be until the build ends -- the layout's working set is what is holding it. Leaving
+        // the request here strands the reader on a blank screen for the whole chapter (device
+        // log: three refusals at maxAlloc=10740 for a 10528-byte record, first page shown only
+        // when the build finished, 19s in). Re-point to the page about to be laid out: it is
+        // served from RAM as it is written, at no allocation, one page later than asked.
+        pageRequest->store(lastBuilt + 1, std::memory_order_relaxed);
         return;
       }
       lastRefusedAttemptKey = attemptKey;
@@ -1422,6 +1440,10 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   // recorded while the build runs simply overwrite it (latest wins).
   buildPageRequest_.store(earlyRenderFn_ ? earlyRenderTargetPage_ : -1, std::memory_order_relaxed);
   sink.pageRequest = &buildPageRequest_;
+  sink.backTurnFlag = &backTurnDuringBuild_;
+  sink.buildNoticeFn = buildNoticeFn_;
+  sink.buildNoticeCtx = buildNoticeCtx_;
+  backTurnDuringBuild_.store(false, std::memory_order_relaxed);
 
   // Styled blocks (borders, start offsets, hanging indents, centering, gaps): collect the
   // vertical-relevant selectors. Streams the on-disk CSS cache -- does NOT materialize the

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -70,6 +70,11 @@ class VerticalSection {
   // See requestPageDuringBuild(). Written by the loop() task, read by the build on the
   // render task; -1 = no pending request.
   std::atomic<int> buildPageRequest_{-1};
+  // See noteBackTurnDuringBuild(). Set by loop(), consumed on the render task between pages so
+  // the notice is drawn by the same task that draws pages -- the framebuffer has one owner.
+  std::atomic<bool> backTurnDuringBuild_{false};
+  void (*buildNoticeFn_)(void*) = nullptr;
+  void* buildNoticeCtx_ = nullptr;
 
  public:
   uint16_t pageCount = 0;
@@ -100,6 +105,20 @@ class VerticalSection {
   // written, otherwise the moment it is laid out). Latest request wins -- rapid presses
   // collapse to the final target.
   void requestPageDuringBuild(int pageIndex) { buildPageRequest_.store(pageIndex, std::memory_order_relaxed); }
+
+  // A BACKWARD turn while the build runs. Unlike a forward one it cannot be served: the page is
+  // already behind the build frontier, so showing it needs a cache read-back, and read-back wants
+  // ~10KB contiguous that the layout's own working set does not leave (measured on device:
+  // maxAlloc bottoms near 6KB mid-build). Rather than refuse silently, tell the reader the
+  // chapter is still indexing. Drawn via setBuildNoticeHook() on the render task.
+  void noteBackTurnDuringBuild() { backTurnDuringBuild_.store(true, std::memory_order_relaxed); }
+
+  // Draws the "still indexing" notice; invoked between pages on the render task. See
+  // noteBackTurnDuringBuild().
+  void setBuildNoticeHook(void* ctx, void (*fn)(void*)) {
+    buildNoticeCtx_ = ctx;
+    buildNoticeFn_ = fn;
+  }
 
   // furiganaEnabled is part of the cache key: the column gap only has to clear ruby when ruby is
   // drawn, so turning furigana off tightens the columns and the chapter must be re-laid out.

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -116,6 +116,7 @@ class VerticalSection {
   // Draws the "still indexing" notice; invoked between pages on the render task. See
   // noteBackTurnDuringBuild().
   void setBuildNoticeHook(void* ctx, void (*fn)(void*)) {
+    backTurnDuringBuild_.store(false, std::memory_order_relaxed);
     buildNoticeCtx_ = ctx;
     buildNoticeFn_ = fn;
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1483,8 +1483,15 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   if (verticalBuildInProgress_.load(std::memory_order_relaxed)) {
     const int shown = earlyDisplayedPage_.load(std::memory_order_relaxed);
     if (shown >= 0 && verticalSection) {
-      const int target = isForwardTurn ? shown + 1 : (shown > 0 ? shown - 1 : 0);
-      verticalSection->requestPageDuringBuild(target);
+      if (isForwardTurn) {
+        // Ahead of the build frontier, so it costs nothing: the page is served straight from
+        // RAM as it is laid out. Reading forward through a building chapter works normally.
+        verticalSection->requestPageDuringBuild(shown + 1);
+      } else {
+        // Backward needs a page already written, which means a cache read-back the build's own
+        // working set cannot fund. Say so instead of ignoring the press.
+        verticalSection->noteBackTurnDuringBuild();
+      }
     }
     lastPageTurnTime = millis();
     return;
@@ -1763,6 +1770,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         if (!pendingPercentJump) {
           earlyTarget = pendingPageJump.has_value() ? *pendingPageJump : (nextPageNumber > 0 ? nextPageNumber : 0);
           verticalSection->setEarlyRenderHook(this, &EpubReaderActivity::earlyRenderVerticalPageThunk, earlyTarget);
+          verticalSection->setBuildNoticeHook(this, &EpubReaderActivity::buildNoticeThunk);
         }
 
         earlyPageActuallyDisplayed_ = false;
@@ -3498,6 +3506,18 @@ void EpubReaderActivity::renderVerticalPageBody(const VerticalPage& vpage, const
   } else {
     block.render(renderer, effectiveReaderFontId(), marginLeft, marginTop, true);
   }
+}
+
+void EpubReaderActivity::buildNoticeThunk(void* ctx) {
+  auto* self = static_cast<EpubReaderActivity*>(ctx);
+  // The framebuffer is lent away for the duration of the chapter extraction; drawing then would
+  // scribble on the bytes the inflate is using. Skipping simply drops the notice -- the press it
+  // answers is already lost either way.
+  if (!self->renderer.hasFrameBuffer()) return;
+  GUI.drawPopup(self->renderer, tr(STR_INDEXING));
+  // The page render that follows repaints the whole screen over this, and a plain FAST leaves
+  // the popup's glyphs ghosting underneath; take the absolute pass.
+  self->pagesUntilFullRefresh = 1;
 }
 
 void EpubReaderActivity::earlyRenderVerticalPageThunk(void* ctx, const VerticalPage& page, const int pageIndex) {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -281,6 +281,9 @@ class EpubReaderActivity final : public Activity {
   // seconds into a ~17s whole-chapter build and the user can keep turning pages while the
   // rest of the chapter builds.
   static void earlyRenderVerticalPageThunk(void* ctx, const VerticalPage& page, int pageIndex);
+  // "Indexing" notice for a backward turn the running build cannot serve. Called between pages
+  // on the render task, so it shares the framebuffer with the page render rather than racing it.
+  static void buildNoticeThunk(void* ctx);
   void earlyRenderVerticalPage(const VerticalPage& page, int pageIndex);
   // True while a vertical chapter build runs on the render task. Read by pageTurn() on the
   // loop() task: while building, the section's pageCount is still 0, so the normal turn path


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
When the cache was cleared, the first page turns were very slow and on long books it felt unresponsive due to low heap.

* **What changes are included?**
** Forward now works by not needing that memory at all. When a read-back is refused for heap, the request re-points to the page about to be laid out, which gets served straight from RAM as it's written — free, one page later than asked. That covers both the initial early render and every forward turn, so you read forward through a building chapter normally.
** Backward raises the "Indexing" notice. It genuinely can't be served: the page is behind the frontier and read-back is exactly what the heap won't fund. The notice is drawn on the render task, between pages — not from the button handler — because the framebuffer has one owner and drawing from the loop task would race the page render. It's skipped during chapter extraction, when the framebuffer is lent to the inflate.

## Additional Context

Verification on XTEINK X4 on device.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
Claude Code, Opus 5
