### PR TITLE
feat: draw on/off settings as switches instead of ON/OFF text

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -194,6 +194,10 @@ Books cannot be removed from your device through Calibre. Use the web interface 
 
 The Settings screen allows you to configure the device's behavior. There are a few settings you can adjust:
 
+Settings that are simply on or off show a switch on the right of their row instead of the words "ON" and "OFF" —
+selecting the row flips it in place. Settings with more than two choices still show their current value as text and
+open a list when selected.
+
 #### 3.6.1 Display
 
 - **Sleep Screen**: Which sleep screen to display when the device sleeps:
@@ -699,7 +703,7 @@ up the dictionaries, fonts, and API key they need.
 Copy a Japanese EPUB to the SD card and open it from the Library. Vertical text activates on its own when the
 book declares `<dc:language>ja</dc:language>`, with no setting to find.
 
-The reader menu (**Confirm**) gains **Vertical Text: ON/OFF** and **Furigana: ON/OFF** for Japanese books. Both
+The reader menu (**Confirm**) gains **Vertical Text** and **Furigana** switches for Japanese books. Both
 toggle in place without leaving the menu, and both are remembered per book.
 
 <p align="center">

--- a/src/activities/settings/KOReaderSettingsActivity.cpp
+++ b/src/activities/settings/KOReaderSettingsActivity.cpp
@@ -11,6 +11,7 @@
 #include "MappedInputManager.h"
 #include "activities/util/KeyboardEntryActivity.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 
 namespace fui = freeink::ui;
 
@@ -127,6 +128,7 @@ void KOReaderSettingsActivity::buildScreen(UiScreen& screen) {
   // rowValues_ strings (no array growth) rather than building a new
   // items/values vector on every render.
   for (int i = 0; i < MENU_ITEMS; i++) {
+    rowItems_[i].toggle = false;
     if (i == 0) {
       const auto username = KOREADER_STORE.getUsername();
       rowValues_[i] = username.empty() ? tr(STR_NOT_SET) : username;
@@ -147,7 +149,11 @@ void KOReaderSettingsActivity::buildScreen(UiScreen& screen) {
       rowValues_[i] =
           KOREADER_STORE.getMatchMethod() == DocumentMatchMethod::FILENAME ? tr(STR_FILENAME) : tr(STR_BINARY);
     } else if (i == 4) {
-      rowValues_[i] = KOREADER_STORE.getSendMetadata() ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
+      // The only on/off row here: Match Method and Sync Behavior are two-state as well, but
+      // their words are the meaning, so they keep them.
+      rowItems_[i].toggle = true;
+      rowItems_[i].toggleChecked = KOREADER_STORE.getSendMetadata();
+      rowValues_[i].clear();
     } else if (i == 5) {
       rowValues_[i] =
           KOREADER_STORE.getSyncBehavior() == KOReaderSyncBehavior::SMART ? tr(STR_SMART_SYNC) : tr(STR_ASK_EVERY_TIME);
@@ -163,6 +169,7 @@ void KOReaderSettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);
   syncListViewport(screen, props);
   screen.list(props);
 }

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -521,16 +521,24 @@ void SettingsActivity::openSleepTimeoutPicker() {
       });
 }
 
