### PR TITLE
fix: font sizes change for English books (#81)

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -96,6 +96,12 @@ Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
+Version 75 is binary-identical to version 74. The version was bumped because a
+`font-size` on `<html>` or `<body>` is no longer applied to layout: it restates
+the base text size, and the reader's own font already *is* that base (every
+declaration resolves against it), so applying it sized whole books away from the
+user's setting. Pages cached by v74 hold the publisher-sized layout.
+
 Version 70 merges upstream's v35 change into the fork's format: the header
 gains a fifth `uint32_t` offset and a `uint32_t` entry per page for the
 visible-text offset LUT. The fork additionally appends a section-wide footnote

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -158,7 +158,10 @@ namespace {
 // v74: a negative text-indent is bounded by the left inset in force. A hanging indent whose
 //      paired margin-left was dropped (Book Margins off) drew the first line off the left edge
 //      of the screen with its first character clipped; cached pages hold those positions.
-constexpr uint8_t SECTION_FILE_VERSION = 74;
+// v75: a font-size on <html>/<body> is ignored -- it restates the base size, which IS the
+//      reader's own font here, so honouring it sized whole books off the user's setting.
+//      Cached pages hold the shrunken layout and its line positions.
+constexpr uint8_t SECTION_FILE_VERSION = 75;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -820,6 +820,19 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
   }
 
