### PR TITLE
fix: use end-of-book view for all readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A wallpaper laid over the page you were reading, so the book shows through inste
 - More of the book's own CSS respected: headings sized as headings, line spacing, page breaks, boxed asides, and rules written as `.callout p`
 - **Use Book Margins** (Text Settings > Layout, on by default) keeps the indents a book sets for itself, so epigraphs and long quotations stay inset. Turn it off and those blocks sit flush with the body text
 - Instant image page turns, since the next image decodes in the background
+- Next-book suggestions at the end of EPUB, TXT/Markdown, XTC and manga books
 - A file browser that shows everything on the card, with unsupported files greyed out rather than hidden
 - Fully localised, in all the languages CrossPoint ships
 

--- a/src/activities/reader/EndOfBookOptions.h
+++ b/src/activities/reader/EndOfBookOptions.h
@@ -9,7 +9,7 @@
 class GfxRenderer;
 class MappedInputManager;
 
-// Shared End-of-Book next-book menu for the EPUB and XTC readers. Collects up to
+// Shared End-of-Book next-book menu for the book readers. Collects up to
 // MAX_SUGGESTIONS sibling books once per reader session, handles the menu input, and
 // draws the end screen. With no suggestions the end screen keeps its historical
 // plain-title look and behavior.

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -175,8 +175,8 @@ void MangaReaderActivity::onExit() {
   ReaderUtils::flushReadingStats(readingSessionStartMs, /*force=*/true, book ? book->getFolder().c_str() : nullptr,
                                  book ? book->getLanguage().c_str() : nullptr);
 
-  // On the last page (currentPage never advances past pageCount-1 -- see
-  // nextPage()) regardless of how long this particular session lasted.
+  // On the last page or the end-screen sentinel, regardless of how long this
+  // particular session lasted.
   // Previously this was nested inside `minutes > 0` AND compared against
   // pageCount instead of pageCount-1, so it could never fire -- manga never
   // got marked finished even at 100% progress, unlike Epub/Txt readers.
@@ -188,6 +188,8 @@ void MangaReaderActivity::onExit() {
   }
 
   saveProgress();
+  endOfBookOptionsReady.store(false, std::memory_order_release);
+  endOfBookOptions.reset();
   panels.clear();
   book.reset();
 
@@ -390,6 +392,12 @@ void MangaReaderActivity::nextPage(const bool keepPanelMode) {
     // In Panels Only a page with no detected crops still matters (cover, splash page, failed
     // detection): leave FullPage selected as the fallback, then resume crops on the next page.
     requestUpdate();
+  } else if (currentPage < book->getPageCount()) {
+    currentPage = book->getPageCount();
+    currentPanel = -1;
+    viewMode = ViewMode::FullPage;
+    automaticPageTurnActive = false;
+    requestUpdate();
   }
 }
 
@@ -412,6 +420,76 @@ void MangaReaderActivity::prevPage(const bool keepPanelMode) {
   }
 }
 
