### PR TITLE
fix: font sizes change for English books (#81)

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -96,6 +96,12 @@ Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
+Version 75 is binary-identical to version 74. The version was bumped because a
+`font-size` on `<html>` or `<body>` is no longer applied to layout: it restates
+the base text size, and the reader's own font already *is* that base (every
+declaration resolves against it), so applying it sized whole books away from the
+user's setting. Pages cached by v74 hold the publisher-sized layout.
+
 Version 70 merges upstream's v35 change into the fork's format: the header
 gains a fifth `uint32_t` offset and a `uint32_t` entry per page for the
 visible-text offset LUT. The fork additionally appends a section-wide footnote

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -158,7 +158,10 @@ namespace {
 // v74: a negative text-indent is bounded by the left inset in force. A hanging indent whose
 //      paired margin-left was dropped (Book Margins off) drew the first line off the left edge
 //      of the screen with its first character clipped; cached pages hold those positions.
-constexpr uint8_t SECTION_FILE_VERSION = 74;
+// v75: a font-size on <html>/<body> is ignored -- it restates the base size, which IS the
+//      reader's own font here, so honouring it sized whole books off the user's setting.
+//      Cached pages hold the shrunken layout and its line positions.
+constexpr uint8_t SECTION_FILE_VERSION = 75;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -820,6 +820,19 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
   }
 
