### PR TITLE
fix: prevent vertical bookmark crash

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3876,12 +3876,17 @@ void EpubReaderActivity::addBookmark() {
     entry.computedChapterPageCount = pageCount;
     entry.computedChapterProgress = currentPage;
     // Record the exact content offset so the bookmark lands correctly after any re-pagination.
-    // currentPageVisibleOffset was captured for this very page at its last render.
-    const std::optional<uint32_t> offset =
-        currentPageVisibleOffset.has_value() ? currentPageVisibleOffset
-        : (currentPage >= 0 && currentPage < section->pageCount)
-            ? section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage))
-            : std::nullopt;
+    // The two layouts own different section objects; never touch `section` while a vertical page
+    // is active (it is null in that mode).
+    std::optional<uint32_t> offset;
+    if (verticalSection && currentPage >= 0 && currentPage < verticalSection->pageCount) {
+      offset = verticalSection->getVisibleTextOffsetForPage(currentPage);
+    } else if (section && currentPage >= 0 && currentPage < section->pageCount) {
+      // currentPageVisibleOffset was captured for this very page at its last render.
+      offset = currentPageVisibleOffset.has_value()
+                   ? currentPageVisibleOffset
+                   : section->getVisibleTextOffsetForPage(static_cast<uint16_t>(currentPage));
+    }
     if (offset.has_value()) {
       entry.visibleTextOffset = *offset;
       entry.hasVisibleTextOffset = true;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the crash reported in #79 when toggling a bookmark in a vertical Japanese EPUB.
* **What changes are included?** Guard bookmark offset resolution by layout and use the vertical section offset when vertical text is active.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

The crash was caused by dereferencing the null horizontal `section` while `verticalSection` was active. The device log showed the failure immediately after bookmark progress resolution.

Validation: default PlatformIO build and clang-format check passed; firmware was flashed to the test device.

---

### AI Usage

Did you use AI tools to help write this code? **YES**