### PR TITLE
refactor: remove dead verifyPowerButtonDuration() from main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,6 @@ EpdFontFamily ui12FontFamily(&ui12RegularFont, &ui12BoldFont);
 
 // measurement of power button press duration calibration value
 unsigned long t1 = 0;
-unsigned long t2 = 0;
 
 // Definitions for SilentRestart.h. RTC_NOINIT survives ESP.restart() but not power loss.
 RTC_NOINIT_ATTR uint32_t silentRebootMagic;
@@ -186,49 +185,6 @@ void silentRestartToTranslation() {
   ESP.restart();
 }
 
-// Verify power button press duration on wake-up from deep sleep
-// Pre-condition: isWakeupByPowerButton() == true
-void verifyPowerButtonDuration() {
-  if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP) {
-    // Fast path for short press
-    // Needed because inputManager.isPressed() may take up to ~500ms to return the correct state
-    return;
-  }
-
-  // Give the user up to 1000ms to start holding the power button, and must hold for SETTINGS.getPowerButtonDuration()
-  const auto start = millis();
-  bool abort = false;
-  // Subtract the current time, because inputManager only starts counting the HeldTime from the first update()
-  // This way, we remove the time we already took to reach here from the duration,
-  // assuming the button was held until now from millis()==0 (i.e. device start time).
-  const uint16_t calibration = start;
-  const uint16_t calibratedPressDuration =
-      (calibration < SETTINGS.getPowerButtonDuration()) ? SETTINGS.getPowerButtonDuration() - calibration : 1;
-
-  gpio.update();
-  // Needed because inputManager.isPressed() may take up to ~500ms to return the correct state
-  while (!gpio.isPressed(HalGPIO::BTN_POWER) && millis() - start < 1000) {
-    delay(10);  // only wait 10ms each iteration to not delay too much in case of short configured duration.
-    gpio.update();
-  }
-
-  t2 = millis();
-  if (gpio.isPressed(HalGPIO::BTN_POWER)) {
-    do {
-      delay(10);
-      gpio.update();
-    } while (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getPowerButtonHeldTime() < calibratedPressDuration);
-    abort = gpio.getPowerButtonHeldTime() < calibratedPressDuration;
-  } else {
-    abort = true;
-  }
-
-  if (abort) {
-    // Button released too early. Returning to sleep.
-    // IMPORTANT: Re-arm the wakeup trigger before sleeping again
-    powerManager.startDeepSleep(gpio);
-  }
-}
 void waitForPowerRelease() {
   gpio.update();
   while (gpio.isPressed(HalGPIO::BTN_POWER)) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Delete a stale copy of the power-button wake-up hold check that sits in `src/main.cpp` with no callers, so the deep-sleep paths can be audited without a decoy `startDeepSleep()` in the way.
* **What changes are included?**
  * Removed `verifyPowerButtonDuration()` (`src/main.cpp:191`).
  * Removed the `t2` global (`src/main.cpp:128`), whose only write lived inside that function.

The live path is unchanged: `setup()` calls `gpio.verifyPowerButtonWakeup(...)` at `src/main.cpp:417`, implemented at `lib/hal/HalGPIO.cpp:196`. The HAL version is a superset of the deleted copy — same calibration and hold logic, plus board guards (`BoardConfig::ACTIVE.input.power < 0`, the M5Paper latch circuit) that the stale copy never had, and it returns `bool` so the caller owns the sleep decision instead of the check calling `startDeepSleep()` itself.

The dead copy survived because it has external linkage, so no `-Wunused-function` warning ever pointed at it.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — **N/A: no file under those paths is modified.** `lib/hal/HalGPIO.cpp` is referenced as the surviving implementation but is not touched; the diff is `src/main.cpp` only.

This is a deletion of unreachable code, so it adds no feature surface.

## Additional Context

**Behaviour:** none. The removed function had no callers, so nothing that ran before runs differently now.

**Memory / flash impact:** 8 bytes of `.data`/`.bss` from the removed `unsigned long t2`, plus whatever the linker was keeping of the function body. Not a meaningful saving and not the point of the change — the value here is that `startDeepSleep()` now appears only on paths that can actually reach it.

**Relationship to upstream:** upstream (`crosspoint-reader/crosspoint-reader`) moved this logic into `HalGPIO::verifyPowerButtonWakeup()` and deleted the `main.cpp` function; this fork kept the old copy. Verified against upstream `master` at `e00f595`.

One deliberate difference from upstream: upstream deleted the function but left **both** `t1` and `t2` declared. This PR also drops `t2`, since with the function gone it has no writer at all. `t1` is left alone — it is likewise never read, but it still has a live write in `setup()` and is dead upstream too, so removing it here would create a longer-lived divergence in a file that takes upstream merges. Better sent upstream than carried as a fork delta.

**Areas to focus on:** confirming the HAL path really is a superset, i.e. that nothing depended on the deleted copy's behaviour of calling `startDeepSleep()` directly.

**Verification:** `pio run` succeeds locally with 0 errors (RAM 15.6%, 51,252 / 327,680 bytes; Flash 96.8%). CI is green on all checks, including `clang-format`, `cppcheck`, `build`, and `unit-tests`. Not flashed to hardware — worth a power-button wake check on device before merge, though no runtime path changed.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — investigation, the deletion, and this description were done by Claude Code.