### PR TITLE
fix: leave a book alone when its own ToC already works

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -5051,7 +5051,31 @@ async function splitEpubChapters(file) {
   const tocRefRe = /(?:href|src)="([^"]+)"/g;
   let tocRef;
   while ((tocRef = tocRefRe.exec(nav || ncx || '')) !== null) existingNames.add(baseName(tocRef[1]));
-  const recoverSpineToc = !!(nav || ncx) && spineChapters.length >= 2 &&
+  // Does the book's own ToC navigate the whole book? Not "does it exist" and not "how many
+  // entries" -- both stubs and real ToCs have entries. What separates them is REACH: a working
+  // ToC lets you jump to the end, a stub stops near the start. Measured on two real books: a
+  // correctly built light novel's ToC reaches spine index 29 of 30 (100%), while a novel that
+  // genuinely needs repair reaches index 4 of 17 (29%) -- it lists the cover and the first page
+  // and nothing else.
+  //
+  // This matters because recovery adds an entry for every structurally-named spine file, and in
+  // a book that is already chaptered most of those files are CONTINUATIONS, not chapter starts.
+  // Left ungated it buried the author's 11 chapters under 29 entries, titling front matter with
+  // its filename ("part0000") and mid-chapter files with whatever sentence they opened on.
+  const spineIndexByName = new Map();
+  spineIds.forEach((id, index) => {
+    const name = baseName(manifest[id] || '');
+    if (name && !spineIndexByName.has(name)) spineIndexByName.set(name, index);
+  });
+  let tocSpineRefs = 0, lastTocSpineIndex = -1;
+  for (const name of existingNames) {
+    const index = spineIndexByName.get(name);
+    if (index === undefined) continue;  // stylesheets, scripts, images: not navigation
+    tocSpineRefs++;
+    if (index > lastTocSpineIndex) lastTocSpineIndex = index;
+  }
+  const bookHasWorkingToc = tocSpineRefs >= 2 && lastTocSpineIndex >= (spineIds.length - 1) / 2;
+  const recoverSpineToc = !!(nav || ncx) && !bookHasWorkingToc && spineChapters.length >= 2 &&
     spineChapters.some(t => !existingNames.has(baseName(t.href)));
   if (recoverSpineToc) {
     tocAdditions.push(...spineChapters);

--- a/tools/epub_split_chapters.py
+++ b/tools/epub_split_chapters.py
@@ -209,8 +209,31 @@ def main():
     elif ncx_path and ncx_path in files:
         toc_source = files[ncx_path].decode("utf-8")
     existing_names = {Path(h.split("#", 1)[0]).name for h in re.findall(r'(?:href|src)="([^"]+)"', toc_source)}
-    recover_spine_toc = bool(toc_source) and len(spine_chapters) >= 2 and any(
-        Path(href).name not in existing_names for href, _ in spine_chapters
+    # Does the book's own ToC navigate the whole book? Not "does it exist" and not "how many
+    # entries" -- both stubs and real ToCs have entries. What separates them is REACH: a working
+    # ToC lets you jump to the end, a stub stops near the start. Measured on two real books: a
+    # correctly built light novel's ToC reaches spine index 29 of 30 (100%), while a novel that
+    # genuinely needs repair reaches index 4 of 17 (29%) -- it lists the cover and the first page
+    # and nothing else.
+    #
+    # This matters because recovery adds an entry for every structurally-named spine file, and in
+    # a book that is already chaptered most of those files are CONTINUATIONS, not chapter starts.
+    # Left ungated it buried the author's 11 chapters under 29 entries, titling front matter with
+    # its filename ("part0000") and mid-chapter files with whatever sentence they opened on.
+    spine_index_by_name = {}
+    for index, idref in enumerate(spine_ids):
+        href = manifest.get(idref)
+        if href:
+            spine_index_by_name.setdefault(Path(href).name, index)
+    toc_spine_indexes = [spine_index_by_name[n] for n in existing_names if n in spine_index_by_name]
+    book_has_working_toc = (
+        len(toc_spine_indexes) >= 2 and max(toc_spine_indexes) >= (len(spine_ids) - 1) / 2
+    )
+    recover_spine_toc = (
+        bool(toc_source)
+        and not book_has_working_toc
+        and len(spine_chapters) >= 2
+        and any(Path(href).name not in existing_names for href, _ in spine_chapters)
     )
     if recover_spine_toc:
         toc_additions.extend(spine_chapters)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop **Optimize EPUB** rebuilding the table of contents of books that already have a good one.
* **What changes are included?** Gate the ToC-recovery half of the feature on whether the book's own ToC already navigates it. Mirrored in `tools/epub_split_chapters.py`, as both files ask.

### What went wrong

Recovery adds a ToC entry for every structurally-named spine file, and nothing asked whether the book needed it. On a correctly built light novel that buried the author's **11 chapters under 29 entries**:

```
part0000.xhtml  ->  part0000                                    [filename: no heading to find]
part0009.xhtml  ->  しかもさっきまで倒れそうだったお父様まで拍手しているよ。   [a sentence mid-chapter]
part0016.xhtml  ->  ジオルドのあまりの迫力になんの言葉も出てこず、私はただ狼狽えた。
```

Those files are *continuations*, not chapters, so there is no title to find — `mrchFindChapterTitle` falls back to the first sentence, or the filename.

### The test: reach, not size

Both a stub ToC and a real one have entries, so counting them proves nothing. What separates them is whether you can navigate to the **end** of the book. Measured on three real EPUBs:

| Book | ToC reach | Needs |
| --- | --- | --- |
| Correct light novel | spine 29 / 30 (100%) | nothing — now left alone |
| Novel with a stub ToC | spine 4 / 17 (29%) | recovery |
| Novel with chapters inside 2 files | spine 8 / 9 (100%) | **splitting** |

### Why only recovery is gated

The third book is the reason. Its ToC *does* reach the end, yet its chapters live inside two large files, so it needs **splitting** — a different repair for a different defect, and one no ToC can rule out. Gating both halves on the same signal would have broken it. Splitting is left exactly as it was.

### Verification

Run against every book above, before and after:

* correct light novel: was "29 sections prepared", now "No chapter structure repair needed"
* stub-ToC novel: still recovers 12 chapters, with real titles (プロローグ, 第一章…第七章, エピローグ, 〈解説〉)
* two-file novel: still splits into 11
* synthetic single-file novel (ToC pointing only at itself): still splits into 3

The JS half was confirmed to reach the firmware by decompressing `FilesPageHtml.generated.h` and checking the new identifiers are present.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — Optimize EPUB is a fork feature.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none are touched.

## Additional Context

* **Memory / flash impact:** negligible; the page is gzipped into flash and the added JS is a few lines.
* **The threshold is a heuristic.** "ToC must reach at least the spine midpoint" separates the observed books with a wide margin (100% vs 29%), but it is calibrated on three real books, not derived. A book with a genuine ToC covering only its first half would be repaired unnecessarily — the failure mode is a cluttered ToC, not lost text.
* Only the source HTML and the Python tool are committed; the generated header is gitignored and rebuilt.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_