### PR TITLE
fix: re-encode progressive pages the manga converter would copy through

### DIFF
--- a/tools/manga_convert/convert_manga.py
+++ b/tools/manga_convert/convert_manga.py
@@ -1278,6 +1278,14 @@ def main():
             print(f"[{page_idx + 1}/{len(pages)}] {os.path.basename(src_path)}")
 
             img = Image.open(src_path)
+            # Re-encoding is a SIDE EFFECT of resizing here -- Pillow's JPEG writer emits baseline
+            # -- and that is the only reason running a book through this script fixes a
+            # progressive page the device decodes poorly or not at all (issue #16). A page that
+            # already fits the target is copied through verbatim below and keeps whatever encoding
+            # it arrived with, so a progressive JPEG small enough to skip the resize stays
+            # progressive even though the user passed --x4 precisely to avoid that. Note it here,
+            # while `img` is still the file as opened.
+            src_is_progressive = bool(img.info.get("progressive") or img.info.get("progression"))
             # Downscale FIRST, before panel detection: every coordinate downstream (panel boxes,
             # crop rects, OCR text boxes, the page dims in panels.idx) then lives in the resized
             # space, matching the page/crop files actually written -- nothing needs rescaling.
@@ -1309,9 +1317,14 @@ def main():
                     img.convert("RGB").save(
                         os.path.join(args.output_dir, f"page_{page_idx:04d}{ext}"), "JPEG", quality=92
                     )
-                elif was_resized:
+                elif was_resized or src_is_progressive:
                     # Resized: the source file no longer matches -- re-encode in the source's own
                     # format so the output keeps its extension (PNG stays PNG, JPEG stays JPEG).
+                    # Progressive: the bytes still match, but re-encode anyway so the page lands on
+                    # the device as baseline. The firmware decodes progressive JPEGs from their DC
+                    # coefficients alone -- a one-eighth-resolution preview scaled back up -- and
+                    # refuses the subsampled split-DC variant outright, so passing one through
+                    # costs detail at best and the whole page at worst.
                     if ext == ".png":
                         img.save(os.path.join(args.output_dir, f"page_{page_idx:04d}{ext}"), "PNG", optimize=True)
                     else:


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Close the converter gap named in #16 (its option 3): `convert_manga.py` passes a progressive JPEG through unchanged when the page already fits the screen, so `--x4` doesn't actually make that page decodable.
* **What changes are included?** One condition in `convert_manga.py`, plus the comment explaining why re-encoding is load-bearing rather than incidental.

### The gap

Re-encoding is a **side effect of resizing**, not a goal. Pillow's JPEG writer emits baseline, so any page that gets downscaled lands on the device as baseline — which is the only reason "run the book through the converter" works as the standing workaround for #16.

```python
was_resized = img.size != orig_size
...
elif was_resized:
    img.convert("RGB").save(..., "JPEG", quality=92)   # re-encodes → baseline
else:
    shutil.copy(src_path, ...)                          # verbatim bytes → stays progressive
```

`fit_to_device` returns the image untouched when it already fits (`--x4` box is 480×800, `--x3` 528×792, swapped for landscape pages), `was_resized` is `False`, and the page is byte-copied. A progressive JPEG that arrives already small enough stays progressive — precisely the thing the user ran the converter to prevent.

### The fix

```python
elif was_resized or src_is_progressive:
```

with the flag read from `img.info` right after `Image.open`, while `img` is still the file as opened.

## Verification

Ran the real script over a three-page folder — a progressive page that already fits, a baseline page that already fits, and a progressive page that gets resized — on `develop` and on this branch:

| page | input | before (`develop`) | after |
|---|---|---|---|
| `page_0000` | progressive, 400×600 (fits) | **progressive** ← the gap | **baseline** |
| `page_0001` | baseline, 400×600 (fits) | baseline | baseline, still **byte-identical** to source |
| `page_0002` | progressive, 1000×1500 (resized) | baseline | baseline |

Nothing is re-encoded that didn't need to be: the baseline page that already fits is still a verbatim copy, confirmed with `cmp` against its source.

**What it costs on device**, measured by running both `page_0000` files through a host build of the firmware's JPEGDEC decode path:

```
before (develop): decode rc=1 out=50x75     <- DC-only preview, scaled back up for display
after  (this PR): decode rc=1 out=400x600   <- full decode
```

64× the pixels for the same page. And for the subsampled split-DC variant — which the firmware refuses outright, before or after #97 — the copy-through costs the whole page rather than its detail.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. Host-side tooling only; no firmware surface.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — not touched.

## Additional Context

**No firmware impact**: `tools/` only, so no flash or RAM change and nothing to rebuild.

**Independent of #97.** That one teaches the device to decode the split-DC layout; this one stops the converter handing it undecodable — or needlessly low-detail — pages in the first place. Either can land without the other.

**A twin I did not fix.** The same `shutil.copy` branch also passes interlaced PNGs through, and `png.inl:621` refuses them with `PNG_UNSUPPORTED_FEATURE`, so they fail on device exactly like split-DC JPEGs. I left it out because I could not test it: Pillow reports no `interlace` key on read and cannot write interlaced PNGs, so I could neither detect the condition through the API already in use nor produce a sample to verify against. Doing it properly means reading the IHDR interlace byte (file offset 28, the same byte `png.inl` reads) and a test fixture built by something other than Pillow. Happy to take it as a follow-up.

**The web tool** (`matcha-reader-tools`) has its own converter and would need the same change separately.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfksy75MvQ1HpyE1hUYjKg)_