### PR TITLE
fix(reader): handle disabled menu entries

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -130,7 +130,7 @@ bool EpubReaderMenuActivity::handleHomeGesture() {
 }
 
 void EpubReaderMenuActivity::activateIndex(const int index) {
-  if (optionPopup.isActive()) return;
+  if (optionPopup.isActive() || !menuRowItems[index].enabled) return;
   // The activated row leaves this screen (popup or finish); a lingering flash
   // would gray an unrelated element on the next render.
   app.clearTapFlash();
@@ -184,6 +184,29 @@ bool EpubReaderMenuActivity::handleButtons() {
   return false;
 }
 
+int EpubReaderMenuActivity::enabledIndexFrom(int index, const int direction) const {
+  const int count = listCount();
+  for (int checked = 0; checked < count; checked++) {
+    if (menuRowItems[index].enabled) return index;
+    index = direction > 0 ? ButtonNavigator::nextIndex(index, count) : ButtonNavigator::previousIndex(index, count);
+  }
+  return nav.selected;
+}
+
+void EpubReaderMenuActivity::navigateButtons() {
+  const int count = listCount();
+  buttonNavigator.onNextRelease(
+      [this, count] { moveSelectionTo(enabledIndexFrom(ButtonNavigator::nextIndex(nav.selected, count), 1)); });
+  buttonNavigator.onPreviousRelease(
+      [this, count] { moveSelectionTo(enabledIndexFrom(ButtonNavigator::previousIndex(nav.selected, count), -1)); });
+  buttonNavigator.onNextContinuous([this, count] {
+    moveSelectionTo(enabledIndexFrom(ButtonNavigator::nextPageIndex(nav.selected, count, nav.visibleRows), 1));
+  });
+  buttonNavigator.onPreviousContinuous([this, count] {
+    moveSelectionTo(enabledIndexFrom(ButtonNavigator::previousPageIndex(nav.selected, count, nav.visibleRows), -1));
+  });
+}
+
 void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
@@ -223,8 +246,29 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  const fui::Rect listRect = screen.body();
   syncListViewport(screen, props);
   screen.list(props);
+
+  // GfxRenderer's 1-bit text path cannot draw the list style's gray foreground,
+  // so thin disabled labels with the same checkerboard mask as the legacy themes.
+  const int16_t rowHeight = props.rowHeight > 0 ? props.rowHeight : screen.theme().rowHeight;
+  const int16_t rowGap = props.rowGap >= 0 ? props.rowGap : screen.theme().listRowGap;
+  const int16_t textX = static_cast<int16_t>(listRect.x + screen.theme().listInset + screen.theme().listSidePadding);
+  const int16_t textAvail =
+      static_cast<int16_t>(listRect.right() - screen.theme().listInset - screen.theme().listSidePadding - textX);
+  const int16_t lineHeight = screen.target().lineHeight(screen.theme().bodyText.font);
+  for (int i = props.topIndex; i < listCount() && i < props.topIndex + nav.visibleRows; i++) {
+    if (menuRowItems[i].enabled) continue;
+    int16_t textWidth =
+        screen.target().measureText(screen.theme().bodyText.font, menuRowItems[i].label, screen.theme().bodyText).width;
+    if (textWidth > textAvail) textWidth = textAvail;
+    const int16_t textY =
+        static_cast<int16_t>(listRect.y + (i - props.topIndex) * (rowHeight + rowGap) + (rowHeight - lineHeight) / 2);
+    for (int y = textY; y < textY + lineHeight; y++)
+      for (int x = textX; x < textX + textWidth; x++)
+        if ((x + y) % 2 == 0) renderer.drawPixel(x, y, false);
+  }
 }
 
 void EpubReaderMenuActivity::drawChrome() {

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -74,13 +74,14 @@ class EpubReaderMenuActivity final : public UiListActivity {
   void activateIndex(int index) override;
   // Popup input runs before any button or touch handling.
   bool handleCustomInput() override;
-  // Back closes on RELEASE and Confirm activates on RELEASE; everything else
-  // (row navigation, page jumps) falls through to the base handler.
+  // Back closes on RELEASE and Confirm activates on RELEASE.
   bool handleButtons() override;
+  void navigateButtons() override;
   // Header via GUI.drawHeader inside the safe area for the battery indicator.
   void drawChrome() override;
 
   void closeCancelled();
+  int enabledIndexFrom(int index, int direction) const;
 
   // Fixed menu layout
   // Not const: the fork rebuilds the row set when a toggle changes what is shown.


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Keep the reader menu cursor visible and navigation predictable when page-dependent actions are disabled.
* **What changes are included?**
  * Skip disabled reader-menu entries for single-step and continuous button navigation while preserving wrap-around.
  * Ignore activation attempts for disabled entries.
  * Render disabled entry labels with the existing checkerboard dimming treatment used by the legacy themes.

The root cause was that physical-button navigation included disabled rows, while FreeInkUI intentionally omitted their selection cursor. This made the cursor appear to disappear until the next enabled row was selected.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable.

## Additional Context

* No FreeInk SDK, HAL, bootloader, OTA, recovery, or private SDK files are changed.
* Validation:
  * `clang-format`
  * `git diff --check`
  * `pio check` — no defects found
  * `pio run` — successful
  * Flashed and verified on the connected device
* Current firmware image remains within the application partition at 99.1% flash usage.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_