### PR TITLE
fix: draw the word-lookup highlight in the word's own font

### DIFF
--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -10,7 +10,6 @@
 #include <climits>
 #include <cstdlib>
 
-#include "CrossPointSettings.h"
 #include "DictionaryDefinitionActivity.h"
 #include "components/UITheme.h"
 
@@ -41,7 +40,6 @@ void indexBuildYield(void*) { vTaskDelay(1); }
 
 void DictionaryWordSelectActivity::onEnter() {
   Activity::onEnter();
-  fontId = SETTINGS.getReaderFontId();
   lineHeight = renderer.getLineHeight(fontId);
   // No null check: a failed allocation just disables the differential
   // fast path (drawHighlightWithSnapshot skips the read), keeping the
@@ -327,7 +325,11 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   snapshotIdx = saved ? selected : -1;
 
   renderer.fillRect(hx, hy, hw, hh, true);
-  renderer.drawText(fontId, word.x, word.y, word.text, false, word.style);
+  // word.fontId, not the page's base font: the box above was measured with the block's own
+  // font, and Page::render drew the word with it too. Drawing the highlight with the base
+  // font puts differently-sized text inside a box sized for the real one -- it overflows and
+  // is clipped by the next repaint (issue #81).
+  renderer.drawText(word.fontId, word.x, word.y, word.text, false, word.style);
   return saved;
 }
 
@@ -360,7 +362,8 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     // The full path's PrewarmScope cleared the glyph cache on exit; batch-load
     // just the highlighted word's glyphs before drawing them white-on-black.
     renderer.getFontCacheManager()->prewarmCache(
-        fontId, words[selected].text, static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
+        words[selected].fontId, words[selected].text,
+        static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
     if (drawHighlightWithSnapshot()) {
       drawHints();
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -17,11 +17,12 @@ class DictionaryWordSelectActivity final : public Activity {
  public:
   explicit DictionaryWordSelectActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                         std::unique_ptr<Page> page, int marginLeft, int marginTop,
-                                        std::string folderName)
+                                        std::string folderName, int baseFontId)
       : Activity("DictionaryWordSelect", renderer, mappedInput),
         page(std::move(page)),
         marginLeft(marginLeft),
         marginTop(marginTop),
+        fontId(baseFontId),
         folderName(std::move(folderName)) {}
 
   void onEnter() override;
@@ -60,6 +61,9 @@ class DictionaryWordSelectActivity final : public Activity {
   std::unique_ptr<Page> page;
   const int marginLeft;
   const int marginTop;
+  // The page's base font, as the reader laid it out: effectiveReaderFontId(), not the raw
+  // setting. A book whose script the selected family cannot carry is rendered with a
+  // substitute, and measuring the page here with the setting would disagree with the pixels.
   int fontId = 0;
   int lineHeight = 0;
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -471,10 +471,10 @@ void EpubReaderActivity::openDictionaryWordSelect() {
   orientedMarginTop += SETTINGS.screenMargin;
   orientedMarginLeft += SETTINGS.screenMargin;
 
-  startActivityForResult(
-      std::make_unique<DictionaryWordSelectActivity>(renderer, mappedInput, std::move(page), orientedMarginLeft,
-                                                     orientedMarginTop, std::move(dictionaryFolder)),
-      [this](const ActivityResult&) { requestUpdate(); });
+  startActivityForResult(std::make_unique<DictionaryWordSelectActivity>(
+                             renderer, mappedInput, std::move(page), orientedMarginLeft, orientedMarginTop,
+                             std::move(dictionaryFolder), effectiveReaderFontId()),
+                         [this](const ActivityResult&) { requestUpdate(); });
 }
 
 void EpubReaderActivity::loop() {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix #81: in the dictionary word-lookup overlay, the highlighted word is drawn in a different font from the one its highlight box was measured with, so it overflows the box and is clipped. It reads as the font size hopping between words on the same page.
* **What changes are included?**

`DictionaryWordSelectActivity` already stores a per-word font id, because a block carrying a CSS `font-size` is laid out and drawn with its own font rather than the reader's base font. The header documents exactly this. Everything honours it except the draw:

| Step | Font used | Correct? |
|---|---|---|
| measure width (`getTextAdvanceX`) | `word.fontId` | yes |
| highlight height (`wordHeight`) | `word.fontId` | yes |
| hit-testing (`wordAt`) | `word.fontId` | yes |
| page repaint (`Page::render`) | resolved per block internally | yes |
| **draw the highlighted word** | `fontId` (base) | **no** |
| **prewarm its glyphs** | `fontId` (base) | **no** |

Three changes:

1. `drawHighlightWithSnapshot()` draws with `word.fontId`. This is the visible bug.
2. The differential repaint path prewarms `word.fontId`, so a styled word no longer misses the glyph cache and fall back to per-glyph SD loads.
3. The base font is passed in from `EpubReaderActivity::effectiveReaderFontId()` instead of being re-derived from `SETTINGS.getReaderFontId()`. When the selected family cannot carry the book's script the reader substitutes another one; the overlay was measuring the page against a font that was never drawn. Passing it in means the two cannot drift.

Only blocks carrying CSS styling are affected, which is why it looks intermittent rather than constant.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No cache format change: this is a draw-time fix only, no layout or persisted structure is touched.
* Memory impact: none. One `int` added to the activity, no new allocation.
* Flash impact: negligible.
* Areas to focus on: the constructor gained a `baseFontId` parameter, so the member init order in the header was adjusted to match declaration order.
* Verification: build clean (`pio run`, default env). Needs a device check on a book with CSS-styled paragraphs, using the page from the issue.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
