### PR TITLE
fix: keep home button hints visible in home screen

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -408,9 +408,8 @@ void HomeActivity::render(RenderLock&&) {
     menuIcons.insert(menuIcons.begin(), Book);
   }
 
-  const Rect menuRect{0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, pageWidth,
-                      pageHeight - (metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset +
-                                    metrics.buttonHintsHeight)};
+  const int menuTop = metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset;
+  const Rect menuRect{0, menuTop, pageWidth, pageHeight - menuTop - metrics.buttonHintsHeight};
   const int menuSelected =
       metrics.homeContinueReadingInMenu ? selectorIndex : selectorIndex - static_cast<int>(recentBooks.size());
 

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -409,8 +409,8 @@ void HomeActivity::render(RenderLock&&) {
   }
 
   const Rect menuRect{0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, pageWidth,
-                      pageHeight - (metrics.headerHeight + metrics.homeTopPadding + metrics.verticalSpacing +
-                                    metrics.homeMenuTopOffset + metrics.buttonHintsHeight)};
+                      pageHeight - (metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset +
+                                    metrics.buttonHintsHeight)};
   const int menuSelected =
       metrics.homeContinueReadingInMenu ? selectorIndex : selectorIndex - static_cast<int>(recentBooks.size());
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Keep the home-screen button labels visible while navigating the menu. Fixes #69.
* **What changes are included?** The menu redraw rectangle now uses the actual cover-tile height, so partial menu redraws stop at the top of the button-hint area.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable; this is a focused UI rendering bug fix reported in #69.

## Additional Context

* Root cause: the partial-redraw rectangle subtracted the header height instead of the home cover-tile height. It therefore extended through the bottom of the screen, clearing the button hints before the fast render path returned.
* User impact: `Resume`, `Select`, `Up`, and `Down` remain visible while moving between home menu items.
* Validation: repository clang-format passed, the default firmware build passed, and the private build was flashed and verified on device.
* Memory / flash impact: none expected; this only corrects an existing rectangle calculation.
* This PR does not touch `freeink-sdk/`, `lib/hal/`, or private content-access sources.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
