### PR TITLE
feat: leave word lookup with the same power click that opens it

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -705,6 +705,7 @@ Reader menu → **Word Lookup**.
 | Left / Right | Move between matched words on the page |
 | Up / Down | Scroll a long definition |
 | Back | Return to reading |
+| Power (short click) | Return to reading, when **Short power button click** is set to **Word Lookup** |
 
 The header counts your position (e.g. 10/35). The page is pre-scanned, so you only ever land on a word the
 dictionary actually has.
@@ -716,7 +717,10 @@ between words and the front Left / Right buttons for scrolling. The default mapp
 In Reader Settings, **Word Lookup Font Size** offers Tiny, Small (default), Medium, and Large definition text.
 
 For one-press access, set **Settings → Controls → Short power button click** to **Word Lookup**. It then opens
-straight from the page, in both EPUBs and manga.
+straight from the page, in both EPUBs and manga — and closes it again: the same click steps back out of a
+definition and out of word selection, so a whole lookup happens under the index finger of the hand already
+holding the device. Back still works as before, and the click only does this while the setting is **Word
+Lookup** (the other settings keep the click for sleep, page turns, refresh or footnotes).
 
 ### 6.3 Page Translation
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -705,7 +705,7 @@ Reader menu → **Word Lookup**.
 | Left / Right | Move between matched words on the page |
 | Up / Down | Scroll a long definition |
 | Back | Return to reading |
-| Power (short click) | Return to reading, when **Short power button click** is set to **Word Lookup** |
+| Power (short click) | Go back, same as Back, when **Short power button click** is set to **Word Lookup** |
 
 The header counts your position (e.g. 10/35). The page is pre-scanned, so you only ever land on a word the
 dictionary actually has.

--- a/src/activities/reader/DictionaryDefinitionActivity.cpp
+++ b/src/activities/reader/DictionaryDefinitionActivity.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 
 #include "CrossPointSettings.h"
+#include "ReaderUtils.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/HtmlToPlainText.h"
@@ -159,7 +160,11 @@ void DictionaryDefinitionActivity::wrapText() {
 }
 
 void DictionaryDefinitionActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  // The power click steps back one screen, exactly like Back: from the definition to the word
+  // selection, and from there out to the page. Two clicks leave the dictionary entirely without
+  // the reading hand ever moving.
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
+      ReaderUtils::powerClickLeavesWordLookup(mappedInput)) {
     finish();
     return;
   }

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -12,6 +12,7 @@
 
 #include "CrossPointSettings.h"
 #include "DictionaryDefinitionActivity.h"
+#include "ReaderUtils.h"
 #include "components/UITheme.h"
 
 namespace {
@@ -250,7 +251,8 @@ void DictionaryWordSelectActivity::loop() {
 
   if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) confirmPressSeen = true;
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
+      ReaderUtils::powerClickLeavesWordLookup(mappedInput)) {
     finish();
     return;
   }

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -17,6 +17,7 @@
 #include "DefinitionTextRenderer.h"
 #include "Epub/Page.h"
 #include "MappedInputManager.h"
+#include "ReaderUtils.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -499,7 +500,8 @@ void EpubReaderWordLookupActivity::performLookupImpl() {
 }
 
 void EpubReaderWordLookupActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
+      ReaderUtils::powerClickLeavesWordLookup(mappedInput)) {
     ActivityResult result;
     result.isCancelled = true;
     setResult(std::move(result));

--- a/src/activities/reader/MangaWordLookupActivity.cpp
+++ b/src/activities/reader/MangaWordLookupActivity.cpp
@@ -13,6 +13,7 @@
 #include "CrossPointSettings.h"
 #include "DefinitionTextRenderer.h"
 #include "MappedInputManager.h"
+#include "ReaderUtils.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -295,7 +296,8 @@ void MangaWordLookupActivity::performLookupImpl() {
 }
 
 void MangaWordLookupActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
+      ReaderUtils::powerClickLeavesWordLookup(mappedInput)) {
     ActivityResult result;
     result.isCancelled = true;
     setResult(std::move(result));

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -134,6 +134,22 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
   return {prev, next, tiltPrev || tiltNext};
 }
 
