### PR TITLE
fix: Never resize a string to a length read from a damaged file

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -471,15 +471,21 @@ bool BookMetadataCache::load() {
     return false;
   }
 
-  serialization::readPod(bookFile, lutOffset);
-  serialization::readPod(bookFile, spineCount);
-  serialization::readPod(bookFile, tocCount);
-
-  serialization::readString(bookFile, coreMetadata.title);
-  serialization::readString(bookFile, coreMetadata.author);
-  serialization::readString(bookFile, coreMetadata.language);
-  serialization::readString(bookFile, coreMetadata.coverItemHref);
-  serialization::readString(bookFile, coreMetadata.textReferenceHref);
+  // A cache file that cannot be read through is treated as absent, not as a book with empty
+  // metadata: the caller rebuilds it, where a half-loaded cache would be believed and kept.
+  // This is the path that aborted on a device whose SD card was failing mid-read.
+  const bool headerOk = serialization::readPod(bookFile, lutOffset) && serialization::readPod(bookFile, spineCount) &&
+                        serialization::readPod(bookFile, tocCount) &&
+                        serialization::readString(bookFile, coreMetadata.title) &&
+                        serialization::readString(bookFile, coreMetadata.author) &&
+                        serialization::readString(bookFile, coreMetadata.language) &&
+                        serialization::readString(bookFile, coreMetadata.coverItemHref) &&
+                        serialization::readString(bookFile, coreMetadata.textReferenceHref);
+  if (!headerOk) {
+    LOG_ERR("BMC", "Cache header unreadable or corrupt; discarding");
+    bookFile.close();
+    return false;
+  }
 
   // Cache cumulative spine sizes in RAM. The progress bar (every render) and percent
   // jumps otherwise pay 2 seeks + a heap-allocating SpineEntry read per access. Spine

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <HalStorage.h>
 #include <Memory.h>
+#include <Serialization.h>
 
 #include <algorithm>
 #include <cstring>
@@ -138,9 +139,12 @@ void writePod(BufferedFileWriter& out, const T& value) {
   out.write(&value, sizeof(T));
 }
 
+// Zeroes `value` first and reports a short read, so a caller can never act on stack garbage --
+// see the note on MAX_SERIALIZED_STRING in Serialization.h for what that cost us.
 template <typename T>