+bool MangaReaderActivity::isAtEndOfBook() const { return book && currentPage >= book->getPageCount(); }
+
+void MangaReaderActivity::clearEndOfBookOptionsIfNeeded() {
+  if (isAtEndOfBook() || !endOfBookOptionsReady.load(std::memory_order_acquire)) return;
+  RenderLock lock(*this);
+  endOfBookOptionsReady.store(false, std::memory_order_release);
+  endOfBookOptions.reset();
+}
+
+void MangaReaderActivity::onReturnFromEndOfBook() {
+  currentPage = book && book->getPageCount() > 0 ? book->getPageCount() - 1 : 0;
+  currentPanel = -1;
+  viewMode = ViewMode::FullPage;
+  loadCurrentPagePanels();
+}
+
+bool MangaReaderActivity::handleEndOfBookMenu() {
+  if (!isAtEndOfBook() || !endOfBookOptionsReady.load(std::memory_order_acquire) || !endOfBookOptions->menuActive()) {
+    return false;
+  }
+
+  std::string openPath;
+  switch (endOfBookOptions->handleMenuInput(mappedInput, &openPath)) {
+    case EndOfBookOptions::Action::OpenBook:
+      activityManager.goToReader(openPath);
+      return true;
+    case EndOfBookOptions::Action::GoHome:
+      onGoHome();
+      return true;
+    case EndOfBookOptions::Action::LastPage:
+      onReturnFromEndOfBook();
+      requestUpdate();
+      return true;
+    case EndOfBookOptions::Action::Redraw:
+      requestUpdate();
+      return true;
+    case EndOfBookOptions::Action::None:
+      return false;
+  }
+  return false;
+}
+
+bool MangaReaderActivity::handleEndOfBookPageTurn(const bool prevTriggered, const bool nextTriggered) {
+  if (!isAtEndOfBook()) return false;
+  if (endOfBookOptionsReady.load(std::memory_order_acquire) && endOfBookOptions->menuActive()) return true;
+  if (nextTriggered) {
+    onGoHome();
+  } else if (prevTriggered) {
+    onReturnFromEndOfBook();
+    requestUpdate();
+  }
+  return true;
+}
+
+bool MangaReaderActivity::renderEndOfBook() {
+  if (!isAtEndOfBook()) return false;
+  if (!endOfBookOptions) {
+    endOfBookOptions = makeUniqueNoThrow<EndOfBookOptions>(renderer);
+    if (!endOfBookOptions) LOG_ERR("MRA", "OOM: EndOfBookOptions");
+    endOfBookOptionsReady.store(endOfBookOptions != nullptr, std::memory_order_release);
+  }
+  renderer.clearScreen();
+  if (endOfBookOptions) {
+    endOfBookOptions->loadOnce(book->getFolder());
+    endOfBookOptions->render(renderer, mappedInput);
+  }
+  renderer.displayBuffer();
+  return true;
+}
+
 void MangaReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption) {
   if (selectedPageTurnOption == 0 || selectedPageTurnOption >= std::size(PAGE_TURN_RATES)) {
     automaticPageTurnActive = false;
@@ -432,6 +510,9 @@ void MangaReaderActivity::loop() {
   // task's normal locking rules. Runs before everything else so a completed warm is visible to
   // this very tick's input handling, and so the single job slot frees up for the next post.
   applyPrefetchResult();
+
+  clearEndOfBookOptionsIfNeeded();
+  if (handleEndOfBookMenu()) return;
 
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
     showBookmarkMessage = false;
@@ -544,6 +625,8 @@ void MangaReaderActivity::loop() {
     return;
   }
 
+  if (handleEndOfBookPageTurn(prevTriggered, nextTriggered)) return;
+
   if (viewMode == ViewMode::PanelZoom) {
     if (nextTriggered) nextPanel();
     if (prevTriggered) prevPanel();
@@ -574,13 +657,7 @@ void MangaReaderActivity::loop() {
 void MangaReaderActivity::render(RenderLock&&) {
   if (!book) return;
 
-  if (currentPage >= book->getPageCount()) {
-    renderer.clearScreen();
-    renderer.drawCenteredText(UI_12_FONT_ID, renderer.getScreenHeight() / 2, tr(STR_END_OF_BOOK), true,
-                              EpdFontFamily::BOLD);
-    renderer.displayBuffer();
-    return;
-  }
+  if (renderEndOfBook()) return;
 
   switch (viewMode) {
     case ViewMode::FullPage:
@@ -1516,11 +1593,12 @@ void MangaReaderActivity::saveProgress() const {
     Storage.mkdir(cachePath.c_str());
   }
 
+  const uint32_t savedPage = book->getPageCount() > 0 ? std::min(currentPage, book->getPageCount() - 1) : 0;
   uint8_t data[7];
-  data[0] = currentPage & 0xFF;
-  data[1] = (currentPage >> 8) & 0xFF;
-  data[2] = (currentPage >> 16) & 0xFF;
-  data[3] = (currentPage >> 24) & 0xFF;
+  data[0] = savedPage & 0xFF;
+  data[1] = (savedPage >> 8) & 0xFF;
+  data[2] = (savedPage >> 16) & 0xFF;
+  data[3] = (savedPage >> 24) & 0xFF;
   int16_t panelVal = static_cast<int16_t>(currentPanel);
   memcpy(data + 4, &panelVal, 2);
   data[6] = panelsOnlyMode ? 1 : 0;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -424,7 +424,8 @@ bool MangaReaderActivity::isAtEndOfBook() const { return book && currentPage >= 
 
 void MangaReaderActivity::clearEndOfBookOptionsIfNeeded() {
   if (isAtEndOfBook() || !endOfBookOptionsReady.load(std::memory_order_acquire)) return;
-  RenderLock lock(*this);
+  RenderLock lock{RenderLock::Try{}};
+  if (!lock.held()) return;
   endOfBookOptionsReady.store(false, std::memory_order_release);
   endOfBookOptions.reset();
 }
@@ -485,6 +486,9 @@ bool MangaReaderActivity::renderEndOfBook() {
   if (endOfBookOptions) {
     endOfBookOptions->loadOnce(book->getFolder());
     endOfBookOptions->render(renderer, mappedInput);
+  } else {
+    renderer.drawCenteredText(UI_12_FONT_ID, renderer.getScreenHeight() * 3 / 8, tr(STR_END_OF_BOOK), true,
+                              EpdFontFamily::BOLD);
   }
   renderer.displayBuffer();
   return true;

--- a/src/activities/reader/MangaReaderActivity.h
+++ b/src/activities/reader/MangaReaderActivity.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "../../BookmarkEntry.h"
+#include "EndOfBookOptions.h"
 #include "EpubReaderMenuActivity.h"
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
@@ -33,6 +34,8 @@ class MangaReaderActivity final : public Activity {
  private:
   std::string pendingBookPath;
   std::unique_ptr<manga::MangaBook> book;
+  std::unique_ptr<EndOfBookOptions> endOfBookOptions;
+  std::atomic<bool> endOfBookOptionsReady{false};
 
   uint32_t currentPage = 0;
   int currentPanel = -1;  // -1 = full page view, 0+ = zoomed panel
@@ -283,6 +286,12 @@ class MangaReaderActivity final : public Activity {
   void nextPage(bool keepPanelMode = false);
   void prevPage(bool keepPanelMode = false);
   int findPanelWithCrop(int start, int step) const;
+  bool isAtEndOfBook() const;
+  void clearEndOfBookOptionsIfNeeded();
+  bool handleEndOfBookMenu();
+  bool handleEndOfBookPageTurn(bool prevTriggered, bool nextTriggered);
+  void onReturnFromEndOfBook();
+  bool renderEndOfBook();
 
   void saveProgress() const;
   void loadProgress();

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -93,7 +93,8 @@ void ReaderActivity::loop() {
 
 void ReaderActivity::clearEndOfBookOptionsIfNeeded() {
   if (isAtEndOfBook() || !endOfBookOptionsReady.load(std::memory_order_acquire)) return;
-  RenderLock lock(*this);
+  RenderLock lock{RenderLock::Try{}};
+  if (!lock.held()) return;
   endOfBookOptionsReady.store(false, std::memory_order_release);
   endOfBookOptions.reset();
 }

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -59,6 +59,9 @@ void TxtReaderActivity::onReaderExit() {
 }
 
 void TxtReaderActivity::readerLoop() {
+  clearEndOfBookOptionsIfNeeded();
+  if (handleEndOfBookMenu()) return;
+
   if (handleBackNavigation()) return;
 
   const auto touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
@@ -69,6 +72,8 @@ void TxtReaderActivity::readerLoop() {
     return;
   }
 
+  if (handleEndOfBookPageTurn(prevTriggered, nextTriggered)) return;
+
   if (prevTriggered && currentPage > 0) {
     currentPage--;
     requestUpdate();
@@ -77,10 +82,17 @@ void TxtReaderActivity::readerLoop() {
       currentPage++;
       requestUpdate();
     } else {
-      onGoHome();
+      currentPage = totalPages;
+      requestUpdate();
     }
   }
 }
+
+bool TxtReaderActivity::isAtEndOfBook() const {
+  return initialized && !pageOffsets.empty() && currentPage >= totalPages;
+}
+
+void TxtReaderActivity::onReturnFromEndOfBook() { currentPage = totalPages > 0 ? totalPages - 1 : 0; }
 
 void TxtReaderActivity::initializeReader() {
   if (initialized) {
@@ -323,6 +335,8 @@ void TxtReaderActivity::render(RenderLock&&) {
     renderer.displayBuffer();
     return;
   }
+
+  if (renderEndOfBook("TRS")) return;
 
   // Bounds check
   if (currentPage < 0) currentPage = 0;

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -46,6 +46,8 @@ class TxtReaderActivity final : public ReaderActivity {
   void onReaderEnter() override;
   void onReaderExit() override;
   void readerLoop() override;
+  bool isAtEndOfBook() const override;
+  void onReturnFromEndOfBook() override;
 
  public:
   explicit TxtReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string bookPath,

--- a/src/util/NextBookFinder.cpp
+++ b/src/util/NextBookFinder.cpp
@@ -3,6 +3,7 @@
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <MangaPanel.h>
 #include <Memory.h>
 
 #include <algorithm>
@@ -14,7 +15,7 @@ namespace {
 constexpr size_t NAME_BUFFER_SIZE = 500;
 
 bool isSupportedBookFile(const std::string_view name) {
-  // Formats ReaderActivity can open (bmp is a viewer, not a book, so it is excluded)
+  // File formats ReaderActivity can open (bmp is a viewer, not a book, so it is excluded)
   return FsHelpers::hasEpubExtension(name) || FsHelpers::hasXtcExtension(name) || FsHelpers::hasTxtExtension(name) ||
          FsHelpers::hasMarkdownExtension(name);
 }
@@ -53,17 +54,17 @@ std::vector<std::string> NextBookFinder::findNextBooks(const std::string& curren
   const auto less = [](const std::string& a, const std::string& b) { return FsHelpers::naturalLess(a, b); };
 
   for (auto file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (file.isDirectory()) {
-      continue;
-    }
     file.getName(nameBuffer.get(), NAME_BUFFER_SIZE);
     if (!SETTINGS.showHiddenFiles && nameBuffer[0] == '.') {
       continue;
     }
-    if (!isSupportedBookFile(nameBuffer.get())) {
+    std::string name{nameBuffer.get()};
+    if (file.isDirectory()) {
+      const std::string fullPath = folder == "/" ? "/" + name : folder + "/" + name;
+      if (!manga::MangaBook::isMangaFolder(fullPath)) continue;
+    } else if (!isSupportedBookFile(name)) {
       continue;
     }
-    std::string name{nameBuffer.get()};
     // Keep only files ordering strictly after the current one; equal names (the book
     // itself, or a case-variant of it) compare "not less" both ways and drop out here.
     if (!FsHelpers::naturalLess(currentName, name)) {

--- a/src/util/NextBookFinder.cpp
+++ b/src/util/NextBookFinder.cpp
@@ -58,13 +58,14 @@ std::vector<std::string> NextBookFinder::findNextBooks(const std::string& curren
     if (!SETTINGS.showHiddenFiles && nameBuffer[0] == '.') {
       continue;
     }
-    std::string name{nameBuffer.get()};
+    const std::string_view nameView{nameBuffer.get()};
     if (file.isDirectory()) {
-      const std::string fullPath = folder == "/" ? "/" + name : folder + "/" + name;
+      const std::string fullPath = folder == "/" ? "/" + std::string{nameView} : folder + "/" + std::string{nameView};
       if (!manga::MangaBook::isMangaFolder(fullPath)) continue;
-    } else if (!isSupportedBookFile(name)) {
+    } else if (!isSupportedBookFile(nameView)) {
       continue;
     }
+    std::string name{nameView};
     // Keep only files ordering strictly after the current one; equal names (the book
     // itself, or a case-variant of it) compare "not less" both ways and drop out here.
     if (!FsHelpers::naturalLess(currentName, name)) {

--- a/src/util/NextBookFinder.h
+++ b/src/util/NextBookFinder.h
@@ -5,7 +5,7 @@
 
 namespace NextBookFinder {
 
-// Collects up to maxCount book files that order after currentBookPath's filename
+// Collects up to maxCount book entries that order after currentBookPath's name
 // (natural sort, same ordering as the file browser) within the same folder.
 // Returns bare filenames in sorted order; the current file itself is excluded.
 // Single directory pass keeping only the maxCount best matches, so memory stays


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Use the same end-of-book experience consistently across every book reader.
* **What changes are included?**
  * Route TXT and Markdown past their final page into the shared end-of-book view instead of immediately returning home.
  * Replace manga's unreachable legacy end label with the shared next-book menu, while preserving panel-only navigation and saving the last real page as progress.
  * Include sibling manga folders in next-book suggestions.
  * Document the supported end-of-book suggestions.

The root causes were separate: TXT handled its last page locally and bypassed the shared state, while manga never advanced to its existing end sentinel. The suggestion scan also accepted files only, so manga folders could not be offered.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this fixes inconsistent behavior between existing Matcha readers).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. Not applicable: none of those paths are changed.

## Additional Context

* EPUB and XTC already used the shared view and remain unchanged.
* BMP/PNG stay image viewers rather than books, so they do not receive a book-ending screen.
* The next-book scan remains bounded to three suggestions.
* Validation: clang-format, `git diff --check`, all 161 native tests, cppcheck, default firmware build, and successful build/upload to an ESP32-C3 device.
* Private SDK/configuration files are not part of this branch or PR.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
