### PR TITLE
fix: honour the Quick-return from footnotes setting

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -269,7 +269,9 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   uint8_t uiTheme = LYRA;
   // Sunlight fading compensation
   uint8_t fadingFix = 0;
-  // Power button return from footnotes (1 = enabled, 0 = disabled)
+  // Power button return from footnotes (1 = enabled, 0 = disabled). Read by
+  // EpubReaderActivity::loop, and only meaningful while shortPwrBtn == FOOTNOTES -- which is also
+  // the only time either settings UI offers it.
   uint8_t pwrBtnFootnoteBack = 1;
   // Use book's embedded CSS styles for EPUB rendering (1 = enabled, 0 = disabled)
   uint8_t embeddedStyle = 1;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -779,7 +779,12 @@ void EpubReaderActivity::loop() {
   if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::FOOTNOTES &&
       mappedInput.wasReleased(MappedInputManager::Button::Power) &&
       !mappedInput.wasReleased(MappedInputManager::Button::Down)) {
-    if (footnoteDepth > 0) {
+    // Inside a footnote the click is REPURPOSED: instead of opening the panel again it jumps back
+    // to the reference it was read from. That repurposing is the whole of what
+    // pwrBtnFootnoteBack ("Quick-return from footnotes") names, so it is what the setting gates --
+    // switched off, the click keeps one meaning everywhere and opens the panel, and Back (handled
+    // above) remains the way out of a footnote.
+    if (footnoteDepth > 0 && SETTINGS.pwrBtnFootnoteBack) {
       restoreSavedPosition();
     } else {
       openFootnotesPanel();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make **Settings → Controls → Quick-return from footnotes** actually do something. It is a fully built setting that no code reads, so turning it off has never changed anything.
* **What changes are included?** One condition in `EpubReaderActivity::loop`, plus a comment on the field recording where it is read.

### The setting exists everywhere except in the behaviour

`pwrBtnFootnoteBack` is:

| Where | What it does today |
| --- | --- |
| `CrossPointSettings.h:273` | declared, defaults to `1` |
| `SettingsList.h:334` | registered → persisted in `settings.json`, exposed in the web settings API |
| `SettingsActivity.cpp:98` | shown on device, only while **Short power button click** is **Footnotes** |
| `SettingsPage.html:486` | same row shown/hidden in the web UI |
| 32 × `translations/*.yaml` | translated |
| **anywhere that branches on its value** | **nothing** |

The behaviour it names is unconditional at `EpubReaderActivity.cpp:779`: while `footnoteDepth > 0`, a short power click always calls `restoreSavedPosition()`. So a user who switches the toggle off gets the feature anyway — with no feedback that their choice was ignored.

`USER_GUIDE.md:318` already documents the intended behaviour ("Toggles on and off the quick return functionality from the footnotes. When the functionality it's active, a short press of the power button will act as the back button from the footnotes page"), so this was promised to users and never wired up. The docs need no change; the code now matches them.

### The fix

```cpp
if (footnoteDepth > 0 && SETTINGS.pwrBtnFootnoteBack) {
  restoreSavedPosition();
} else {
  openFootnotesPanel();
}
```

Inside a footnote the click is *repurposed* — instead of opening the panel it jumps back to the reference. That repurposing is the whole of what the setting names, so it is what the setting gates. Switched off, the click keeps one meaning everywhere and opens the panel (`openFootnotesPanel()` is safe from inside a footnote: it builds the current section's list and returns early when empty). Back still leaves a footnote either way — that path is handled a few lines above and is untouched.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. Nothing new is added — an existing setting starts working.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**No change at defaults.** The setting ships as `1`, which is exactly today's behaviour. The only users affected are those who already turned it off and saw nothing happen.

**Memory / flash.** 6,349,215 → 6,349,235 on `default`, **+20 bytes**. RAM unchanged (15.6%, 51,260 bytes) — the field was already allocated, it just wasn't read.

**The alternative was deleting it.** A dead setting costs a RAM byte, a settings-file key, two UI rows and 32 translated strings, so removing it is defensible. I implemented it instead because it is a real choice to want (a click that always opens the panel), the docs already describe it, and deleting a persisted key is the more opinionated call. Happy to flip to removal if you'd rather.

**Verified:** `pio run -e default` clean, `bin/clang-format-fix` clean. **Not tested on hardware.** Worth checking with **Short power button click** set to **Footnotes**, in a book with footnotes: with the toggle **on**, power inside a footnote returns to the reference (unchanged); with it **off**, power inside a footnote opens the footnote panel instead, and Back still returns.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg)_