### PR TITLE
feat: collapse coverage-variant fonts into the family they widen

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -586,6 +586,8 @@ There are three ways to install fonts:
 
 Once installed, custom fonts appear in **Settings → Reader → Font Family** alongside the built-in fonts.
 
+A font that only widens another one's character coverage does not get its own row. `NotoSerifExtended` is Noto Serif plus Greek, Cyrillic and phonetic characters, so it is folded into the **Noto Serif** entry rather than listed beside it; the same applies to any `…Extended` or `…IPA` font whose base font is present. Selecting the single row gives you the widest version installed, except in a Japanese book, where the base font is paired with the Japanese font instead — only one SD font is ever held in memory at a time. A variant whose base font is *not* installed keeps its own row, so its characters are always reachable.
+
 See [docs/sd-card-fonts.md](./docs/sd-card-fonts.md) for full installation details and SD card folder structure.
 
 ---

--- a/docs/sd-card-fonts.md
+++ b/docs/sd-card-fonts.md
@@ -13,6 +13,8 @@ There are three ways to install fonts:
 2. Go to **Settings > System > Manage Fonts**
 3. Browse available font families and tap to download
 4. Downloaded fonts appear immediately in **Settings > Reader > Font Family**
+   (see [Coverage variants](#coverage-variants) for the families that share a
+   row with the font they widen)
 
 ### Option 2: Upload via web browser
 
@@ -51,6 +53,35 @@ There are three ways to install fonts:
                └── ...
 
 3. Insert the SD card and power on your CrossPoint reader
+
+## Coverage variants
+
+Some families exist only to widen another family's character set:
+`NotoSerifExtended` is Noto Serif plus Greek, Cyrillic and the phonetic block,
+and a `…IPA` cut adds the phonetic block alone. Listing them next to the family
+they widen puts the same typeface on the font list twice, so they are folded
+into the base row instead — one typeface, one entry.
+
+A family is treated as a variant when its name is another family's name plus
+`Extended` or `IPA`, **and** that base family exists: either a built-in
+(`NotoSerif`, `NotoSans`) or another family installed on the card. A variant
+whose base is not installed keeps its own row, so hiding a row can never put
+its characters out of reach.
+
+Which of the two is loaded depends on the book:
+
+| Book | Reader font | SD fonts resident |
+| --- | --- | --- |
+| Latin, Greek, Cyrillic, phonetic | the variant | 1 (the variant) |
+| Japanese | the base, paired with the Japanese font | 1 (the Japanese font) |
+
+Japanese books take the base because the Japanese companion font already
+carries their text; standing the variant in as well would mean two resident SD
+fonts, which does not reliably fit the ESP32-C3 heap.
+
+The selection stored in settings always names the base — the substitution is
+made at load time, so moving the card to a device without the variant simply
+falls back to the base.
 
 ## CJK in the User Interface
 

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -372,8 +372,10 @@ int CrossPointSettings::getBuiltinSerifReaderFontId() const {
 }
 
 int CrossPointSettings::getReaderFontId() const {
-  // Check SD card font first
-  if (sdFontFamilyName[0] != '\0' && sdFontIdResolver) {
+  // Asked unconditionally, not just when an SD family is named: a built-in selection whose
+  // picker row collapsed a wider-coverage variant (NotoSerif + NotoSerifExtended) resolves to
+  // that variant, and the resolver answers 0 when nothing stands in.
+  if (sdFontIdResolver) {
     int id = sdFontIdResolver(sdFontResolverCtx, sdFontFamilyName, fontPointSize);
     if (id != 0) return id;
   }

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -17,6 +17,17 @@
 
 namespace {
 
+// Family names are compared case- and separator-insensitively: the same face reaches us as
+// "NotoSansJP", "notosans-jp" or "Noto Sans JP" depending on who wrote the directory.
+std::string normalizedFamilyKey(const std::string& familyName) {
+  std::string key;
+  key.reserve(familyName.size());
+  for (const char c : familyName) {
+    if (std::isalnum(static_cast<unsigned char>(c))) key.push_back(static_cast<char>(std::tolower(c)));
+  }
+  return key;
+}
+
 // Point the reader font size at a size the given family actually ships, and
 // persist the change so the settings UI and the loaded font never disagree.
 // Guarded by the value-change check: a no-op snap must not write SPIFFS.
@@ -102,11 +113,9 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
   // Latin books in the JP face. Revert it to the matching built-in and let
   // ensureJpFallback() bring the extension back as the companion where needed.
   if (SETTINGS.sdFontFamilyName[0] != '\0' && isBuiltinJpExtension(SETTINGS.sdFontFamilyName)) {
-    std::string norm;
-    for (const char* c = SETTINGS.sdFontFamilyName; *c; ++c) {
-      if (std::isalnum(static_cast<unsigned char>(*c))) norm.push_back(static_cast<char>(std::tolower(*c)));
-    }
-    SETTINGS.fontFamily = norm == "notoserifjp" ? CrossPointSettings::NOTOSERIF : CrossPointSettings::NOTOSANS;
+    SETTINGS.fontFamily = normalizedFamilyKey(SETTINGS.sdFontFamilyName) == "notoserifjp"
+                              ? CrossPointSettings::NOTOSERIF
+                              : CrossPointSettings::NOTOSANS;
     LOG_INF("SDFS", "Reverting hidden JP extension selection '%s' to built-in", SETTINGS.sdFontFamilyName);
     SETTINGS.sdFontFamilyName[0] = '\0';
   }
@@ -249,12 +258,8 @@ int SdCardFontSystem::resolveFontId(const char* familyName, uint8_t /*pointSize*
 }
 
 bool SdCardFontSystem::isBuiltinJpExtension(const std::string& familyName) {
-  std::string norm;
-  norm.reserve(familyName.size());
-  for (const char c : familyName) {
-    if (std::isalnum(static_cast<unsigned char>(c))) norm.push_back(static_cast<char>(std::tolower(c)));
-  }
-  return norm == "notosansjp" || norm == "notoserifjp";
+  const std::string key = normalizedFamilyKey(familyName);
+  return key == "notosansjp" || key == "notoserifjp";
 }
 
 bool SdCardFontSystem::loadedFamilyCovers(const SdCardFontManager& mgr, const std::string& name,
@@ -295,11 +300,7 @@ void SdCardFontSystem::ensureJpFallback(GfxRenderer& renderer, const uint8_t poi
   // built-in Noto face with its matching JP extension, then try the other extension.
   const bool preferSans = selected.empty() && SETTINGS.fontFamily == CrossPointSettings::NOTOSANS;
   auto extensionRank = [preferSans](const std::string& name) {
-    std::string norm;
-    for (const char c : name) {
-      if (std::isalnum(static_cast<unsigned char>(c))) norm.push_back(static_cast<char>(std::tolower(c)));
-    }
-    return norm == (preferSans ? "notosansjp" : "notoserifjp") ? 0 : 1;
+    return normalizedFamilyKey(name) == (preferSans ? "notosansjp" : "notoserifjp") ? 0 : 1;
   };
   std::vector<const SdCardFontFamilyInfo*> candidates;
   for (const auto& fam : registry_.getFamilies()) {

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <iterator>
 
 #include "CrossPointSettings.h"
@@ -26,6 +27,17 @@ std::string normalizedFamilyKey(const std::string& familyName) {
     if (std::isalnum(static_cast<unsigned char>(c))) key.push_back(static_cast<char>(std::tolower(c)));
   }
   return key;
+}
+
+// Suffixes marking a family as a wider-coverage cut of another one, ordered widest-first:
+// a base with both variants installed resolves to the earlier entry. "Extended" adds Greek,
+// Cyrillic and the phonetic block on top of a Latin face; "IPA" adds the phonetic block alone.
+constexpr const char* kCoverageVariantSuffixes[] = {"Extended", "IPA"};
+
+// Directory name of a built-in reader family, so a variant can name one as its base even
+// though the built-ins are compiled in rather than discovered on the card.
+const char* builtinFamilyDirName(const uint8_t fontFamily) {
+  return fontFamily == CrossPointSettings::NOTOSANS ? "NotoSans" : "NotoSerif";
 }
 
 // Point the reader font size at a size the given family actually ships, and
@@ -66,23 +78,9 @@ void SdCardFontSystem::begin(GfxRenderer& renderer) {
   };
   SETTINGS.sdFontResolverCtx = this;
 
-  // If user has a saved SD font selection, load it
-  if (SETTINGS.sdFontFamilyName[0] != '\0') {
-    const auto* family = registry_.findFamily(SETTINGS.sdFontFamilyName);
-    if (family) {
-      if (manager_.loadFamily(*family, renderer, SETTINGS.fontPointSize)) {
-        snapFontPointSizeTo(manager_.currentPointSize());
-        setupUiFallbacks(renderer);
-        LOG_DBG("SDFS", "Loaded SD card font family: %s", SETTINGS.sdFontFamilyName);
-      } else {
-        LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", SETTINGS.sdFontFamilyName);
-        SETTINGS.clearSdFontFamily();
-      }
-    } else {
-      LOG_DBG("SDFS", "SD font family not found on card: %s (clearing)", SETTINGS.sdFontFamilyName);
-      SETTINGS.clearSdFontFamily();
-    }
-  }
+  // Load whatever the saved selection resolves to. Shared with ensureLoaded() so a selection
+  // written by an older build is migrated, and a coverage variant stands in, at boot too.
+  ensureSelectedLoaded(renderer);
 
   ensureJpFallback(renderer, SETTINGS.fontPointSize);
   updateGlobalFallback(renderer);
@@ -120,11 +118,38 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
     SETTINGS.sdFontFamilyName[0] = '\0';
   }
 
-  const char* wantedFamily = SETTINGS.sdFontFamilyName;
+  // Likewise for a coverage variant: the picker no longer offers it, so a selection saved by an
+  // older build would name a row that is gone. Point the setting at the base it widens -- the
+  // row that now stands for both -- and let resolveSelectedFamily() bring the variant back where
+  // it fits.
+  if (SETTINGS.sdFontFamilyName[0] != '\0' && isCoverageVariant(SETTINGS.sdFontFamilyName, &registry_)) {
+    const std::string baseKey = coverageVariantBase(SETTINGS.sdFontFamilyName);
+    const SdCardFontFamilyInfo* base = nullptr;
+    for (const auto& fam : registry_.getFamilies()) {
+      if (normalizedFamilyKey(fam.name) == baseKey) {
+        base = &fam;
+        break;
+      }
+    }
+    LOG_INF("SDFS", "Migrating hidden variant selection '%s' to its base", SETTINGS.sdFontFamilyName);
+    if (base) {
+      strncpy(SETTINGS.sdFontFamilyName, base->name.c_str(), sizeof(SETTINGS.sdFontFamilyName) - 1);
+      SETTINGS.sdFontFamilyName[sizeof(SETTINGS.sdFontFamilyName) - 1] = '\0';
+    } else {
+      SETTINGS.fontFamily = baseKey == "notosans" ? CrossPointSettings::NOTOSANS : CrossPointSettings::NOTOSERIF;
+      SETTINGS.sdFontFamilyName[0] = '\0';
+    }
+  }
+
+  // What the user picked stays in SETTINGS; what is resident may be the wider variant standing
+  // in for it. A stand-in that fails to load falls back to the base rather than clearing the
+  // selection -- the user never chose the variant, so it must not be able to unpick their font.
+  const std::string wantedFamily = resolveSelectedFamily();
+  const bool standingIn = wantedFamily != SETTINGS.sdFontFamilyName;
 
   const std::string& currentFamily = manager_.currentFamilyName();
 
-  if (wantedFamily[0] == '\0') {
+  if (wantedFamily.empty()) {
     if (!currentFamily.empty()) {
       manager_.unloadAll(renderer);
     }
@@ -142,9 +167,10 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
   if (familyMatches) {
     const auto* family = registry_.findFamily(wantedFamily);
     if (!family) {
-      LOG_DBG("SDFS", "SD font family disappeared: %s (clearing)", wantedFamily);
+      LOG_DBG("SDFS", "SD font family disappeared: %s%s", wantedFamily.c_str(),
+              standingIn ? " (keeping base selection)" : " (clearing)");
       manager_.unloadAll(renderer);
-      SETTINGS.clearSdFontFamily();
+      if (!standingIn) SETTINGS.clearSdFontFamily();
       return;
     }
     const auto* selected = family->findNearestSize(SETTINGS.fontPointSize);
@@ -153,7 +179,7 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
     // the setting still names a size this family does not ship.
     snapFontPointSizeTo(wantedPt);
     if (!registryWasDirty && wantedPt == manager_.currentPointSize()) return;
-    LOG_DBG("SDFS", "Reloading %s: size %u -> %u%s", wantedFamily, manager_.currentPointSize(), wantedPt,
+    LOG_DBG("SDFS", "Reloading %s: size %u -> %u%s", wantedFamily.c_str(), manager_.currentPointSize(), wantedPt,
             registryWasDirty ? " [registry dirty]" : "");
   }
 
@@ -178,14 +204,16 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
     if (manager_.loadFamily(*family, renderer, SETTINGS.fontPointSize)) {
       snapFontPointSizeTo(manager_.currentPointSize());
       setupUiFallbacks(renderer);
-      LOG_DBG("SDFS", "Loaded SD font family: %s", wantedFamily);
+      LOG_DBG("SDFS", "Loaded SD font family: %s", wantedFamily.c_str());
     } else {
-      LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", wantedFamily);
-      SETTINGS.clearSdFontFamily();
+      LOG_ERR("SDFS", "Failed to load SD font family: %s%s", wantedFamily.c_str(),
+              standingIn ? " (keeping base selection)" : " (clearing)");
+      if (!standingIn) SETTINGS.clearSdFontFamily();
     }
   } else {
-    LOG_DBG("SDFS", "SD font family not found: %s (clearing)", wantedFamily);
-    SETTINGS.clearSdFontFamily();
+    LOG_DBG("SDFS", "SD font family not found: %s%s", wantedFamily.c_str(),
+            standingIn ? " (keeping base selection)" : " (clearing)");
+    if (!standingIn) SETTINGS.clearSdFontFamily();
   }
 }
 
@@ -254,12 +282,70 @@ int SdCardFontSystem::resolveFontId(const char* familyName, uint8_t /*pointSize*
   // The manager holds exactly one reader-size font, already selected for
   // SETTINGS.fontPointSize, so the size argument is implicit — always return
   // that font's ID. ensureLoaded() must have run for the current settings first.
+  //
+  // An empty name is the built-in selection asking what stands in for it: the resident family,
+  // when a coverage variant was loaded in the built-in's place, and 0 (use the built-in) when
+  // nothing is. Runs in the page render loop via getReaderFontId(), so it must not allocate.
+  if (familyName == nullptr || familyName[0] == '\0') {
+    const std::string& resident = manager_.currentFamilyName();
+    return resident.empty() ? 0 : manager_.getFontId(resident);
+  }
   return manager_.getFontId(familyName);
 }
 
 bool SdCardFontSystem::isBuiltinJpExtension(const std::string& familyName) {
   const std::string key = normalizedFamilyKey(familyName);
   return key == "notosansjp" || key == "notoserifjp";
+}
+
+std::string SdCardFontSystem::coverageVariantBase(const std::string& familyName) {
+  const std::string key = normalizedFamilyKey(familyName);
+  for (const char* suffix : kCoverageVariantSuffixes) {
+    const std::string suffixKey = normalizedFamilyKey(suffix);
+    // Strictly longer: a family named exactly "IPA" is its own face, not a suffix on nothing.
+    if (key.size() <= suffixKey.size()) continue;
+    if (key.compare(key.size() - suffixKey.size(), suffixKey.size(), suffixKey) == 0) {
+      return key.substr(0, key.size() - suffixKey.size());
+    }
+  }
+  return {};
+}
+
+const SdCardFontFamilyInfo* SdCardFontSystem::findCoverageVariant(const std::string& baseName) const {
+  const std::string baseKey = normalizedFamilyKey(baseName);
+  if (baseKey.empty()) return nullptr;
+  for (const char* suffix : kCoverageVariantSuffixes) {
+    const std::string wanted = baseKey + normalizedFamilyKey(suffix);
+    for (const auto& fam : registry_.getFamilies()) {
+      if (normalizedFamilyKey(fam.name) == wanted) return &fam;
+    }
+  }
+  return nullptr;
+}
+
+bool SdCardFontSystem::isCoverageVariant(const std::string& familyName, const SdCardFontRegistry* registry) {
+  const std::string baseKey = coverageVariantBase(familyName);
+  if (baseKey.empty()) return false;
+  // The base has to actually exist, otherwise the variant is the only carrier of its glyphs
+  // and hiding it would put them out of reach. Built-in bases are always present.
+  if (baseKey == "notoserif" || baseKey == "notosans") return true;
+  if (registry == nullptr) return false;
+  for (const auto& fam : registry->getFamilies()) {
+    if (normalizedFamilyKey(fam.name) == baseKey) return true;
+  }
+  return false;
+}
+
+std::string SdCardFontSystem::resolveSelectedFamily() const {
+  const std::string selected = SETTINGS.sdFontFamilyName;
+  // A book that needs Japanese keeps the base as-is. The companion ensureJpFallback() is about
+  // to load carries this book's text, so standing a coverage variant in here would only make it
+  // the second resident SD font -- the pairing that does not reliably fit this heap. Leaving the
+  // base built-in also keeps its `preferSans` ranking working, which reads an empty selection.
+  if (jpFallbackNeeded_) return selected;
+  const std::string base = selected.empty() ? builtinFamilyDirName(SETTINGS.fontFamily) : selected;
+  const auto* variant = findCoverageVariant(base);
+  return variant ? variant->name : selected;
 }
 
 bool SdCardFontSystem::loadedFamilyCovers(const SdCardFontManager& mgr, const std::string& name,
@@ -362,6 +448,10 @@ void SdCardFontSystem::setJpFallbackNeeded(GfxRenderer& renderer, const bool nee
   if (jpFallbackNeeded_ == needed) return;
   LOG_DBG("SDFS", "JP fallback needed: %d", needed);
   jpFallbackNeeded_ = needed;
+  // resolveSelectedFamily() reads this flag: a collapsed entry is the base plus a JP companion
+  // for a Japanese book and the wider variant for any other, so the selection is re-resolved
+  // here rather than only at book open. Called at book/activity boundaries, never mid-render.
+  ensureSelectedLoaded(renderer);
   ensureJpFallback(renderer, SETTINGS.fontPointSize);
   updateGlobalFallback(renderer);
 }

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -24,7 +24,10 @@ std::string normalizedFamilyKey(const std::string& familyName) {
   std::string key;
   key.reserve(familyName.size());
   for (const char c : familyName) {
-    if (std::isalnum(static_cast<unsigned char>(c))) key.push_back(static_cast<char>(std::tolower(c)));
+    // Both <cctype> calls take the unsigned value: char is signed on this target, and passing a
+    // negative one is undefined. UTF-8 continuation bytes reach here for any non-ASCII name.
+    const auto byte = static_cast<unsigned char>(c);
+    if (std::isalnum(byte)) key.push_back(static_cast<char>(std::tolower(byte)));
   }
   return key;
 }

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -55,6 +55,14 @@ class SdCardFontSystem {
   /// fallback instead of being selected directly.
   static bool isBuiltinJpExtension(const std::string& familyName);
 
+  /// True for SD families that only widen the coverage of a family the device already offers
+  /// (NotoSerifExtended over the built-in Noto Serif, PagellaIPA over an installed Pagella).
+  /// The picker shows the base alone and resolveSelectedFamily() decides which of the two is
+  /// resident, so one typeface is one row. A variant whose base is NOT installed stays
+  /// visible: collapsing a row must never make its glyphs unreachable. `registry` is where the
+  /// base is looked up; a null registry can only match the built-in bases.
+  static bool isCoverageVariant(const std::string& familyName, const SdCardFontRegistry* registry);
+
   /// Access the registry (e.g. for settings UI to enumerate available fonts).
   const SdCardFontRegistry& registry() const { return registry_; }
 
@@ -84,6 +92,19 @@ class SdCardFontSystem {
   ///    card (extension families first) at the reader size and use that
   ///  - no CJK family on the card -> the built-in jōyō-subset fallback captured at begin()
   void ensureSelectedLoaded(GfxRenderer& renderer);
+
+  /// Base family a coverage variant widens ("NotoSerifExtended" -> "NotoSerif"), or empty when
+  /// the name carries none of the known suffixes. Does not check that the base exists.
+  static std::string coverageVariantBase(const std::string& familyName);
+
+  /// Installed variant standing in for `baseName`, or nullptr when the card has none.
+  const SdCardFontFamilyInfo* findCoverageVariant(const std::string& baseName) const;
+
+  /// Family that should be resident for the current selection and reading context. Empty means
+  /// "the built-in reader font, nothing to load". This is a runtime substitution only —
+  /// SETTINGS.sdFontFamilyName keeps naming what the user actually picked.
+  std::string resolveSelectedFamily() const;
+
   void ensureJpFallback(GfxRenderer& renderer, uint8_t pointSize);
   void updateGlobalFallback(GfxRenderer& renderer);
   bool loadedFamilyCovers(const SdCardFontManager& mgr, const std::string& name, uint32_t cp) const;

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -34,6 +34,9 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
     for (const auto& f : families) {
       // Hidden everywhere the picker hides them -- see SdCardFontSystem::isBuiltinJpExtension.
       if (SdCardFontSystem::isBuiltinJpExtension(f.name)) continue;
+      // Likewise for a wider-coverage cut of a family already listed: the base row stands for
+      // both -- see SdCardFontSystem::isCoverageVariant.
+      if (SdCardFontSystem::isCoverageVariant(f.name, registry)) continue;
       enumStringValues.push_back(f.name);
     }
   }

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -106,6 +106,10 @@ void TextSettingsActivity::rebuildFamilyList() {
       // companion logic in SdCardFontSystem::ensureJpFallback(). Hidden here for the
       // same reason the settings picker hides them -- see isBuiltinJpExtension.
       if (SdCardFontSystem::isBuiltinJpExtension(families[i].name)) continue;
+      // Same reasoning for a wider-coverage cut of a family already on this list
+      // (NotoSerifExtended over Noto Serif): one typeface is one row, and the base row's
+      // selection resolves to whichever of the two suits the book being opened.
+      if (SdCardFontSystem::isCoverageVariant(families[i].name, registry_)) continue;
       // settingIndex stays the REGISTRY index (what sdFontFamilyName resolves against);
       // the list position is separate now that the list is filtered.
       fonts_.push_back({families[i].name, false, static_cast<uint8_t>(CrossPointSettings::BUILTIN_FONT_COUNT + i)});


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Show one row per typeface in the font list. `NotoSerifExtended` is Noto Serif plus Greek, Cyrillic and the phonetic block, so anyone with the font pack installed saw four Noto rows for two typefaces.
* **What changes are included?**
  * A family whose name is another family's name plus `Extended` or `IPA` now shares that family's row, in the reader picker (`TextSettingsActivity::rebuildFamilyList`) and in the generic settings list (`SettingsList.h`) alike — the same two places the existing JP-extension filter lives.
  * Which of the two loads is resolved **per book**: a Japanese book takes the base paired with the JP companion, any other book takes the wider variant. Exactly one SD font is resident either way.
  * The substitution is runtime-only. `sdFontFamilyName` keeps naming what the user picked, so a stand-in that fails to load or has gone missing falls back to the base instead of clearing their selection.
  * A selection saved by an older build that names a now-hidden variant is migrated to its base on load, next to the existing JP-extension revert.
  * A variant whose base is **not** installed keeps its own row.
  * Preceded by a small refactor: the alnum-lowercase family-name normalisation was open-coded three times in `SdCardFontSystem.cpp` and is now one helper.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. This PR does not touch any of those areas.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable. This is a font-list clarity fix within the current scope.

## Additional Context

* **Why per-book rather than always preferring the widest variant.** Making the variant the reader font
  unconditionally means a Japanese book holds *two* resident SD fonts: the variant has no CJK, so `selectedHasCjk`
  is false and `ensureJpFallback()` loads `NotoSerifJP` on top of it — the pairing `SdCardFontSystem.cpp` already
  warns "don't reliably coexist on this heap". `effectiveReaderFontId` then makes the companion the actual reader
  font, leaving the variant in heap contributing nothing. Resolving per book keeps it at one.
* **A second defect that fix avoids.** `preferSans` is `selected.empty() && fontFamily == NOTOSANS`. Once any
  `~Extended` family is the selection, `selected` is non-empty and `preferSans` is permanently false — picking Noto
  Sans and opening a Japanese book would have handed you `NotoSerifJP`, a serif JP face for a sans reader. Leaving
  the base built-in for Japanese books keeps that ranking working.
* **Why a variant without an installed base stays visible.** The built-ins have no Greek (commented out at
  `fontconvert.py:80`) and no IPA block at all, so `NotoSerifExtended` is the only carrier of those glyphs. Hiding a
  row whose base doesn't exist would put them out of reach; the base-must-exist check makes the collapse
  structurally incapable of that.
* **Potential risks**, both from `begin()` resolving the stand-in at boot:
  1. A user on a built-in with an `~Extended` variant installed now holds an SD font from boot, where the built-in
     was free flash. That is the trade the collapse makes, but it is new for built-in users.
  2. A Japanese-only reader pays one wasted load/unload per boot — the variant loads at startup, then the first
     Japanese book flips `jpFallbackNeeded_` and unloads it. Avoiding this needs a "reader context established"
     signal that does not exist today; not invented here.
* **Specific areas to focus on:** the `standingIn` guard on every `clearSdFontFamily()` path in
  `ensureSelectedLoaded()`, and `getReaderFontId()` now calling the resolver unconditionally (it runs in the page
  render loop — the empty-name path takes the resident name by const ref and does not allocate).
* **Validation:** `pio run -e default` SUCCESS, `pio check --fail-on-defect low --fail-on-defect medium
  --fail-on-defect high` clean, clang-format 21 clean. **Not yet device-tested** — the four-Noto-rows-become-two
  check, opening a Japanese and a Latin book back to back to confirm the swap, and heap across that transition all
  still need hardware.
* Memory / flash impact: RAM 16.7% (54,820 B), unchanged. Flash 98.8% — 6,478,069 B, +1,236 B over `develop`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZyT61Y6w1gXKiAAWVwsP2