### PR TITLE
fix: restore cyclic list navigation

### DIFF
--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -519,14 +519,11 @@ void FileBrowserActivity::buildScreen(UiScreen& screen) {
   // Tap opens/navigates; long-press prompts delete (physical buttons stay in loop()).
   props.inputMask = fui::InputTouch | fui::InputLongPress;
   props.valueInset = 8;  // air between the extension and the row edge
-  // File names in the small font, wrapping onto a second line inside the same
-  // row height (rowHeight is derived from the small font itself: two of its
-  // lines plus 8, so two small lines always fit), so long names show more
-  // text. maxLines=2 doubles as the caller-owned marker: an all-default
-  // smallText fails textStyleUnset and Screen::list() would substitute
-  // bodyText back (FONT_SLOT_SMALL is 0).
+  // Keep file names on one line: long names are cropped rather than making
+  // only their selection row taller. Zero renders as one line and also marks
+  // the small-font style as caller-owned (FONT_SLOT_SMALL itself is 0).
   fui::TextStyle label = screen.theme().smallText;
-  label.maxLines = 2;
+  label.maxLines = 0;
   props.labelText = label;
   // The trailing value here is just the short extension: skip the balanced
   // 60%-band wrap cap and let both name lines run the full width before it.

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -289,6 +289,26 @@ void SettingsActivity::stepTab(const int direction) {
   requestUpdate();
 }
 
+void SettingsActivity::navigateButtons() {
+  if (!finishOnBack) {
+    UiTabListActivity::navigateButtons();
+    return;
+  }
+
+  // Embedded Reader Settings hides and locks the tab bar, so navigate only
+  // the visible rows (ring positions 1..N) instead of landing on hidden 0.
+  const int count = listCount();
+  if (count <= 0) return;
+  buttonNavigator.onNextRelease([this, count] { moveRingTo(ButtonNavigator::nextIndex(ringPos() - 1, count) + 1); });
+  buttonNavigator.onPreviousRelease(
+      [this, count] { moveRingTo(ButtonNavigator::previousIndex(ringPos() - 1, count) + 1); });
+  buttonNavigator.onNextContinuous(
+      [this, count] { moveRingTo(ButtonNavigator::nextPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1); });
+  buttonNavigator.onPreviousContinuous([this, count] {
+    moveRingTo(ButtonNavigator::previousPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1);
+  });
+}
+
 bool SettingsActivity::handleButtons() {
   if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
     if (ringPos() == 0) {

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -224,6 +224,7 @@ class SettingsActivity final : public UiTabListActivity {
   void activateIndex(int index) override;
   void onTabAction(int index) override;
   void stepTab(int direction) override;
+  void navigateButtons() override;
   bool handleButtons() override;
   bool handleCustomInput() override;
 

--- a/src/util/ButtonNavigator.cpp
+++ b/src/util/ButtonNavigator.cpp
@@ -139,12 +139,11 @@ int ButtonNavigator::previousPageIndex(const int currentIndex, const int totalIt
     return previousIndex(currentIndex, totalItems);
   }
 
-  const int lastPageIndex = (totalItems - 1) / itemsPerPage;
   const int currentPageIndex = currentIndex / itemsPerPage;
 
   if (currentPageIndex > 0) {
     return (currentPageIndex - 1) * itemsPerPage;
   }
 
-  return lastPageIndex * itemsPerPage;
+  return totalItems - 1;
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Restore predictable cyclic navigation after the shared FreeInkUI list migration.
* **What changes are included?** Wrap backward page navigation to the actual final item, keep embedded Reader Settings within their visible rows, and keep cropped file names at a uniform row height.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Root cause: the shared previous-page helper wrapped to the first row of the last page, and embedded Reader Settings still included their hidden tab-bar position in the navigation ring.
* File names remain intentionally single-line and cropped; long unbreakable names no longer create a taller selector.
* No changes to `freeink-sdk/`, `lib/hal/`, or private SDK code.
* Validation: clang-format, `git diff --check`, `pio check`, full `pio run`, and successful on-device verification.
* Flash impact: approximately +696 bytes compared with the preceding local build; no observed RAM change.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
