### PR TITLE
fix: decode progressive JPEGs whose DC scan is non-interleaved

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -838,7 +838,7 @@ Worth knowing before you read too much into them.
 Please note that this firmware is currently in active development. The following features are **not yet supported** but are planned for future updates:
 
 * **Cover Images:** Large cover images embedded into EPUB require several seconds (~10s for ~2000 pixel tall image) to convert for sleep screen and home screen thumbnail. Consider optimizing the EPUB with e.g. https://github.com/bigbag/epub-to-xtc-converter to speed this up.
-* **Unsupported Image Formats:** Most JPG and PNG images in EPUBs render correctly. GIFs and progressive JPEGs are not supported and will fall back to an `[Image]` placeholder.
+* **Unsupported Image Formats:** Most JPG and PNG images in EPUBs render correctly. GIFs are not supported and fall back to an `[Image]` placeholder. Progressive JPEGs do render, but only their DC coefficients are decoded — a preview at one-eighth resolution, scaled back up, so fine detail is lost. The one variant that is refused outright is a progressive JPEG that both splits its DC coefficients across one scan per component *and* uses chroma subsampling; re-encode those as baseline (`jpegtran -copy none -optimize`, or run the page through the manga converter).
 * 
 * **Dictionary Lookup:** Inline word lookup is not yet implemented.
 

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -4,6 +4,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <JPEGDEC.h>
+#include <JpegDecodeError.h>
 #include <Logging.h>
 #include <Memory.h>
 
@@ -575,7 +576,8 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
     if (ctx.cancelled) {
       LOG_DBG("JPG", "Decode cancelled: %s", imagePath.c_str());
     } else {
-      LOG_ERR("JPG", "Decode failed (rc=%d, lastError=%d)", rc, jpeg->getLastError());
+      const int err = jpeg->getLastError();
+      LOG_ERR("JPG", "Decode failed (rc=%d, lastError=%d): %s", rc, err, jpegDecodeErrorText(err));
     }
     if (ctx.caching) ctx.cache.abort();
     return false;

--- a/lib/JpegToBmpConverter/JpegDecodeError.h
+++ b/lib/JpegToBmpConverter/JpegDecodeError.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <JPEGDEC.h>
+
+// JPEGDEC reports every failure as a small integer, and the ones that occur on this device mean
+// very different things. `Decode failed (rc=0, lastError=2)` reads like memory pressure, which is
+// what sent the last investigation looking at the heap for a file that was simply an unusual --
+// and, until the JPEGDEC patches, unsupported -- progressive layout (issue #16).
+//
+// Lives here rather than beside either caller because both converters need it: the framebuffer
+// one in lib/Epub/Epub/converters (which already includes this lib) and JpegToBmpConverter itself.
+//
+// Every return is a string literal, so the text is flash-resident, costs no allocation, and is
+// safe to hand straight to LOG_ERR.
+inline const char* jpegDecodeErrorText(const int err) {
+  switch (err) {
+    case JPEG_SUCCESS:
+      return "success";
+    case JPEG_INVALID_PARAMETER:
+      return "invalid parameter";
+    case JPEG_DECODE_ERROR:
+      // The catch-all: corrupt data, a truncated file, or a bitstream this decoder walked out of
+      // step with. NOT an out-of-memory condition, which is what the bare number suggested.
+      return "corrupt or truncated JPEG data";
+    case JPEG_UNSUPPORTED_FEATURE:
+      // Reachable via the 0003 patch, which refuses the one layout it cannot traverse: a
+      // progressive JPEG whose DC scan is split per component AND which is chroma-subsampled.
+      // Name the remedy here -- it is the whole difference between a two-minute fix and the
+      // investigation in issue #16.
+      return "unsupported JPEG variant (progressive, split DC scan, chroma subsampled) -- "
+             "re-encode baseline, e.g. jpegtran -copy none -optimize";
+    case JPEG_INVALID_FILE:
+      return "not a JPEG file";
+    default:
+      return "unknown error";
+  }
+}

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -3,6 +3,7 @@
 #include <HalDisplay.h>
 #include <HalStorage.h>
 #include <JPEGDEC.h>
+#include <JpegDecodeError.h>
 #include <Logging.h>
 #include <Memory.h>
 #include <freertos/FreeRTOS.h>
