### PR TITLE
ci: install pyyaml too, the builder's next missing import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python fatfs-ng
+          uv pip install --system littlefs-python fatfs-ng pyyaml
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -104,7 +104,7 @@ jobs:
         # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python fatfs-ng
+          uv pip install --system littlefs-python fatfs-ng pyyaml
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4
@@ -166,7 +166,7 @@ jobs:
         # package) or semantic_version (a core dependency).
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python fatfs-ng
+          uv pip install --system littlefs-python fatfs-ng pyyaml
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -32,7 +32,7 @@ jobs:
         # never sees. Without it every build and cppcheck job dies with ModuleNotFoundError.
         run: |
           uv pip install --system -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
-          uv pip install --system littlefs-python fatfs-ng
+          uv pip install --system littlefs-python fatfs-ng pyyaml
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Unbreak CI. Every PlatformIO job currently fails ~17s in, before compiling a single file, on any branch.
* **What changes are included?** Adds `pyyaml` to the system Python install in all three `ci.yml` PlatformIO jobs (`cppcheck`, `Build default`, `Build sticky`) and in `release_candidate.yml`, which installs the same set.

```
ModuleNotFoundError: No module named 'yaml'
  builder/frameworks/component_manager.py, line 14: import yaml
```

The platform builder imports `yaml` at module load, but the workflows install only `pioarduino-core`, `littlefs-python` and `fatfs-ng`. `pyyaml` arrived transitively until now — the core is pinned by URL, its dependency *resolution* is not, and today's resolve (27 packages) no longer includes it. `develop`'s last run on 2026-08-09 was green, so this landed from upstream within the last three days and hits every new PR.

Same class as bb0f72f (`fatfs-ng`) and #88 (`littlefs-python`), so it follows that pattern: name the builder's import instead of relying on someone else's dependency tree.

**This should be the last one.** Every third-party import across `builder/*.py` and `builder/frameworks/*.py` is `SCons`, `click`, `requests`, `semantic_version`, `platformio`, `littlefs`, `fatfs`, `yaml` — everything else is stdlib. `click`/`requests`/`semantic_version` come with pioarduino-core, so with `pyyaml` added the set is complete.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. — CI-only, no firmware surface.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

Two lines of CI config; no firmware, no memory or flash impact. `release-fonts.yml` doesn't use PlatformIO and is untouched. This PR's own CI run is the verification — it carries the fix.

Split out of #91 at the author's request; #91 stays red until this merges into `develop`.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg)_