### PR TITLE
feat: use Gemini 3.6 Flash for reader translation

### DIFF
--- a/src/activities/reader/EpubReaderTranslationActivity.cpp
+++ b/src/activities/reader/EpubReaderTranslationActivity.cpp
@@ -45,7 +45,7 @@ constexpr uint32_t WIFI_STACK_RESERVE = 36000;
 // conservative empirical floor above the crash point, not a documented ESP-IDF constant.
 constexpr uint32_t MIN_HEAP_FOR_WIFI_INIT = 70000;
 constexpr const char* API_KEY_PATH = "/system/gemini.key";
-constexpr const char* GEMINI_MODEL = "gemini-2.5-flash";
+constexpr const char* GEMINI_MODEL = "gemini-3.6-flash";
 
 }  // namespace
 
@@ -207,7 +207,6 @@ bool EpubReaderTranslationActivity::callGeminiApi(const std::string& apiKey) {
                      sourceText;
 
   auto config = reqDoc["generationConfig"].to<JsonObject>();
-  config["temperature"] = 0.3;
   config["maxOutputTokens"] = 2048;
 
   std::string body;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Update reader page translation to use the current Gemini 3.6 Flash model.
* **What changes are included?** The existing translation request now targets `gemini-3.6-flash`; the deprecated `temperature` parameter was removed while preserving the output-token limit.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector; it updates the existing Gemini translation integration.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

Gemini 3.6 Flash requires removing deprecated sampling parameters such as `temperature`. No HAL, SDK, private SDK, or device-level code is changed.

Validation: `./bin/clang-format-fix`, `git diff --check`, and `pio run` (default) pass.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
