### PR TITLE
fix: align Japanese dictionary example formatting

### DIFF
--- a/src/activities/reader/DefinitionTextRenderer.cpp
+++ b/src/activities/reader/DefinitionTextRenderer.cpp
@@ -124,6 +124,7 @@ void formatGrammarBody(std::string& text, const std::string& headword) {
     if (close == std::string::npos) return;
     line.erase(0, close + 2);
     trim(line);
+    while (line.rfind("\xe3\x80\x80", 0) == 0) line.erase(0, 3);  // Japanese full-width space.
   };
 
   size_t pos = 0;
@@ -580,9 +581,8 @@ WrapResult DrawWrappedImpl(GfxRenderer& renderer, const int fontId, const std::s
                             text[contentStart + 1] == ')';
     const bool indented = text.compare(contentStart, 3, "   ") == 0;
     const bool hangingSense = isNumberedSense(text, contentStart, paraEnd) || alphaLabel || indented;
-    // The example rule is drawn separately; measuring its font glyph makes the text offset
-    // depend on whichever fallback font happened to resolve `│` first.
-    const char* hangingPrefix = isExample ? "   " : alphaLabel ? "a)" : indented ? "   " : "1. ";
+    // Align the example rule with the body text after `1. `; its text starts one space farther in.
+    const char* hangingPrefix = isExample ? "1.  " : alphaLabel ? "a)" : indented ? "   " : "1. ";
     const int hangingIndent =
         (hangingSense || isNote || isExample)
             ? renderer.getTextWidthScaled(fontId, hangingPrefix, paragraphScale, EpdFontFamily::REGULAR)
@@ -595,7 +595,7 @@ WrapResult DrawWrappedImpl(GfxRenderer& renderer, const int fontId, const std::s
           isNote ? (firstLine ? hangingIndent : continuationIndent) : (firstLine ? 0 : continuationIndent);
       return std::max(1, maxWidth - indent);
     };
-    const int exampleRuleX = isExample ? textX + renderer.getTextWidthScaled(fontId, "  ", paragraphScale) : 0;
+    const int exampleRuleX = isExample ? textX + renderer.getTextWidthScaled(fontId, "1. ", paragraphScale) : 0;
     static constexpr char kExamplePrefix[] = "  │ ";
     const auto drawWrappedLine = [&](const char* line, const bool firstLine, const int y) {
       int lineX =

--- a/src/activities/reader/DefinitionTextRenderer.cpp
+++ b/src/activities/reader/DefinitionTextRenderer.cpp
@@ -590,28 +590,32 @@ WrapResult DrawWrappedImpl(GfxRenderer& renderer, const int fontId, const std::s
     const int continuationIndent =
         isNote ? hangingIndent + renderer.getTextWidthScaled(fontId, "→ ", paragraphScale, EpdFontFamily::REGULAR)
                : hangingIndent;
-    const auto availableWidth = [&](const bool firstLine) {
-      const int indent =
-          isNote ? (firstLine ? hangingIndent : continuationIndent) : (firstLine ? 0 : continuationIndent);
-      return std::max(1, maxWidth - indent);
+    // An example is indented on every line, its first included: the marker is stripped before
+    // measuring, so there is no leading prefix to stand in for the indent the way "1. " does on a
+    // numbered sense.
+    const auto lineIndent = [&](const bool firstLine) {
+      return (isNote || isExample) ? (firstLine ? hangingIndent : continuationIndent)
+                                   : (firstLine ? 0 : continuationIndent);
     };
-    const int exampleRuleX = isExample ? textX + renderer.getTextWidthScaled(fontId, "1. ", paragraphScale) : 0;
+    const auto availableWidth = [&](const bool firstLine) { return std::max(1, maxWidth - lineIndent(firstLine)); };
+    const int exampleRuleX =
+        isExample ? textX + renderer.getTextWidthScaled(fontId, "1. ", paragraphScale, EpdFontFamily::REGULAR) : 0;
     static constexpr char kExamplePrefix[] = "  │ ";
     const auto drawWrappedLine = [&](const char* line, const bool firstLine, const int y) {
-      int lineX =
-          textX + (isNote ? (firstLine ? hangingIndent : continuationIndent) : (firstLine ? 0 : continuationIndent));
-      const char* visibleLine = line;
-      if (isExample && firstLine && std::strncmp(line, kExamplePrefix, sizeof(kExamplePrefix) - 1) == 0) {
-        // The marker identifies example paragraphs for layout; draw only the text and the one
-        // continuous rule below it. Rendering the UTF-8 `│` as well produced a double divider.
-        visibleLine += sizeof(kExamplePrefix) - 1;
-        lineX = textX + hangingIndent;
-      }
-      renderer.drawTextScaled(fontId, lineX, y, visibleLine, paragraphScale, paragraphBlack, paragraphStyle);
+      renderer.drawTextScaled(fontId, textX + lineIndent(firstLine), y, line, paragraphScale, paragraphBlack,
+                              paragraphStyle);
       if (isExample) renderer.drawLine(exampleRuleX, y, exampleRuleX, y + lineHeight - 1, 1, paragraphBlack);
     };
     bool firstParagraphLine = true;
     size_t remStart = contentStart;
+    // The marker only tags the paragraph as an example; the rule is drawn separately, and
+    // rendering the UTF-8 `│` as well produced a double divider. Dropping it here rather than at
+    // draw time keeps the wrapped width and the drawn width the same string -- measuring it would
+    // otherwise price the line by whichever fallback font happened to resolve `│`.
+    if (isExample && contentStart + sizeof(kExamplePrefix) - 1 <= paraEnd &&
+        text.compare(contentStart, sizeof(kExamplePrefix) - 1, kExamplePrefix) == 0) {
+      remStart += sizeof(kExamplePrefix) - 1;
+    }
     const size_t remEndFixed = paraEnd;
     nlPos = nextNl == std::string::npos ? text.size() + 1 : nextNl + 1;
 
@@ -672,11 +676,9 @@ WrapResult DrawWrappedImpl(GfxRenderer& renderer, const int fontId, const std::s
           }
           break;
         }
-        const size_t unbreakablePrefix = !firstParagraphLine ? 0
-                                         : isExample         ? sizeof(kExamplePrefix) - 1
-                                         : alphaLabel        ? 2
-                                         : indented          ? 3
-                                                             : 0;
+        // Labels that are still part of the text must not be split off it. An example's marker
+        // was dropped from `remStart`, so its first line starts at real text and needs no guard.
+        const size_t unbreakablePrefix = !firstParagraphLine ? 0 : alphaLabel ? 2 : indented ? 3 : 0;
         if (text[pos] == ' ' && pos >= remStart + unbreakablePrefix) {
           lastSpaceBreak = lineBuf.size();
         }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make Japanese vocabulary and grammar examples visually consistent in Word Lookup.
* **What changes are included?** Align vocabulary example rules with the definition text, strip full-width spaces left after grammar example labels, and render Latin labels with Japanese example text in one font run so their baselines match.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Root causes: vocabulary rules used a generic space offset instead of the numbered definition's measured text edge; grammar entries can retain a Japanese full-width space after their original example number; and drawing `a)` separately resolves a different font ascender and shifts its baseline.
* The change is confined to the shared definition renderer; it does not touch `freeink-sdk/`, HAL, or private build files.
* Validated with clang-format, `git diff --check`, a full PlatformIO build, and a successful flash and visual check on the device.
* Memory and flash impact are negligible.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