@@ -755,7 +756,8 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
   }
 
   if (rc != 1 || ctx.error) {
-    LOG_ERR("JPG", "JPEG decode failed (rc=%d, err=%d)", rc, jpeg->getLastError());
+    const int err = jpeg->getLastError();
+    LOG_ERR("JPG", "JPEG decode failed (rc=%d, err=%d): %s", rc, err, jpegDecodeErrorText(err));
     return false;
   }
 

--- a/scripts/jpegdec_patches/0003-decode-non-interleaved-dc-scans.patch
+++ b/scripts/jpegdec_patches/0003-decode-non-interleaved-dc-scans.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: patch <patch@local>
+Date: Thu, 13 Aug 2026 07:10:00 +0000
+Subject: [PATCH 3/3] Decode progressive JPEGs whose DC scan is non-interleaved
+
+A progressive JPEG may split its DC coefficients into one scan per component
+(SOS with a single component, Ss=0 Se=0) instead of one interleaved scan.
+MozJPEG and most web optimizers emit that layout, so it is common in scanned
+and ripped material -- see crosspoint issue #16.
+
+The MCU loop in DecodeJPEG always reads a Y block followed by two chroma
+blocks per MCU. In a non-interleaved scan the chroma bits are simply not
+there, so those two reads consume bits belonging to the following Y blocks;
+the bitstream desynchronizes and the next Huffman lookup fails, reported as a
+bare JPEG_DECODE_ERROR.
+
+Skip the chroma reads for such a scan. Without subsampling the component's
+block grid is the MCU grid, so the existing traversal is already correct once
+the extra reads are gone. Subsampled images (where a 2x2 MCU holds four Y
+blocks but the scan is raster order over the component) and non-luma output
+are refused with JPEG_UNSUPPORTED_FEATURE rather than rendered scrambled.
+---
+diff --git a/src/jpeg.inl b/src/jpeg.inl
+index 1bd38b2..2c59c58 100644
+--- a/src/jpeg.inl
++++ b/src/jpeg.inl
+@@ -5067,6 +5067,29 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
+     iLum2 = MCU2;
+     iLum3 = MCU3;
+     iErr = 0;
++    // CrossPoint patch: a progressive JPEG may carry its DC coefficients in one scan PER
++    // COMPONENT rather than a single interleaved scan (SOS with one component, Ss=0, Se=0).
++    // MozJPEG and most web optimizers emit that layout, so it is common in ripped material.
++    // The MCU loop below always reads a Y block and then two chroma blocks per MCU; in a
++    // non-interleaved scan those two extra reads consume bits belonging to the FOLLOWING Y
++    // blocks. The bitstream desynchronizes and the next Huffman lookup fails, which surfaced
++    // as a bare JPEG_DECODE_ERROR that names nothing.
++    //
++    // Without subsampling the component's block grid IS the MCU grid -- cx/cy are computed as
++    // (width+7)>>3 for 0x00/0x01/0x11 above and mcuCX/mcuCY are 8 -- so decoding one block per
++    // MCU and skipping the chroma reads is exactly the right traversal. Under subsampling the
++    // two orders diverge (a 2x2 MCU holds four Y blocks, while the scan is raster order over
++    // the whole component), so that combination is refused rather than rendered scrambled.
++    //
++    // Luma-only output only: chroma is never read here, and JPEGPutMCU8BitGray uses the Y MCU
++    // alone. A colour caller would otherwise compose against stale chroma blocks.
++    const int bNonInterleavedDC = (pJPEG->ucMode == 0xc2 && pJPEG->ucComponentsInScan == 1 &&
++                                   pJPEG->ucNumComponents > 1);
++    if (bNonInterleavedDC && (pJPEG->ucSubSample > 0x11 || pJPEG->ucPixelType < EIGHT_BIT_GRAYSCALE))
++    {
++        pJPEG->iError = JPEG_UNSUPPORTED_FEATURE;
++        return 0;
++    }
+     pJPEG->iResCount = pJPEG->iResInterval;
+     // Calculate how many MCUs we can fit in the pixel buffer to maximize LCD drawing speed
+     iMCUCount = MAX_BUFFERED_PIXELS / (mcuCX * mcuCY);
+@@ -5227,7 +5250,9 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
+                     }
+                 } // if 2:2 subsampling
+             } // if subsampling used
+-            if (pJPEG->ucSubSample && pJPEG->ucNumComponents == 3) // if color (not CMYK)
++            // CrossPoint patch: a non-interleaved DC scan carries no chroma bits at all, so these
++            // reads must not happen -- see bNonInterleavedDC above.
++            if (pJPEG->ucSubSample && pJPEG->ucNumComponents == 3 && !bNonInterleavedDC) // if color (not CMYK)
+             {
+                 // first chroma
+                 pJPEG->ucACTable = cACTable1;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Closes #16 — the reported Kagurabachi cover (and any MozJPEG-style progressive JPEG) now decodes instead of failing with `Decode failed (rc=0, lastError=2)`.
* **What changes are included?** The real fix from the issue's list (option 4) as JPEGDEC patch `0003`, plus option 1 (a legible error) for the one variant still refused.

### The failing layout

Confirmed on the attached file: `SOF2 1500x2250`, 4:4:4, 14 scans, the first three being **single-component DC scans**.

```
scan  0: 1 comp [1] Ss=0 Se=0 Al=0   <- Y  DC
scan  1: 1 comp [2] Ss=0 Se=0 Al=0   <- Cb DC
scan  2: 1 comp [3] Ss=0 Se=0 Al=0   <- Cr DC
scan  3+: AC refinements
```

`DecodeJPEG`'s MCU loop always reads a Y block and then two chroma blocks per MCU. In a non-interleaved scan those chroma bits **are not there**, so the two extra reads consume bits belonging to the *following* Y blocks. The bitstream desynchronizes and the next Huffman lookup fails — reported as a bare `JPEG_DECODE_ERROR`, which reads like memory pressure and is why the original investigation went looking at a heap that was fine.

### The fix

Skip those reads for a non-interleaved scan. **No new geometry is needed:** without subsampling the component's block grid *is* the MCU grid (`cx`/`cy` are `(width+7)>>3` and `mcuCX`/`mcuCY` are 8 for `0x00`/`0x01`/`0x11`), so the existing traversal is already correct once the stolen reads are gone.

Two cases are refused rather than rendered wrong, with `JPEG_UNSUPPORTED_FEATURE`:

- **subsampled** split-DC — a 2×2 MCU holds four Y blocks while the scan is raster order over the whole component, so the orders genuinely diverge;
- **non-luma output** — chroma is never decoded here, and `JPEGPutMCU8BitGray` reads the Y MCU alone, so a colour caller would compose against stale chroma.

Both were failing before this PR too; they now fail *legibly*.

## Verification

The device can't be tested from here, so I built a **host harness** from the vendored JPEGDEC plus all three patches and ran the real file through the same `EIGHT_BIT_GRAYSCALE` / `JPEG_SCALE_EIGHTH` path the firmware uses.

| File | Before | After |
|---|---|---|
| **reported cover** (4:4:4 split DC) | `rc=0 lastError=2` | `rc=1`, 188×282 |
| baseline 4:2:0 | ok | **byte-identical** |
| progressive interleaved DC | ok | **byte-identical** |
| grayscale baseline | ok | **byte-identical** |
| grayscale progressive | ok | **byte-identical** |
| progressive 4:4:4 | ok | **byte-identical** |
| MozJPEG-optimized 4:2:0 | ok | **byte-identical** |

The decoded preview is the right image, not a scrambled one: against a Pillow reference box-downscaled to 188×282, **mean \|diff\| 7.5, RMSE 16.0**, which is the expected gap between a DC-only decode (each DC *is* the block mean) and a full decode. Visually identical side by side.

Build integration: reset `.pio/libdeps/.../JPEGDEC` to pristine and rebuilt — the pre-script picks the new patch up automatically (it globs `*.patch` sorted) and applies all three in order; each is correctly detected as already-applied on the next build.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. It fixes an existing decode path; no new surface.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**Transient failure is not persisted** (the issue asks for this explicitly) — and no change was needed: `MangaPanel::generateThumbBmp` removes the partial thumb and returns false, and `HomeActivity` writes `coverBmpPath` only on success. A refused page retries on the next open instead of becoming a permanent "no cover".

**Memory / flash.** 6,349,215 → 6,349,693 on `default`, **+478 bytes**, almost all of it the new error strings (flash-resident literals). RAM unchanged at 15.6%. The decoder patch adds one stack local and removes work; the flag is a local, not a new `JPEGIMAGE` field, so the decoder struct doesn't grow.

**Left for follow-ups** (issue options 2 and 3, both separable): a cover fallback to a later page when page 0 won't decode, and `convert_manga.py` re-encoding progressive input even when it doesn't resize. Say the word and I'll do either.

**Not tested on hardware.** Worth checking the reported book end to end: cover in Library and on Home, thumbnail, and the full-page view.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg)_