+  // A font-size on <html>/<body> is the book restating the size its body text should have --
+  // and that base is the READER's font here, because every font-size resolves against it
+  // (cssBlockFontId, ReaderFontScale.cpp) rather than against a fixed 16px. Applying a root
+  // declaration on top of a base it is itself describing multiplies the user's setting by the
+  // publisher's default: `body { font-size: 0.8em }` drags an entire book a ladder step (or two,
+  // since ties snap down) below the size they chose, and no declaration further in ever brings
+  // it back -- <p> inherits the root font through the block/inline style stack. Dropping it here
+  // costs nothing the book can express elsewhere: every nested font-size still applies, so
+  // headings, captions and small print keep their intended relationship to the body text.
+  if (strcasecmp(name, "body") == 0 || strcasecmp(name, "html") == 0) {
+    cssStyle.defined.fontSize = 0;
+  }
+
   // HTML dir attribute overrides CSS direction (case-insensitive per HTML spec)
   if (!dirAttr.empty()) {
     if (strcasecmp(dirAttr.c_str(), "rtl") == 0) {

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -92,7 +92,10 @@ void DictionaryWordSelectActivity::extractWords() {
       box.width = 0;  // measured below, once the advance table is ready
       box.row = rowCount;
       box.text = text;
-      box.fontId = lineFontId;
+      // An inline font-size (a <span> inside the block) overrides the block's font for this
+      // word alone, exactly as TextBlock::render resolves it. 0 = no override.
+      const int32_t wordFont = block->wordFont(i);
+      box.fontId = wordFont != 0 ? static_cast<int>(wordFont) : lineFontId;
       words.push_back(box);
       rowHasWords = true;
 
@@ -327,7 +330,10 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   snapshotIdx = saved ? selected : -1;
 
   renderer.fillRect(hx, hy, hw, hh, true);
-  renderer.drawText(fontId, word.x, word.y, word.text, false, word.style);
+  // word.fontId, NOT the reader's font: the box was measured with the font the page laid this
+  // word out in, so drawing it in a different size spills white glyphs past the black panel and
+  // over the neighbouring words (the page's own ink is only erased inside the box).
+  renderer.drawText(word.fontId, word.x, word.y, word.text, false, word.style);
   return saved;
 }
 
@@ -360,7 +366,8 @@ void DictionaryWordSelectActivity::render(RenderLock&&) {
     // The full path's PrewarmScope cleared the glyph cache on exit; batch-load
     // just the highlighted word's glyphs before drawing them white-on-black.
     renderer.getFontCacheManager()->prewarmCache(
-        fontId, words[selected].text, static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
+        words[selected].fontId, words[selected].text,
+        static_cast<uint8_t>(1u << (static_cast<uint8_t>(words[selected].style) & 0x03)));
     if (drawHighlightWithSnapshot()) {
       drawHints();
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -10,7 +10,6 @@
 #include <climits>
 #include <cstdlib>
 
-#include "CrossPointSettings.h"
 #include "DictionaryDefinitionActivity.h"
 #include "components/UITheme.h"
 
@@ -41,7 +40,6 @@ void indexBuildYield(void*) { vTaskDelay(1); }
 
 void DictionaryWordSelectActivity::onEnter() {
   Activity::onEnter();
-  fontId = SETTINGS.getReaderFontId();
   lineHeight = renderer.getLineHeight(fontId);
   // No null check: a failed allocation just disables the differential
   // fast path (drawHighlightWithSnapshot skips the read), keeping the

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -17,11 +17,12 @@ class DictionaryWordSelectActivity final : public Activity {
  public:
   explicit DictionaryWordSelectActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                         std::unique_ptr<Page> page, int marginLeft, int marginTop,
-                                        std::string folderName)
+                                        std::string folderName, int baseFontId)
       : Activity("DictionaryWordSelect", renderer, mappedInput),
         page(std::move(page)),
         marginLeft(marginLeft),
         marginTop(marginTop),
+        fontId(baseFontId),
         folderName(std::move(folderName)) {}
 
   void onEnter() override;
@@ -61,6 +62,9 @@ class DictionaryWordSelectActivity final : public Activity {
   std::unique_ptr<Page> page;
   const int marginLeft;
   const int marginTop;
+  // The page's base font, as the reader laid it out: effectiveReaderFontId(), not the raw
+  // setting. A book whose script the selected family cannot carry is rendered with a
+  // substitute, and measuring the page here with the setting would disagree with the pixels.
   int fontId = 0;
   int lineHeight = 0;
 

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -38,17 +38,18 @@ class DictionaryWordSelectActivity final : public Activity {
     uint16_t row;
     const char* text;
     EpdFontFamily::Style style;
-    // The font the line was laid out with: a block carrying a CSS font-size is drawn with its
-    // own (larger) font, and measuring its words with the reader's font would size the
-    // highlight box for text that is not there.
+    // The font this word was laid out AND drawn with by the page: the block's own font when it
+    // carries a CSS font-size, or an inline font-size on the word itself. Measuring the box with
+    // one font and repainting the word with another sizes the highlight for text that is not
+    // there -- see drawHighlightWithSnapshot.
     int fontId;
   };
 
   enum class Popup : uint8_t { None, Busy, NotFound, Error };
 
   void extractWords();
-  // Hit-test / highlight height for a word: its own line height when the block carries a CSS
-  // font-size, the page's otherwise.
+  // Hit-test / highlight height for a word: the line height of its own font when CSS gave it
+  // one, the page's otherwise.
   int wordHeight(const WordBox& word) const;
   int closestInRow(uint16_t row, int centerX) const;
   int wordAt(int x, int y) const;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -471,10 +471,10 @@ void EpubReaderActivity::openDictionaryWordSelect() {
   orientedMarginTop += SETTINGS.screenMargin;
   orientedMarginLeft += SETTINGS.screenMargin;
 
-  startActivityForResult(
-      std::make_unique<DictionaryWordSelectActivity>(renderer, mappedInput, std::move(page), orientedMarginLeft,
-                                                     orientedMarginTop, std::move(dictionaryFolder)),
-      [this](const ActivityResult&) { requestUpdate(); });
+  startActivityForResult(std::make_unique<DictionaryWordSelectActivity>(
+                             renderer, mappedInput, std::move(page), orientedMarginLeft, orientedMarginTop,
+                             std::move(dictionaryFolder), effectiveReaderFontId()),
+                         [this](const ActivityResult&) { requestUpdate(); });
 }
 
 void EpubReaderActivity::loop() {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes #81 in full. On an English book (LOTR) the page text renders smaller than the reader font size setting, and looking a word up in the dictionary paints the highlighted word at a different size, spilling white glyphs over the neighbouring words.
* **What changes are included?** This supersedes and replaces **#91** and **#93**, which each fixed part of the issue and overlapped on two lines (they conflicted textually on the comments attached to those lines). Nothing is dropped: this is the union of both, with the shared lines resolved once. Three commits, one concern each.

### 1. The mangled highlight (the screenshot) — from #91 and #93

`DictionaryWordSelectActivity` measured the highlight box with the font the page laid the word out in, but repainted the word with the reader's base font. Larger glyphs, box sized for smaller ones → the tail of the word landed outside the black panel on untouched page, and the overspill wrote white pixels across the following words ("he was" in the issue's photo).

* draw with `word.fontId`, and prewarm that font on the differential repaint path rather than the base font
* `WordBox::fontId` now also picks up an inline `font-size` on the word itself (`TextBlock::wordFont`), which `TextBlock::render` honours and the box measurement already assumed

Everything in the overlay already honoured the per-word font except the draw:

| Step | Font used before | Font used now |
|---|---|---|
| measure width (`getTextAdvanceX`) | `word.fontId` | unchanged |
| highlight height (`wordHeight`) | `word.fontId` | unchanged |
| hit-testing (`wordAt`) | `word.fontId` | unchanged |
| page repaint (`Page::render`) | resolved per block internally | unchanged |
| **draw the highlighted word** | base `fontId` | **`word.fontId`** |
| **prewarm its glyphs** | base `fontId` | **`word.fontId`** |

### 2. The base font the overlay measures against — from #93

The base font is now passed in from `EpubReaderActivity::effectiveReaderFontId()` instead of being re-derived from `SETTINGS.getReaderFontId()` in `onEnter()`. When the selected family cannot carry the book's script the reader substitutes another one; the overlay was measuring the page against a font that was never drawn. This still matters after fix 1, because that base font remains the input to `resolveFontId`, `wordHeight` and both `page->render` calls. Passing it in means the two cannot drift.

### 3. The whole book rendering small — from #91

Every CSS `font-size` here resolves against the *reader's* font rather than a fixed 16px (`ReaderFontScale.cpp`), so the user's size setting is what `1em` means. A book that declares `body { font-size: 0.8em }` is describing that same base — applying it on top multiplies the user's choice by the publisher's default. The book then lays out a ladder step below the chosen size (two steps, since `snapToLadder` resolves ties downward), and nothing further in brings it back: a paragraph inherits the root font through the block/inline style stack.

A `font-size` on the **root element — html or body** — is now dropped at style resolution. Nested declarations are untouched, so headings, captions and small print keep their intended relationship to the body text.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. All three are bug fixes to existing reader behaviour; no new surface.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**Relationship to #91 and #93.** Both should be closed in favour of this one. The only textual conflict between them was the comment on `drawHighlightWithSnapshot`'s `drawText` call and its neighbouring prewarm call — identical code, two different explanations. #91's wording is kept. The `.h` changes from the two merged cleanly (they touch different regions: #91 the `WordBox` doc comments, #93 the constructor and the `fontId` member).

**Cache impact.** Fix 3 changes layout, so `SECTION_FILE_VERSION` 74 → 75 (byte layout unchanged; `SECTION_FILE_PARTIAL_VERSION` derives from it automatically). Every book re-lays out once on first open after flashing. `docs/file-formats.md` records the bump. `CSS_CACHE_VERSION` is untouched — the change is at style-application time, not parse time, so the stored rule maps stay valid.

**Memory / flash.** No new allocations: fix 1 reads an existing per-word array, fix 2 adds one `int` to the activity and removes a settings read, fix 3 clears a bit on a stack-local `CssStyle`. #91 measured at **+86 bytes** of flash against `develop`; #93's own contribution is negligible, so expect the combined figure to land in the same place. **The combined branch has not been built here** — this container has no PlatformIO and no clang-format 21, so both are left to CI. Each source branch built clean on its own and the merge is a textual union plus one comment choice, but treat the build as CI-verified rather than locally verified.

**Vertical (tategaki) is unaffected.** The vertical engine keeps one cell size per column and `VerticalBlockStyle` carries no font size, so `VSECTION_FILE_VERSION` does not move.

**Not tested on hardware.** Worth checking on the page from the issue, plus one normal book to confirm nothing moved where the block font already equals the base font, and the highlight in a rotated orientation.

**Specific area to focus on:** whether dropping the root `font-size` outright is the behaviour you want, versus honouring it only when it scales *up*. Note the workaround it partly replaces — Embedded Style: Off — is all-or-nothing (it drops every rule plus inline style attributes), whereas this keeps the rest of the book's formatting. If that one call is contentious, it is isolated in commit 2 of 3 (`fix: keep the reader's font size when a book styles <body>`) and can be dropped without touching the overlay fixes.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxvPinQu56wh5qb2uumjtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxvPinQu56wh5qb2uumjtS)_