### PR TITLE
ci: install fatfs-ng too, the builder's other missing import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,15 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
-        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
-        # system site-packages while installing its own dependencies into a penv the builder
-        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        # The espressif32 builder imports `littlefs` and `fatfs` at module scope
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from system
+        # site-packages while installing its own dependencies into a penv the builder never sees.
+        # Without them every build and cppcheck job dies with ModuleNotFoundError. These are the
+        # only two: every other import in that builder is stdlib, platformio, SCons (a tool
+        # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python
+          uv pip install --system littlefs-python fatfs-ng
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -94,13 +96,15 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
-        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
-        # system site-packages while installing its own dependencies into a penv the builder
-        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        # The espressif32 builder imports `littlefs` and `fatfs` at module scope
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from system
+        # site-packages while installing its own dependencies into a penv the builder never sees.
+        # Without them every build and cppcheck job dies with ModuleNotFoundError. These are the
+        # only two: every other import in that builder is stdlib, platformio, SCons (a tool
+        # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python
+          uv pip install --system littlefs-python fatfs-ng
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -154,13 +158,15 @@ jobs:
           enable-cache: false
 
       - name: Install PlatformIO Core
-        # littlefs-python alongside the core: the espressif32 builder imports `littlefs`
-        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from
-        # system site-packages while installing its own dependencies into a penv the builder
-        # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
+        # The espressif32 builder imports `littlefs` and `fatfs` at module scope
+        # (platforms/espressif32/builder/main.py), and with --system PlatformIO runs from system
+        # site-packages while installing its own dependencies into a penv the builder never sees.
+        # Without them every build and cppcheck job dies with ModuleNotFoundError. These are the
+        # only two: every other import in that builder is stdlib, platformio, SCons (a tool
+        # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python
+          uv pip install --system littlefs-python fatfs-ng
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -32,7 +32,7 @@ jobs:
         # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python
+          uv pip install --system littlefs-python fatfs-ng
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Finish unblocking CI. #88 added `littlefs-python`; the next import surfaced behind it.
* **What changes are included?** Add `fatfs-ng` to the four `uv pip install --system` steps that run a build.

### The failure

```
ModuleNotFoundError: No module named 'fatfs'
```

Same shape as #88, same cause: the workflow installs PlatformIO with `--system`, so the builder runs from system site-packages while PlatformIO installs its own dependencies into a penv the builder never consults.

### Why this is the last one, not the next in a series

Rather than add a package per failed run, I enumerated the builder's imports. `platforms/espressif32/builder/main.py` imports exactly two third-party modules at module scope:

```python
from littlefs import LittleFS
from fatfs import Partition, RamDisk, create_extended_partition
from fatfs import create_esp32_wl_image
from fatfs.partition_extended import PartitionExtended
from fatfs.wrapper import pyf_mkfs, PY_FR_OK as FR_OK
```

Everything else across `builder/*.py` is stdlib, `platformio`, `SCons` (shipped as a tool package) or `semantic_version` (a PlatformIO core dependency). `fatfs-ng` provides `fatfs` — confirmed against a working local environment, which has `fatfs-ng` 0.1.15 and `littlefs-python` 0.18.0 installed exactly where the builder can see them.

### The standing alternative

As noted in #88: the structural fix is to drop `--system` so PlatformIO manages one environment consistently, rather than mirroring its dependencies into the system interpreter by hand. That is a larger change across every workflow. This PR keeps the current approach and completes it — with the import list above as the evidence that the set is now closed.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — CI configuration, not firmware.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none are touched.

## Additional Context

* **Memory / flash impact:** none. No firmware code changes.
* **Verification:** only CI can prove this — a local machine already has both packages, so the failure is not reproducible here.
* Blocks #89 and #87, which are failing on this and nothing else.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_