-void readPod(BufferedFileReader& in, T& value) {
-  in.read(&value, sizeof(T));
+bool readPod(BufferedFileReader& in, T& value) {
+  value = T{};
+  return in.read(&value, sizeof(T)) == sizeof(T);
 }
 
 inline void writeString(BufferedFileWriter& out, const std::string& s) {
@@ -149,13 +153,13 @@ inline void writeString(BufferedFileWriter& out, const std::string& s) {
   out.write(s.data(), len);
 }
 
-inline void readString(BufferedFileReader& in, std::string& s) {
-  uint32_t len;
-  readPod(in, len);
+inline bool readString(BufferedFileReader& in, std::string& s) {
+  s.clear();
+  uint32_t len = 0;
+  if (!readPod(in, len) || len > MAX_SERIALIZED_STRING) return false;
   s.resize(len);
-  if (len > 0) {
-    in.read(&s[0], len);
-  }
+  if (len == 0) return true;
+  return in.read(&s[0], len) == len;
 }
 
 }  // namespace serialization

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -48,14 +48,27 @@ void writePod(HalFile& file, const T& value) {
   file.write(reinterpret_cast<const uint8_t*>(&value), sizeof(T));
 }
 
+// Every serialized string is preceded by its length, and that length is then handed to
+// std::string::resize(). A cache file truncated or misread -- an SD card failing mid-read is the
+// case seen in the wild -- yields a nonsense length, and resize() on it either throws
+// length_error or exhausts the heap. Under -fno-exceptions both end at abort(), taking the
+// device down while it was only trying to read a book's title. So: the readers below zero their
+// output before reading, report whether the read was complete, and refuse a length that cannot
+// be true. No string this format stores is anywhere near this size.
+constexpr uint32_t MAX_SERIALIZED_STRING = 64 * 1024;
+
+// Returns false on a short read, having left `value` zeroed rather than holding stack garbage.
 template <typename T>
-void readPod(std::istream& is, T& value) {
+bool readPod(std::istream& is, T& value) {
+  value = T{};
   is.read(reinterpret_cast<char*>(&value), sizeof(T));
+  return is.gcount() == static_cast<std::streamsize>(sizeof(T));
 }
 
 template <typename T>
-void readPod(HalFile& file, T& value) {
-  file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T));
+bool readPod(HalFile& file, T& value) {
+  value = T{};
+  return file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T)) == static_cast<int>(sizeof(T));
 }
 
 inline void writeString(std::ostream& os, const std::string& s) {
@@ -70,17 +83,25 @@ inline void writeString(HalFile& file, const std::string& s) {
   file.write(reinterpret_cast<const uint8_t*>(s.data()), len);
 }
 
-inline void readString(std::istream& is, std::string& s) {
-  uint32_t len;
-  readPod(is, len);
+inline bool readString(std::istream& is, std::string& s) {
+  s.clear();
+  uint32_t len = 0;
+  if (!readPod(is, len) || len > MAX_SERIALIZED_STRING) return false;
   s.resize(len);
+  if (len == 0) return true;
   is.read(&s[0], len);
+  return is.gcount() == static_cast<std::streamsize>(len);
 }
 
-inline void readString(HalFile& file, std::string& s) {
-  uint32_t len;
-  readPod(file, len);
+inline bool readString(HalFile& file, std::string& s) {
+  s.clear();
+  uint32_t len = 0;
+  if (!readPod(file, len) || len > MAX_SERIALIZED_STRING) return false;
+  // A length past the end of the file is corruption however plausible its size looks.
+  const int remaining = file.available();
+  if (remaining >= 0 && len > static_cast<uint32_t>(remaining)) return false;
   s.resize(len);
-  file.read(&s[0], len);
+  if (len == 0) return true;
+  return file.read(&s[0], len) == static_cast<int>(len);
 }
 }  // namespace serialization

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -8,6 +8,7 @@
 #include "MappedInputManager.h"
 #include "ReaderUtils.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 
 namespace fui = freeink::ui;
 
@@ -51,6 +52,11 @@ void EpubReaderMenuActivity::buildMenuRowItems() {
       case MenuAction::TOGGLE_PANELS_ONLY:
         item.toggle = true;
         item.toggleChecked = panelsOnlyEnabled;
+        break;
+      // On/off rows carry a switch, like every on/off row in Settings. The state is refreshed
+      // in buildScreen(), since it changes without the menu closing.
+      case MenuAction::NIGHT_MODE:
+        item.toggle = true;
         break;
       default:
         break;
@@ -261,7 +267,8 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
     } else if (action == MenuAction::AUTO_PAGE_TURN) {
       menuRowItems[i].value = pageTurnLabels[selectedPageTurnOption];
     } else if (action == MenuAction::NIGHT_MODE) {
-      menuRowItems[i].value = I18N.get(SETTINGS.screenInverted ? StrId::STR_STATE_ON : StrId::STR_STATE_OFF);
+      // A switch row draws its state in the switch, so the value slot stays empty.
+      menuRowItems[i].toggleChecked = SETTINGS.screenInverted != 0;
     } else if (action == MenuAction::FRONTLIGHT) {
       menuRowItems[i].value = I18N.get(Frontlight.isOn() ? StrId::STR_STATE_ON : StrId::STR_STATE_OFF);
     }
@@ -273,6 +280,7 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  applySwitchStyle(props);            // pill switches, as everywhere else
   const fui::Rect listRect = screen.body();
   syncListViewport(screen, props);
   screen.list(props);


### PR DESCRIPTION
A crash report from a reading session ends in `abort()`. The stack decodes to:

```
abort()
  __cxa_init_primary_exception / __cxa_throw     <- std::length_error also on the stack
  operator new(unsigned int)
  std::string::resize(unsigned int, char)
  BookMetadataCache::load()            BookMetadataCache.cpp:461
  BookMetadataCache::getSpineEntry(int)
```

The logs above it show the SD card failing for minutes beforehand:

```
[808893] content read failed for OEBPS/chapter_011.xhtml   (x3)
[809145] Failed to stream item contents to temp file after retries
[905026] open for write failed: /system/bookstats/985b0a73.bin
[910142] Failed to load page from SD - clearing section cache
```

## The bug

Every serialized string is `[u32 length][bytes]`, and `readString` handed that length straight to `resize()` without validating it. `readPod` also discarded the result of the read, so a short read left `uint32_t len;` holding uninitialized stack garbage.

Resizing to a nonsense length either throws `length_error` or exhausts the heap. Under `-fno-exceptions` both end at `abort()` — which is why `operator new`, `__cxa_throw` and `std::length_error` all appear on one stack.

The failing card is the trigger; turning a bad read into `abort()` is the defect. It should have discarded the cache and rebuilt it.

## The fix

- `readPod` zeroes its output before reading and returns whether the read was complete, so no caller can act on stack garbage.
- `readString` refuses a length that cannot be true: past the end of the file, or beyond a 64KB bound. Checked against every `writeString` call site — they store hrefs, titles, anchors, item ids, image paths and ruby text, none remotely near that.
- `BookMetadataCache::load()` checks those results and discards a cache it cannot read through, so the caller rebuilds it. Loading half of one and believing it is how a failing card becomes a permanently wrong cache.

Both the `HalFile` and `BufferedFileReader` readers had the identical flaw; both are fixed.

## Not covered

No regression test: the host suite has no `HalStorage` stub, so exercising these readers means building one, which is larger than the fix. The change is reasoned from the stack rather than proven by a test — worth a careful read of the bounds.