### PR TITLE
fix: end bold, italic and bouten where their element ends

### DIFF
--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -176,19 +176,39 @@ struct TextExtractor {
   // Style tracking — each entry records the elementDepth at which
   // bold/italic was activated. On endElement, if we're leaving that
   // depth, pop and flush.
-  int boldDepth = 0;
-  int italicDepth = 0;
   int elementDepth = 0;
-  static constexpr int MAX_STYLE_STACK = 8;
-  int boldOpenedAtDepth[MAX_STYLE_STACK] = {};
-  int boldStackSize = 0;
-  int italicOpenedAtDepth[MAX_STYLE_STACK] = {};
-  int italicStackSize = 0;
-  int emphasisDepth = 0;
-  int emphasisOpenedAtDepth[MAX_STYLE_STACK] = {};
-  int emphasisStackSize = 0;
 
-  bool hasEmphasis() const { return emphasisDepth > 0; }
+  static constexpr int MAX_STYLE_STACK = 8;
+  // One inline style's nesting. This existed three times over -- three counters, three arrays,
+  // three copies of the same push/pop arithmetic -- which is how a single off-by-one in the
+  // close check shipped in triplicate. Plain ints, so the footprint is exactly what the loose
+  // members cost.
+  struct StyleStack {
+    int depth = 0;
+    int openedAt[MAX_STYLE_STACK] = {};
+    int size = 0;
+
+    bool active() const { return depth > 0; }
+    // Past MAX_STYLE_STACK the open cannot be recorded, so it must not be counted either: a
+    // counter with no stack entry to close it stays raised for the rest of the chapter.
+    bool canOpen() const { return size < MAX_STYLE_STACK; }
+    void open(const int elementDepth) {
+      depth++;
+      openedAt[size++] = elementDepth;
+    }
+    // endElement decrements elementDepth before asking, so the element that opened the style
+    // sits one level deeper than the value being compared against.
+    bool closesHere(const int elementDepth) const { return size > 0 && openedAt[size - 1] - 1 == elementDepth; }
+    void close() {
+      depth--;
+      size--;
+    }
+  };
+  StyleStack boldStack;
+  StyleStack italicStack;
+  StyleStack emphasisStack;
+
+  bool hasEmphasis() const { return emphasisStack.active(); }
 
   // Diagnostic: bisects a ~11KB drop seen accumulating within a single furigana-dense paragraph's
   // SAX processing, too large to be explained by RubyRun/string vector growth alone. Call at the
@@ -207,8 +227,8 @@ struct TextExtractor {
   static bool isItalicTag(const char* name) { return strcasecmp(name, "i") == 0 || strcasecmp(name, "em") == 0; }
   uint8_t currentStyle() const {
     uint8_t s = 0;
-    if (boldDepth > 0) s |= 1;    // EpdFontFamily::BOLD
-    if (italicDepth > 0) s |= 2;  // EpdFontFamily::ITALIC
+    if (boldStack.active()) s |= 1;    // EpdFontFamily::BOLD
+    if (italicStack.active()) s |= 2;  // EpdFontFamily::ITALIC
     return s;
   }
 
@@ -416,32 +436,29 @@ struct TextExtractor {
       self->inRp = true;
     }
     if (isBoldTag(name) || hasClass(atts, "bold")) {
-      self->flushCurrentText();
-      // Both together or neither: the counter is undone by a matching entry on the stack, so
-      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
-      if (self->boldStackSize < MAX_STYLE_STACK) {
-        self->boldDepth++;
-        self->boldOpenedAtDepth[self->boldStackSize++] = self->elementDepth;
+      if (self->boldStack.canOpen()) {
+        // Before the change, so the run built so far is closed under the OLD style. A full
+        // stack changes nothing, so it must not split the run either.
+        self->flushCurrentText();
+        self->boldStack.open(self->elementDepth);
       }
     }
     if (isItalicTag(name) || hasClass(atts, "italic")) {
-      self->flushCurrentText();
-      // Both together or neither: the counter is undone by a matching entry on the stack, so
-      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
-      if (self->italicStackSize < MAX_STYLE_STACK) {
-        self->italicDepth++;
-        self->italicOpenedAtDepth[self->italicStackSize++] = self->elementDepth;
+      if (self->italicStack.canOpen()) {
+        // Before the change, so the run built so far is closed under the OLD style. A full
+        // stack changes nothing, so it must not split the run either.
+        self->flushCurrentText();
+        self->italicStack.open(self->elementDepth);
       }
     }
     if (hasClass(atts, "em-sesame") || hasClass(atts, "em-dot") || hasClass(atts, "em-circle") ||
         hasClass(atts, "em-sesame-open") || hasClass(atts, "em-dot-open") || hasClass(atts, "em-circle-open") ||
         hasClass(atts, "em-triangle") || hasClass(atts, "em-double-circle")) {
-      self->flushCurrentText();
-      // Both together or neither: the counter is undone by a matching entry on the stack, so
-      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
-      if (self->emphasisStackSize < MAX_STYLE_STACK) {
-        self->emphasisDepth++;
-        self->emphasisOpenedAtDepth[self->emphasisStackSize++] = self->elementDepth;
+      if (self->emphasisStack.canOpen()) {
+        // Before the change, so the run built so far is closed under the OLD style. A full
+        // stack changes nothing, so it must not split the run either.
+        self->flushCurrentText();
+        self->emphasisStack.open(self->elementDepth);
       }
     }
     if (strcasecmp(name, "img") == 0 || strcasecmp(name, "image") == 0) {
@@ -544,21 +561,17 @@ struct TextExtractor {
       if (self->currentRuns.size() >= SOFT_FLUSH_RUNS) self->emitRuns(false);
       return;
     }
-    if (self->boldStackSize > 0 && self->boldOpenedAtDepth[self->boldStackSize - 1] - 1 == self->elementDepth) {
+    if (self->boldStack.closesHere(self->elementDepth)) {
       self->flushCurrentText();
-      self->boldDepth--;
-      self->boldStackSize--;
+      self->boldStack.close();
     }
-    if (self->italicStackSize > 0 && self->italicOpenedAtDepth[self->italicStackSize - 1] - 1 == self->elementDepth) {
+    if (self->italicStack.closesHere(self->elementDepth)) {
       self->flushCurrentText();
-      self->italicDepth--;
-      self->italicStackSize--;
+      self->italicStack.close();
     }
-    if (self->emphasisStackSize > 0 &&
-        self->emphasisOpenedAtDepth[self->emphasisStackSize - 1] - 1 == self->elementDepth) {
+    if (self->emphasisStack.closesHere(self->elementDepth)) {
       self->flushCurrentText();
-      self->emphasisDepth--;
-      self->emphasisStackSize--;
+      self->emphasisStack.close();
     }
     if (isBlockTag(name)) {
       self->blockDepth--;

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -74,7 +74,11 @@ namespace {
 // proportion. Format change: a v131 record starts with the image flag. (132-133 were consumed
 // during development by builds that computed those positions wrongly; such records parse cleanly,
 // so caches carrying those numbers must not be trusted.)
-constexpr uint8_t VSECTION_FILE_VERSION = 134;
+// v135: bold/italic/bouten now END where their element ends. The close compared the opening
+// elementDepth against an already-decremented one, so a style was never popped and ran to the end
+// of the chapter -- most visibly a <span class="em-sesame"> putting sesame marks on every
+// character after it. Cached pages carry the marks and the pagination they caused.
+constexpr uint8_t VSECTION_FILE_VERSION = 135;
 // 4KB, not 1KB: chapter builds are SD-latency-bound -- the inflate staging write, the
 // staging read-back, and the expat feed each touch the card once per chunk, so quadrupling
 // the chunk quarters the transaction count for ~12KB of transient buffers.
@@ -413,22 +417,32 @@ struct TextExtractor {
     }
     if (isBoldTag(name) || hasClass(atts, "bold")) {
       self->flushCurrentText();
-      self->boldDepth++;
-      if (self->boldStackSize < MAX_STYLE_STACK) self->boldOpenedAtDepth[self->boldStackSize++] = self->elementDepth;
+      // Both together or neither: the counter is undone by a matching entry on the stack, so
+      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
+      if (self->boldStackSize < MAX_STYLE_STACK) {
+        self->boldDepth++;
+        self->boldOpenedAtDepth[self->boldStackSize++] = self->elementDepth;
+      }
     }
     if (isItalicTag(name) || hasClass(atts, "italic")) {
       self->flushCurrentText();
-      self->italicDepth++;
-      if (self->italicStackSize < MAX_STYLE_STACK)
+      // Both together or neither: the counter is undone by a matching entry on the stack, so
+      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
+      if (self->italicStackSize < MAX_STYLE_STACK) {
+        self->italicDepth++;
         self->italicOpenedAtDepth[self->italicStackSize++] = self->elementDepth;
+      }
     }
     if (hasClass(atts, "em-sesame") || hasClass(atts, "em-dot") || hasClass(atts, "em-circle") ||
         hasClass(atts, "em-sesame-open") || hasClass(atts, "em-dot-open") || hasClass(atts, "em-circle-open") ||
         hasClass(atts, "em-triangle") || hasClass(atts, "em-double-circle")) {
       self->flushCurrentText();
-      self->emphasisDepth++;
-      if (self->emphasisStackSize < MAX_STYLE_STACK)
+      // Both together or neither: the counter is undone by a matching entry on the stack, so
+      // incrementing it past MAX_STYLE_STACK leaves the style on for the rest of the chapter.
+      if (self->emphasisStackSize < MAX_STYLE_STACK) {
+        self->emphasisDepth++;
         self->emphasisOpenedAtDepth[self->emphasisStackSize++] = self->elementDepth;
+      }
     }
     if (strcasecmp(name, "img") == 0 || strcasecmp(name, "image") == 0) {
       const char* src = nullptr;
@@ -530,17 +544,18 @@ struct TextExtractor {
       if (self->currentRuns.size() >= SOFT_FLUSH_RUNS) self->emitRuns(false);
       return;
     }
-    if (self->boldStackSize > 0 && self->boldOpenedAtDepth[self->boldStackSize - 1] == self->elementDepth) {
+    if (self->boldStackSize > 0 && self->boldOpenedAtDepth[self->boldStackSize - 1] - 1 == self->elementDepth) {
       self->flushCurrentText();
       self->boldDepth--;
       self->boldStackSize--;
     }
-    if (self->italicStackSize > 0 && self->italicOpenedAtDepth[self->italicStackSize - 1] == self->elementDepth) {
+    if (self->italicStackSize > 0 && self->italicOpenedAtDepth[self->italicStackSize - 1] - 1 == self->elementDepth) {
       self->flushCurrentText();
       self->italicDepth--;
       self->italicStackSize--;
     }
-    if (self->emphasisStackSize > 0 && self->emphasisOpenedAtDepth[self->emphasisStackSize - 1] == self->elementDepth) {
+    if (self->emphasisStackSize > 0 &&
+        self->emphasisOpenedAtDepth[self->emphasisStackSize - 1] - 1 == self->elementDepth) {
       self->flushCurrentText();
       self->emphasisDepth--;
       self->emphasisStackSize--;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop an inline style (bold, italic, or JP bouten) running to the end of the chapter instead of ending with its element. Reported from a real book: sesame dots appearing a couple of pages into a chapter and never stopping.
* **What changes are included?**
  * Fix the off-by-one in the close check for all three style stacks in `VerticalSection`'s extractor.
  * Stop the depth counter being incremented when the stack that closes it is full.
  * Bump `VSECTION_FILE_VERSION` 134 → 135, since cached pages hold both the stray marks and the pagination they caused.

### The bug

`startElement` increments `elementDepth` **before** recording where a style opened; `endElement` decrements it **before** checking whether to close one. So a `<span>` opened at depth 4 was compared against 3 and never matched:

```cpp
// close, after elementDepth has already been decremented
if (self->emphasisStackSize > 0 && self->emphasisOpenedAtDepth[…] == self->elementDepth) {
```

The style was therefore never popped and `hasEmphasis()` stayed true for the remainder of the chapter.

The box path in the same file already had the correct form, which is what the three stacks now use:

```cpp
if (self->boxOpenedAtDepth >= 0 && self->elementDepth == self->boxOpenedAtDepth - 1) {
```

Bouten is where this is glaring; **bold and italic leaked identically** and just read as a book that looked heavy.

Second, narrower leak in the same place: `emphasisDepth++` ran unconditionally while the stack push was guarded by `MAX_STYLE_STACK`, so a style opened past that limit could never be undone. Counter and stack entry now move together.

### Reproducing

Any vertical (`dc:language=ja`) book with a bouten span. Confirmed against a commercial EPUB whose chapter contains exactly one:

```html
<span class="em-sesame">ちっちゃな</span>くせに、高い木の鈴を鳴らすのですから。
```

Five characters should carry marks. Every character to the end of the chapter did.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — vertical text and bouten are fork features.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none are touched.

## Additional Context

* **Memory / flash impact:** none. Same fields, same arithmetic; one comparison changed and two increments moved inside an existing branch.
* **Risk:** the cache bump re-indexes every vertical chapter once on first open. Pagination legitimately shifts where marks disappear.
* **Focus for review:** the `- 1` is the whole fix; worth confirming against the box path's existing convention rather than reasoning about it fresh.
* Local gates: `clang-format` clean, `pio run` SUCCESS, `pio check --fail-on-defect low/medium/high` no defects.
* Verified by code inspection and on-device; not covered by an automated test — the extractor has no unit-test harness.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_