+  // A font-size on <html>/<body> is the book restating the size its body text should have --
+  // and that base is the READER's font here, because every font-size resolves against it
+  // (cssBlockFontId, ReaderFontScale.cpp) rather than against a fixed 16px. Applying a root
+  // declaration on top of a base it is itself describing multiplies the user's setting by the
+  // publisher's default: `body { font-size: 0.8em }` drags an entire book a ladder step (or two,
+  // since ties snap down) below the size they chose, and no declaration further in ever brings
+  // it back -- <p> inherits the root font through the block/inline style stack. Dropping it here
+  // costs nothing the book can express elsewhere: every nested font-size still applies, so
+  // headings, captions and small print keep their intended relationship to the body text.
+  if (strcasecmp(name, "body") == 0 || strcasecmp(name, "html") == 0) {
+    cssStyle.defined.fontSize = 0;
+  }
+
   // HTML dir attribute overrides CSS direction (case-insensitive per HTML spec)
   if (!dirAttr.empty()) {
     if (strcasecmp(dirAttr.c_str(), "rtl") == 0) {

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -92,7 +92,10 @@ void DictionaryWordSelectActivity::extractWords() {
       box.width = 0;  // measured below, once the advance table is ready
       box.row = rowCount;
       box.text = text;
-      box.fontId = lineFontId;
+      // An inline font-size (a <span> inside the block) overrides the block's font for this
+      // word alone, exactly as TextBlock::render resolves it. 0 = no override.
+      const int32_t wordFont = block->wordFont(i);
+      box.fontId = wordFont != 0 ? static_cast<int>(wordFont) : lineFontId;
       words.push_back(box);
       rowHasWords = true;
 
@@ -327,7 +330,10 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   snapshotIdx = saved ? selected : -1;
 
   renderer.fillRect(hx, hy, hw, hh, true);
-  renderer.drawText(fontId, word.x, word.y, word.text, false, word.style);
+  // word.fontId, NOT the reader's font: the box was measured with the font the page laid this
+  // word out in, so drawing it in a different size spills white glyphs past the black panel and
+  // over the neighbouring words (the page's own ink is only erased inside the box).
+  renderer.drawText(word.fontId, word.x, word.y, word.text, false, word.style);
   return saved;
 }
 
@@ -360,7 +366,8 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     // The full path's PrewarmScope cleared the glyph cache on exit; batch-load
     // just the highlighted word's glyphs before drawing them white-on-black.
     renderer.getFontCacheManager()->prewarmCache(
-        fontId, words[selected].text, static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
+        words[selected].fontId, words[selected].text,
+        static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
     if (drawHighlightWithSnapshot()) {
       drawHints();
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -38,17 +38,18 @@ class DictionaryWordSelectActivity final : public Activity {
     uint16_t row;
     const char* text;
     EpdFontFamily::Style style;
-    // The font the line was laid out with: a block carrying a CSS font-size is drawn with its
-    // own (larger) font, and measuring its words with the reader's font would size the
-    // highlight box for text that is not there.
+    // The font this word was laid out AND drawn with by the page: the block's own font when it
+    // carries a CSS font-size, or an inline font-size on the word itself. Measuring the box with
+    // one font and repainting the word with another sizes the highlight for text that is not
+    // there -- see drawHighlightWithSnapshot.
     int fontId;
   };
 
   enum class Popup : uint8_t { None, Busy, NotFound, Error };
 
   void extractWords();
-  // Hit-test / highlight height for a word: its own line height when the block carries a CSS
-  // font-size, the page's otherwise.
+  // Hit-test / highlight height for a word: the line height of its own font when CSS gave it
+  // one, the page's otherwise.
   int wordHeight(const WordBox& word) const;
   int closestInRow(uint16_t row, int centerX) const;
   int wordAt(int x, int y) const;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes #81 — on an English book (LOTR) the page text renders smaller than the reader font size setting, and looking a word up in the dictionary paints the highlighted word at a different size, spilling white glyphs over the neighbouring words.
* **What changes are included?** Two independent fixes for the two halves of that report.

### 1. The mangled highlight (the screenshot)

`DictionaryWordSelectActivity` measured the highlight box with the font the page laid the word out in (`:109`, the block's own font when its CSS sets `font-size`) but repainted the word with the reader's base font (`:330`). Larger glyphs, box sized for smaller ones → the tail of the word landed outside the black panel on untouched page, and the overspill wrote white pixels across the following words ("he was" in the issue's photo).

* draw with `word.fontId`, and prewarm that font on the differential repaint path rather than the base font
* `WordBox::fontId` now also picks up an inline `font-size` on the word itself (`TextBlock::wordFont`), which `TextBlock::render` honours (`TextBlock.cpp:303`) and the box measurement already assumed

### 2. The whole book rendering small

Every CSS `font-size` here resolves against the *reader's* font rather than a fixed 16px (`ReaderFontScale.cpp`), so the user's size setting is what `1em` means. A book that declares `body { font-size: 0.8em }` is describing that same base — applying it on top multiplies the user's choice by the publisher's default. The book then lays out a ladder step below the chosen size (two steps, since `snapToLadder` resolves ties downward), and nothing further in brings it back: a paragraph inherits the root font through the block/inline style stack.

A `font-size` on the **root element — html or body** — is now dropped at style resolution. Nested declarations are untouched, so headings, captions and small print keep their intended relationship to the body text.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. Both are bug fixes to existing reader behaviour; no new surface.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**Cache impact.** Fix 2 changes layout, so `SECTION_FILE_VERSION` 74 → 75 (byte layout unchanged; `SECTION_FILE_PARTIAL_VERSION` derives from it automatically). Every book re-lays out once on first open after flashing. `docs/file-formats.md` records the bump. `CSS_CACHE_VERSION` is untouched — the change is at style-application time, not parse time, so the stored rule maps stay valid.

**Memory / flash.** Measured on `default`: `develop` is 6,349,215 bytes, this branch 6,349,301 — **+86 bytes**. (An earlier revision of this description said +52 against an inferred baseline; that number was never built. See the comment below.) RAM 15.6%, flash 96.9%. No new allocations: fix 1 reads an existing per-word array, fix 2 clears a bit on a stack-local `CssStyle`.

**Vertical (tategaki) is unaffected.** The vertical engine keeps one cell size per column and `VerticalBlockStyle` carries no font size, so `VSECTION_FILE_VERSION` does not move.

**Verified:** `pio run -e default` clean, `bin/clang-format-fix` clean, and CI green on all seven checks. **Not tested on hardware** — worth checking on the page from the issue, plus one normal book to confirm nothing moved where the block font already equals the base font, and the highlight in a rotated orientation.

**Specific area to focus on:** whether dropping the root `font-size` outright is the behaviour you want, versus honouring it only when it scales *up*. Note the workaround it partly replaces — Embedded Style: Off — is all-or-nothing (it drops every rule plus inline style attributes), whereas this keeps the rest of the book's formatting.

The third commit merges `develop` in to pick up the CI fix from #92; the effective diff is still the five reader/doc files.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg