### PR TITLE
fix: make chapter selection atomic

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1207,21 +1207,6 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
               openReaderMenu();
               return;
             }
-            if (!result.isCancelled) {
-              const auto& chapterResult = std::get<ChapterResult>(result.data);
-              RenderLock lock(*this);
-
-              currentSpineIndex = chapterResult.spineIndex;
-
-              // If anchor is not empty, it will be used later to calculate the page number.
-              pendingAnchor = chapterResult.anchor;
-
-              // Otherwise page 0 will be used.
-              nextPageNumber = 0;
-
-              section.reset();
-              verticalSection.reset();
-            }
             const auto& chapterResult = std::get<ChapterResult>(result.data);
             RenderLock lock(*this);
 
@@ -1235,6 +1220,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
             nextPageNumber = 0;
 
             section.reset();
+            verticalSection.reset();
           });
       break;
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Prevent intermittent EPUB chapter jumps from being discarded after indexing.
* **What changes are included?** Remove the duplicated chapter-selection state update and perform the horizontal and vertical section reset once, inside the same render lock.

The chapter-selection callback contained two copies of the navigation update in separate `RenderLock` scopes. The render task could begin indexing the selected chapter between those scopes; the second update then discarded the newly built section. This produced timing-dependent behavior where the first selection returned to the previous position and the second selection worked.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. This fixes a regression in the current EPUB reader callback.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. Not applicable: none of those paths are changed.

## Additional Context

* Net change: 15 lines removed, 1 line added.
* Matcha's vertical-reader behavior is preserved by resetting `verticalSection` in the surviving atomic update.
* No static memory increase; the firmware shrinks slightly.
* Validation: clang-format, `git diff --check`, all 161 native tests, cppcheck, and the default firmware build.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