+// A short power-button click closes the dictionary / word-lookup screens, but only when that same
+// click is what opens them (SHORT_PWRBTN::WORD_LOOKUP). The button sits under the holding hand's
+// index finger, so entering AND leaving with it is what makes the shortcut one-handed -- opening
+// with the power button and having to reach across for Back defeats the point.
+//
+// Left alone under every other shortPwrBtn value: Sleep, Page Turn, Force Refresh and Footnotes
+// each own the click elsewhere, and a lookup screen must not swallow it from them.
+//
+// Down is excluded for the same reason the open paths exclude it (EpubReaderActivity,
+// MangaReaderActivity): Power+Down is the screenshot combo, which must not also dismiss the very
+// screen it was pressed to capture.
+inline bool powerClickLeavesWordLookup(const MappedInputManager& input) {
+  return SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::WORD_LOOKUP &&
+         input.wasReleased(MappedInputManager::Button::Power) && !input.wasReleased(MappedInputManager::Button::Down);
+}
+
 struct TouchPageTurn {
   bool prev;
   bool next;

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -142,9 +142,10 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
 // Left alone under every other shortPwrBtn value: Sleep, Page Turn, Force Refresh and Footnotes
 // each own the click elsewhere, and a lookup screen must not swallow it from them.
 //
-// Down is excluded for the same reason the open paths exclude it (EpubReaderActivity,
-// MangaReaderActivity): Power+Down is the screenshot combo, which must not also dismiss the very
-// screen it was pressed to capture.
+// The Down term mirrors the open paths (EpubReaderActivity, MangaReaderActivity) exactly: a power
+// release that arrives in the SAME input update as a Down release is the Power+Down screenshot
+// combo being let go, not a request to leave, so the screen survives being screenshotted. Down held
+// on its own is not consulted -- only the two releases coinciding.
 inline bool powerClickLeavesWordLookup(const MappedInputManager& input) {
   return SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::WORD_LOOKUP &&
          input.wasReleased(MappedInputManager::Button::Power) && !input.wasReleased(MappedInputManager::Button::Down);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Closes #77. When **Short power button click** is set to **Word Lookup**, the click now closes the dictionary as well as opening it, so the whole lookup happens under the index finger of the hand already holding the device.
* **What changes are included?** A short power click leaves at every step of the lookup flow, plus the matching USER_GUIDE entries.

Today the shortcut is one-way: it opens the lookup from the page, but only Back closes it — and Back is a front button, so a shortcut whose entire point is the power button's position under the holding hand still forced the other hand across the device to get out again.

**Covered screens** — every activity the shortcut can land you in:

| Screen | Power click now does |
| --- | --- |
| `EpubReaderWordLookupActivity` (Japanese) | returns to the page |
| `MangaWordLookupActivity` | returns to the panel |
| `DictionaryWordSelectActivity` (Latin word selection) | returns to the page |
| `DictionaryDefinitionActivity` | steps back to the word selection, exactly as Back does — two clicks return to the page |

**Gating.** Only when `shortPwrBtn == WORD_LOOKUP`. Sleep, Page Turn, Force Refresh and Footnotes each own the click elsewhere, and a lookup screen must not swallow it from them. `Power+Down` is excluded, matching the open paths in `EpubReaderActivity` and `MangaReaderActivity`: that's the screenshot combo, and it must not dismiss the screen it was pressed to capture.

The predicate is one shared `ReaderUtils::powerClickLeavesWordLookup()` next to `detectPageTurn()`, which is where the reader's other power-click policy already lives, rather than the same three-term condition copy-pasted into four activities.

**No self-cancelling click.** `ActivityManager::loop()` calls `currentActivity->loop()` before it processes the pending push, so a newly opened lookup's first `loop()` runs on the *next* main iteration, after a fresh `gpio.update()` has cleared `releasedEvents` (`InputManager::update()`). The release that opens a screen can't also close it, and the release that closes one can't re-open it.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. This completes an existing fork shortcut rather than adding a surface: no new setting, no new menu item, no new activity.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**Memory / flash.** Measured on `default`: `develop` at `555c362` is 6,349,215 bytes, this branch is 6,349,113 — i.e. 102 bytes *smaller*. Adding four call sites cannot shrink the image; the delta is inlining/section-layout noise from the new `ReaderUtils.h` includes, so read it as "no meaningful flash change" rather than a saving. RAM unchanged at 15.6% (51,260 bytes). No allocation, no new state: the predicate reads two existing input edges and one settings byte.

**No new setting.** The issue asks for the shortcut to work both ways, not for a toggle, and #81's neighbour `pwrBtnFootnoteBack` shows the cost of one: it is defined, shown in Settings, and read by nothing outside `SettingsActivity`. Worth a separate look, but out of scope here.

**Docs.** USER_GUIDE §6.2 gains a Power row in the Word Lookup button table and a sentence on the round trip. `README.md` describes the feature, not its keybindings, so it needs no change.

**Verified:** `pio run -e default` clean, `bin/clang-format-fix` clean. **Not tested on hardware.** Worth checking: the round trip in a Japanese book, in a Latin book via the definition view, and in manga; that Power+Down still screenshots the lookup screen without closing it; and that with the setting on **Sleep** a held power button still sleeps from inside a lookup.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg)_