### PR TITLE
fix: stop scanning DictIndex's folder for StarDict dictionaries

### DIFF
--- a/src/util/DictionaryRegistry.cpp
+++ b/src/util/DictionaryRegistry.cpp
@@ -17,6 +17,18 @@ namespace {
 // see FileBrowserActivity's showHiddenFiles check).
 constexpr const char* DICT_ROOTS[] = {"/dictionaries", "/.dictionaries"};
 
+// /dictionaries/jp belongs to DictIndex (the Japanese lookup path), not to StarDict: it holds
+// vocab, names and grammar .idx+.dat side by side, at the fixed paths DictIndex.h declares.
+// Three stems in one folder is exactly what findStem() calls ambiguous, so probing it logged a
+// "multiple index stems" skip on every scan -- a correct outcome reported as a fault, for a
+// folder that was never a StarDict dictionary. Japanese does not use StarDict at all, so the
+// folder itself is never a dictionary this registry should return.
+//
+// Only the folder ITSELF is DictIndex's. StarDict dictionaries nested inside it
+// (/dictionaries/jp/<name>/) are still discovered, and folderForLanguage() resolves "ja" to
+// exactly that "jp/" prefix.
+bool isDictIndexFolder(const char* folderName) { return strcmp(folderName, "jp") == 0; }
+
 std::string languageFolder(const std::string& language) {
   if (language.size() < 2) return {};
   std::string out = language.substr(0, 2);
@@ -86,7 +98,8 @@ void discover(std::vector<DictionaryEntry>& out) {
 
       std::string folderPath = std::string(dictRoot) + "/" + name;
       std::string stem;
-      if (findStem(folderPath.c_str(), stem)) {
+      // Skipped as a dictionary in its own right, still descended into below for nested ones.
+      if (!isDictIndexFolder(name) && findStem(folderPath.c_str(), stem)) {
         out.push_back({name, std::move(stem)});
         continue;
       }
@@ -113,6 +126,10 @@ bool resolveBasePath(const char* folderName, std::string& basePathOut) {
   if (folderName[0] == '.' || strpbrk(folderName, "\\") != nullptr || strstr(folderName, "..") != nullptr) return false;
   const char* slash = strchr(folderName, '/');
   if (slash && (slash == folderName || slash[1] == '\0' || strchr(slash + 1, '/'))) return false;
+  // Never resolvable as StarDict (see isDictIndexFolder); returning early keeps a stale settings
+  // value naming it from re-logging the ambiguous-stem skip on every lookup. Nested "jp/<name>"
+  // still resolves -- only the bare folder is DictIndex's.
+  if (isDictIndexFolder(folderName)) return false;
 
   for (const char* dictRoot : DICT_ROOTS) {
     std::string folderPath = std::string(dictRoot) + "/" + folderName;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop `DictionaryRegistry` from scanning `/dictionaries/jp` — DictIndex's folder — as though it were a StarDict dictionary, and with it the misleading log line that scan produces on every boot.
* **What changes are included?** A one-folder exclusion in `DictionaryRegistry`, plus the reasoning recorded next to it.

### The message

```
[DBG] [DREG] Skipping /dictionaries/jp: multiple index stems found
```

`/dictionaries/jp` belongs to **DictIndex**, the Japanese lookup path, at the fixed paths [DictIndex.h:56-75](../blob/develop/lib/Dict/DictIndex.h#L56) declares:

```
/dictionaries/jp/vocab.idx     (legacy: jmdict.idx)
/dictionaries/jp/names.idx     (legacy: jmnedict.idx)
/dictionaries/jp/grammar.idx
```

Three distinct `.idx` stems, by design. StarDict expects exactly one stem per folder, so `findStem()` sees three, correctly refuses to guess which is meant, and skips the folder.

**The skip is right; reporting it as an anomaly is not.** Nothing is broken — Japanese lookups go through `DictIndex`, which uses those fixed paths and never consults this registry, and Japanese does not use StarDict at all. But a log line saying a dictionary folder was *skipped* reads as a broken dictionary, and cost real debugging time in exactly that way.

### The fix

- `discover()` leaves the folder itself alone, while **still descending into it**. Nested `/dictionaries/jp/<name>/` StarDict dictionaries are discovered exactly as before — that nesting is what `folderForLanguage()` resolves `"ja"` to, via the `jp/` prefix.
- `resolveBasePath()` returns false for the bare folder, so a stale `dictionaryName` in `settings.json` naming it cannot re-trigger the same log on every lookup.

Scoped to the one folder that is actually owned elsewhere. Any other folder with two stems still reports as ambiguous, which is a genuine misconfiguration worth surfacing.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **No behaviour change for any working dictionary.** The folder was already being skipped; this stops the pointless probe and the log it emitted. StarDict dictionaries elsewhere, and nested under `jp/`, are unaffected.
* **Memory / flash:** negligible. One `strcmp` per top-level folder per scan, no allocation.
* **Verified:** `pio run -e default` clean, `clang-format` clean. Device check: the `DREG` line should be gone from the boot log, with Japanese lookup still working.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
