### PR TITLE
ci: pin Python to 3.13 so PlatformIO can build its penv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          # 3.13, not 3.14: PlatformIO Core 6.1.19 cannot build its penv on 3.14
+          # ("Failed to install Python dependencies into penv"), which fails every job
+          # before a single file is compiled. Raise only once pio can create its env there.
+          python-version: '3.13'
 
       - name: Install clang-format-21
         run: |
@@ -45,7 +48,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -76,7 +79,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -130,7 +133,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release-fonts.yml
+++ b/.github/workflows/release-fonts.yml
@@ -24,7 +24,10 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          # 3.13, not 3.14: PlatformIO Core 6.1.19 cannot build its penv on 3.14
+          # ("Failed to install Python dependencies into penv"), which fails every job
+          # before a single file is compiled. Raise only once pio can create its env there.
+          python-version: '3.13'
 
       - name: Install font tools
         run: pip install freetype-py fonttools pyyaml

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -14,7 +14,10 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          # 3.13, not 3.14: PlatformIO Core 6.1.19 cannot build its penv on 3.14
+          # ("Failed to install Python dependencies into penv"), which fails every job
+          # before a single file is compiled. Raise only once pio can create its env there.
+          python-version: '3.13'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Get CI green again. Every build and cppcheck job in the repo is currently failing, on every PR, for a reason unrelated to the code under review.
* **What changes are included?** Pin `python-version` from `'3.14'` to `'3.13'` in all six places across `ci.yml`, `release_candidate.yml` and `release-fonts.yml`, with a note saying why.

### The failure

```
Processing default (platform: …platform-espressif32.zip; board: esp32-c3-devkitm-1 …)
Error: Failed to install Python dependencies into penv
Created pioarduino Python virtual environment using uv: /home/runner/.platformio/penv
Error: Failed to install Python dependencies (exit code: 2)
```

PlatformIO cannot create its own virtualenv, so nothing is ever compiled. The knock-on effects are what make this confusing to diagnose:

* **cppcheck** exits 1 having printed a header and no defects at all — it looks like a failed analysis, but no analysis ran.
* **Test Status** is a gate job (`needs: build-default, build-sticky, clang-format, cppcheck, unit-tests`) and fails purely because its dependencies did.

So three red checks, one cause.

### Why 3.13

The workflows pin `'3.14'`, which floats across patch releases. The last green run on `develop` (9 Aug) used **3.14.6**; runs from 12 Aug use **3.14.7**, and all of them fail. The pinned PlatformIO Core is unchanged at 6.1.19.

The same **PlatformIO Core 6.1.19** builds this project cleanly on **Python 3.13.5** locally — full `pio run`, `pio check --fail-on-defect low/medium/high`, and the unit tests. Same core, same repo, different Python, opposite outcome.

The release workflows carry the identical `'3.14'` pin and would have failed the same way at the next release, so they are pinned too.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — CI configuration, not firmware.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none are touched.

## Additional Context

* **Memory / flash impact:** none. No firmware code changes.
* **Verification:** this can only be proven by CI itself — a local machine has a working penv already, so the failure cannot be reproduced here. The evidence is the version comparison above. If these checks come back green, that is the test.
* **Risk:** if a future PlatformIO release requires 3.14, this pin has to move with it; the comment in each file says so.
* Worth confirming the same pin does not need applying anywhere else — I covered the three workflow files that set `python-version`.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_