+bool SettingsActivity::settingIsSwitch(const SettingInfo& setting) {
+  if (setting.type == SettingType::TOGGLE) return setting.valuePtr != nullptr || setting.valueGetter != nullptr;
+  // A two-value {OFF, ON} enum is a switch wearing an enum's clothes: activateSetting() cycles
+  // it in place (only sizes above two reach the popup). Any other pair keeps its words -- the
+  // labels are the meaning there (FILENAME/BINARY), which a bare switch would throw away.
+  if (setting.type != SettingType::ENUM) return false;
+  if (setting.enumValues.size() != 2 || !setting.enumStringValues.empty()) return false;
+  return setting.enumValues[0] == StrId::STR_STATE_OFF && setting.enumValues[1] == StrId::STR_STATE_ON;
+}
+
+bool SettingsActivity::settingSwitchState(const SettingInfo& setting) {
+  if (setting.valuePtr != nullptr) return SETTINGS.*(setting.valuePtr) != 0;
+  if (setting.valueGetter) return setting.valueGetter() != 0;
+  return false;
+}
+
 std::string SettingsActivity::settingValueText(const SettingInfo& setting) {
-  if (setting.type == SettingType::TOGGLE && setting.valuePtr != nullptr) {
-    return SETTINGS.*(setting.valuePtr) ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-  }
-  // DynamicToggle (Vertical Text, Furigana): per-book state that lives on the pushing reader
-  // activity, not in CrossPointSettings, so it has a getter instead of a member pointer. Without
-  // this branch the row renders with no value at all -- the ENUM path below has the same pair.
-  if (setting.type == SettingType::TOGGLE && setting.valueGetter) {
-    return setting.valueGetter() != 0 ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-  }
+  // On/off rows draw a switch instead of a value; buildScreen() skips this for them.
   if (setting.type == SettingType::ENUM && setting.valuePtr != nullptr) {
     // Guard like the valueGetter branch below: a corrupt/migrated settings
     // byte must not index past the enum table.
@@ -580,6 +588,13 @@ void SettingsActivity::buildScreen(UiScreen& screen) {
   // render.
   const auto& settings = *currentSettings;
   for (size_t i = 0; i < settings.size(); i++) {
+    rowItems_[i].toggle = settingIsSwitch(settings[i]);
+    if (rowItems_[i].toggle) {
+      rowItems_[i].toggleChecked = settingSwitchState(settings[i]);
+      rowValues_[i].clear();
+      rowItems_[i].value = nullptr;
+      continue;
+    }
     rowValues_[i] = settingValueText(settings[i]);
     rowItems_[i].value = rowValues_[i].empty() ? nullptr : rowValues_[i].c_str();
   }
@@ -590,6 +605,7 @@ void SettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);
   // Titles match the value's font size (smallText) so both sides of a row
   // read as one unit; labels that still don't fit wrap onto a second line.
   // maxLines=2 also marks the style explicitly set (an all-default smallText

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -228,6 +228,11 @@ class SettingsActivity final : public UiTabListActivity {
   bool handleCustomInput() override;
 
   static std::string settingValueText(const SettingInfo& setting);
+  // True when the row is an on/off setting, so it draws a switch instead of a value string.
+  // Covers both TOGGLE forms and the two-value {OFF, ON} enums, which already flip in place
+  // rather than opening the option popup.
+  static bool settingIsSwitch(const SettingInfo& setting);
+  static bool settingSwitchState(const SettingInfo& setting);
   void selectCategory(int categoryIndex);
   void applyUiSettingChange(uint8_t CrossPointSettings::* valuePtr);
 

--- a/src/activities/settings/StatusBarSettingsActivity.cpp
+++ b/src/activities/settings/StatusBarSettingsActivity.cpp
@@ -12,6 +12,7 @@
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 
 namespace fui = freeink::ui;
@@ -203,6 +204,24 @@ void StatusBarSettingsActivity::handleSelection() {
   SETTINGS.saveToFile();
 }
 
+bool StatusBarSettingsActivity::rowIsSwitch(const int index, bool& checked) {
+  // The three element-visibility rows. ITEM_CLOCK_SYNC is deliberately not here: it reports
+  // whether a sync has happened rather than setting anything, so it keeps its words.
+  switch (index) {
+    case ITEM_CHAPTER_PAGE_COUNT:
+      checked = SETTINGS.statusBarChapterPageCount != 0;
+      return true;
+    case ITEM_BOOK_PROGRESS_PERCENTAGE:
+      checked = SETTINGS.statusBarBookProgressPercentage != 0;
+      return true;
+    case ITEM_BATTERY:
+      checked = SETTINGS.statusBarBattery != 0;
+      return true;
+    default:
+      return false;
+  }
+}
+
 std::string StatusBarSettingsActivity::rowValueText(const int index) {
   switch (index) {
     case ITEM_CHAPTER_PAGE_COUNT:
@@ -252,7 +271,14 @@ void StatusBarSettingsActivity::buildScreen(UiScreen& screen) {
   // rowValues_ strings (no array growth) rather than building a new
   // items/values vector on every render.
   for (int i = 0; i < visibleItemCount; i++) {
-    rowValues_[i] = rowValueText(i);
+    bool checked = false;
+    rowItems_[i].toggle = rowIsSwitch(i, checked);
+    if (rowItems_[i].toggle) {
+      rowItems_[i].toggleChecked = checked;
+      rowValues_[i].clear();
+    } else {
+      rowValues_[i] = rowValueText(i);
+    }
     rowItems_[i].value = rowValues_[i].empty() ? nullptr : rowValues_[i].c_str();
   }
 
@@ -262,6 +288,7 @@ void StatusBarSettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);
   props.labelText = screen.theme().smallText;
   props.labelText.maxLines = 2;  // also the explicitly-set marker, see SettingsActivity
   syncListViewport(screen, props);

--- a/src/activities/settings/StatusBarSettingsActivity.h
+++ b/src/activities/settings/StatusBarSettingsActivity.h
@@ -28,6 +28,9 @@ class StatusBarSettingsActivity final : public UiListActivity {
   bool handleCustomInput() override;
 
   std::string rowValueText(int index);
+  // True when the row is an element-visibility switch, so it draws one in place of its value.
+  // `checked` is only written when it is.
+  static bool rowIsSwitch(int index, bool& checked);
 
   void handleSelection();
 

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -17,6 +17,7 @@
 #include "SdCardFontSystem.h"
 #include "TextSettingsPreview.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 
 namespace fui = freeink::ui;
@@ -255,6 +256,10 @@ void TextSettingsActivity::buildScreen(UiScreen& screen) {
   // than building a new items/values vector on every render.
   const int count = listCount();
   for (int i = 0; i < count; i++) {
+    bool checked = false;
+    rowItems_[i].toggle = false;
+    // Cleared up front so a row that sets no value can't keep the previous tab's text.
+    rowValues_[i].clear();
     switch (tab_) {
       case Tab::Family:
         rowValues_[i] = (i == currentFamilyIndex_) ? tr(STR_SELECTED) : "";
@@ -262,15 +267,22 @@ void TextSettingsActivity::buildScreen(UiScreen& screen) {
       case Tab::Size:
         rowValues_[i] = (i == currentSizeIndex_) ? tr(STR_SELECTED) : "";
         break;
-      case Tab::Layout:
-        rowValues_[i] = layoutValueText(i);
+      case Tab::Layout: {
+        // Visible position -> LayoutRow, as the labels do: a Japanese book hides three of the
+        // rows, so `i` is not the enum value (see layoutRowAt()).
+        const int layoutRow = static_cast<int>(layoutRowAt(i));
+        rowItems_[i].toggle = layoutRowIsSwitch(layoutRow, checked);
+        if (!rowItems_[i].toggle) rowValues_[i] = layoutValueText(layoutRow);
         break;
+      }
       case Tab::Style:
-        rowValues_[i] = styleValueText(i);
+        // Every Style row is on/off, so this tab is all switches and has no value text.
+        rowItems_[i].toggle = styleRowIsSwitch(i, checked);
         break;
       default:
         break;
     }
+    if (rowItems_[i].toggle) rowItems_[i].toggleChecked = checked;
     rowItems_[i].value = rowValues_[i].empty() ? nullptr : rowValues_[i].c_str();
   }
 
@@ -280,6 +292,7 @@ void TextSettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);
   // Titles match the value's font size (smallText) so both sides of a row
   // read as one unit; labels that still don't fit wrap onto a second line.
   // maxLines=2 also marks the style explicitly set (see SettingsActivity).
@@ -454,23 +467,52 @@ void TextSettingsActivity::confirmLayoutRow(int row) {
   }
 }
 
+bool TextSettingsActivity::layoutRowIsSwitch(const int row, bool& checked) const {
+  switch (static_cast<LayoutRow>(row)) {
+    case LayoutRow::ParaSpacing:
+      checked = SETTINGS.extraParagraphSpacing != 0;
+      return true;
+    case LayoutRow::BookSideMargins:
+      checked = SETTINGS.bookCssMargins != 0;
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool TextSettingsActivity::styleRowIsSwitch(const int row, bool& checked) const {
+  switch (static_cast<StyleRow>(row)) {
+    case StyleRow::FocusReading:
+      checked = SETTINGS.focusReadingEnabled != 0;
+      return true;
+    case StyleRow::Hyphenation:
+      checked = SETTINGS.hyphenationEnabled != 0;
+      return true;
+    case StyleRow::EmbeddedStyle:
+      checked = SETTINGS.embeddedStyle != 0;
+      return true;
+    case StyleRow::AntiAliasing:
+      checked = SETTINGS.textAntiAliasing != 0;
+      return true;
+    default:
+      return false;
+  }
+}
+
 std::string TextSettingsActivity::layoutValueText(int row) const {
   switch (static_cast<LayoutRow>(row)) {
     case LayoutRow::LineSpacing: {
       const uint8_t v = SETTINGS.lineSpacing;
       return v < std::size(LINE_SPACING_IDS) ? I18N.get(LINE_SPACING_IDS[v]) : I18N.get(StrId::STR_NORMAL);
     }
-    case LayoutRow::ParaSpacing:
-      return SETTINGS.extraParagraphSpacing ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
     case LayoutRow::Alignment: {
       const uint8_t v = SETTINGS.paragraphAlignment;
       return v < std::size(ALIGNMENT_IDS) ? I18N.get(ALIGNMENT_IDS[v]) : I18N.get(StrId::STR_JUSTIFY);
     }
     case LayoutRow::ScreenMargin:
       return std::to_string(SETTINGS.screenMargin);
-    case LayoutRow::BookSideMargins:
-      return SETTINGS.bookCssMargins ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
 
+    // ParaSpacing and BookSideMargins draw switches -- see layoutRowIsSwitch().
     default:
       return "";
   }
@@ -495,22 +537,6 @@ void TextSettingsActivity::confirmStyleRow(int row) {
       return;
   }
   requestUpdate();
-}
-
-std::string TextSettingsActivity::styleValueText(int row) const {
-  switch (static_cast<StyleRow>(row)) {
-    case StyleRow::FocusReading:
-      return SETTINGS.focusReadingEnabled ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-    case StyleRow::Hyphenation:
-      return SETTINGS.hyphenationEnabled ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-    case StyleRow::EmbeddedStyle:
-      return SETTINGS.embeddedStyle ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-    case StyleRow::AntiAliasing:
-      return SETTINGS.textAntiAliasing ? tr(STR_STATE_ON) : tr(STR_STATE_OFF);
-
-    default:
-      return "";
-  }
 }
 
 // Only Focus Reading shows in the preview (bold prefixes); the other Style rows

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -66,7 +66,10 @@ class TextSettingsActivity final : public UiTabListActivity {
   void activateRow(int row);
 
   std::string layoutValueText(int row) const;
-  std::string styleValueText(int row) const;
+  // On/off rows draw a switch in place of their value. `checked` is only read when the row is
+  // one; `row` is the visible index, so Layout goes through layoutRowAt() like its value text.
+  bool layoutRowIsSwitch(int row, bool& checked) const;
+  bool styleRowIsSwitch(int row, bool& checked) const;
   // Button-hint label for Confirm at the current ring position.
   const char* confirmLabelText() const;
   // True when the focused list row is a setting the preview cannot reflect.

--- a/src/components/UiAppHelpers.h
+++ b/src/components/UiAppHelpers.h
@@ -127,6 +127,19 @@ inline freeink::ui::BitmapRef listIconFor(const UIIcon icon, const int size = 24
   }
 }
 
+// Give a list's on/off rows (fui::ListItem::toggle) their house style. The SDK ships square
+// switches -- ListProps::toggleRadius/toggleKnobRadius default to 0 and Screen::list() has no
+// theme token to substitute -- so the pill shape has to be set per list, and every settings
+// screen sets it through here rather than repeating the numbers.
+//
+// The radii are deliberately larger than any switch we draw: fui::toggle clamps the track to
+// height/2 and the knob to its own height/2, so an over-large value is the way to say "fully
+// round" without restating the geometry here.
+inline void applySwitchStyle(freeink::ui::ListProps& props) {
+  props.toggleRadius = 0xFF;      // clamped to height/2 -> pill ends
+  props.toggleKnobRadius = 0xFF;  // clamped to knobHeight/2 -> circular knob
+}
+
 // Bottom-anchored Cancel / OK pair for slider dialogs on touch devices, where
 // the physical Back/Confirm buttons (and their auto-hidden hints) may not
 // exist. Callers gate on hasTouch(): button boards keep the hint chrome and


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Use the SDK's switch control for every on/off setting, instead of the mix of "ON"/"OFF" and "Show"/"Hide" text the settings screens carry today, and give it a pill shape.
* **What changes are included?**
  * Every `SettingType::TOGGLE` row in the main settings list draws a switch (~20 settings), along with the two-value `{OFF, ON}` enums — Quick Resume, Touch Controls, Send Metadata.
  * Text Settings: Extra Spacing and Book Side Margins on Layout, and all four Style rows.
  * Status Bar: chapter page count, book progress %, and battery, which read "Show"/"Hide".
  * KOReader: the Send Metadata row.
  * One `applySwitchStyle()` helper sets the pill radii, since the SDK ships square switches and `Screen::list()` has no theme token for them.
  * A fix that fell out of the work: Text Settings' Layout tab read its value text by visible index while its labels mapped through `layoutRowAt()`.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. This PR does not touch any of those areas — it only consumes the switch the SDK
      already ships.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable. This is a UI consistency pass over existing settings screens.

## Additional Context

* **What the SDK already provides.** `fui::ListItem` has `toggle`/`toggleChecked` and `list()` draws the switch
  inline from the row style's foreground, so it stays legible on inverted (selected) rows. No new drawing code here —
  the rows just stop writing a value string and set the flag instead.
* **Why the shape needs a downstream helper.** `ListProps::toggleRadius`/`toggleKnobRadius` default to 0 and
  `Screen::list()` has no theme token to substitute, so a square switch is what every caller gets by default. The
  helper passes `0xFF` for both: `list()` clamps the track to `height/2` and the knob to `knobHeight/2`, so that is
  the way to say "fully round" without restating the geometry. Track and knob geometry are left at the SDK's
  defaults — if the proportions look wrong next to the pill, `toggleKnobInset` is the dial.
* **What deliberately keeps its words**, since a bare switch would destroy the meaning: KOReader's Match Method
  (`FILENAME`/`BINARY`) and Sync Behavior (`SMART`/`ASK`), which are two-state but not on/off; `Clock: Synced/Not set`,
  which reports a status rather than setting one; and everything with three or more values, which opens the option
  popup — `{OFF, NORMAL, INVERTED}` and the page-turn `{OFF, 1, 3, 6, 12}`.
* **Potential risks:** the `{OFF, ON}` enums now render as switches while still being enums underneath. That is safe
  because `activateSetting()` cycles any two-value enum in place (`% 2`) and only reaches the popup above two, so
  activation is unchanged — but it is the one place where the control's appearance and the setting's type differ.
* **Specific areas to focus on:** `settingIsSwitch()`'s enum test, which is deliberately narrow (exactly two values,
  exactly `STR_STATE_OFF` then `STR_STATE_ON`, no `enumStringValues`); and the per-row reset of `ListItem::toggle` in
  each build loop, since `rowItems_` persists across renders and a stale `true` would draw a switch on the wrong row.
* **Validation:** `pio run -e default` SUCCESS, `pio check --fail-on-defect low --fail-on-defect medium
  --fail-on-defect high` clean, clang-format 21 clean. **Not device-tested** — the switches, the pill radius, and the
  Japanese-book Layout tab (where the index fix applies) all need a visual check on hardware.
* Memory / flash impact: RAM 16.7% (54,820 B), unchanged. Flash 98.9% — 6,478,497 B, +378 B over `develop`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZyT61Y6w1gXKiAAWVwsP2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZyT61Y6w1gXKiAAWVwsP2)_