### PR TITLE
feat: Give the reader menu's on/off rows the house switch

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -8,6 +8,7 @@
 #include "MappedInputManager.h"
 #include "ReaderUtils.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 
 namespace fui = freeink::ui;
 
@@ -51,6 +52,11 @@ void EpubReaderMenuActivity::buildMenuRowItems() {
       case MenuAction::TOGGLE_PANELS_ONLY:
         item.toggle = true;
         item.toggleChecked = panelsOnlyEnabled;
+        break;
+      // On/off rows carry a switch, like every on/off row in Settings. The state is refreshed
+      // in buildScreen(), since it changes without the menu closing.
+      case MenuAction::NIGHT_MODE:
+        item.toggle = true;
         break;
       default:
         break;
@@ -261,7 +267,8 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
     } else if (action == MenuAction::AUTO_PAGE_TURN) {
       menuRowItems[i].value = pageTurnLabels[selectedPageTurnOption];
     } else if (action == MenuAction::NIGHT_MODE) {
-      menuRowItems[i].value = I18N.get(SETTINGS.screenInverted ? StrId::STR_STATE_ON : StrId::STR_STATE_OFF);
+      // A switch row draws its state in the switch, so the value slot stays empty.
+      menuRowItems[i].toggleChecked = SETTINGS.screenInverted != 0;
     } else if (action == MenuAction::FRONTLIGHT) {
       menuRowItems[i].value = I18N.get(Frontlight.isOn() ? StrId::STR_STATE_ON : StrId::STR_STATE_OFF);
     }
@@ -273,6 +280,7 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);            // pill switches, as everywhere else
   const fui::Rect listRect = screen.body();
   syncListViewport(screen, props);
   screen.list(props);


### PR DESCRIPTION
Two rows in the reader menu still looked unlike every other on/off row in the firmware.

**Night Mode** drew its state as ON/OFF text in the value slot rather than carrying a switch. It is a switch row now, its state still refreshed in place so the menu does not close when you toggle it.

**Panels Only** (manga) was already a switch row, but the reader menu never applied the house switch style, so it drew the SDK's square default instead of the pill. `applySwitchStyle` covers both rows at once — that omission was the whole cause.

Device-tested on the X4: both rows show the pill switch, and Night Mode still toggles without closing the menu.

Frontlight in the same menu is the remaining ON/OFF text row and would take the same one-line change; left out since it was not part of the request.