### PR TITLE
ci: install littlefs-python so the espressif32 builder can import it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
+        # system site-packages while installing its own dependencies into a penv the builder
+        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        run: |
+          uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+          uv pip install --system littlefs-python
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -88,7 +94,13 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
+        # system site-packages while installing its own dependencies into a penv the builder
+        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        run: |
+          uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+          uv pip install --system littlefs-python
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -142,7 +154,13 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
+        # system site-packages while installing its own dependencies into a penv the builder
+        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        run: |
+          uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+          uv pip install --system littlefs-python
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -26,7 +26,13 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        run: uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
+        # system site-packages while installing its own dependencies into a penv the builder
+        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        run: |
+          uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
+          uv pip install --system littlefs-python
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Get CI green. Every build and cppcheck job still fails after the Python pin in #86 — this is the next failure behind it.
* **What changes are included?** Install `littlefs-python` alongside PlatformIO Core in the four `uv pip install --system` steps that run a build (`ci.yml` ×3, `release_candidate.yml` ×1).

### The failure

```
ModuleNotFoundError: No module named 'littlefs':
  File ".../platformio/builder/main.py", line 173:
    env.SConscript("$BUILD_SCRIPT")
  File ".../platforms/espressif32/builder/main.py", line 25:
```

The espressif32 platform's builder imports `littlefs`, and nothing in CI provides it. Both `Build default`/`Build sticky` and `cppcheck` die here — cppcheck included, because `pio check` runs the same build script, which is why it reports a failure with an empty defect list.

### Why installing it `--system` is the right place

Look at where the traceback runs from: `/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/site-packages/platformio/`. The workflow installs PlatformIO with `uv pip install --system`, so the builder executes out of **system** site-packages, while PlatformIO installs its own dependencies into a **penv** the builder never consults. The dependency gets installed somewhere real and stays invisible to the code that needs it.

A working local environment has exactly this package — `littlefs-python` 0.18.0, providing the `littlefs` module — which is why the same commit builds locally and not in CI.

### Relationship to #86

Distinct failures in the same subsystem. #86 fixed PlatformIO's *penv creation* (`Failed to install Python dependencies into penv` on Python 3.14). With that fixed the run gets further and hits this. The pin is confirmed working in these logs: `Successfully set up CPython (3.13.14)`.

`release-fonts.yml` is untouched — it never invokes PlatformIO.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — CI configuration, not firmware.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none are touched.

## Additional Context

* **Memory / flash impact:** none. No firmware code changes.
* **Verification:** only CI can prove this — a local machine already has the package, so the failure cannot be reproduced here. If these checks come back green, that is the test.
* **A more thorough alternative**, if further modules surface the same way: drop `--system` so PlatformIO manages one environment consistently, instead of pinning missing dependencies one at a time. That is a larger change to every workflow and I did not want to bundle it with an urgent unblock.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_