### PR TITLE
feat: Disable the informational dictionary row, and make disabled rows look disabled

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -277,25 +277,7 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   syncListViewport(screen, props);
   screen.list(props);
 
-  // GfxRenderer's 1-bit text path cannot draw the list style's gray foreground,
-  // so thin disabled labels with the same checkerboard mask as the legacy themes.
-  const int16_t rowHeight = props.rowHeight > 0 ? props.rowHeight : screen.theme().rowHeight;
-  const int16_t rowGap = props.rowGap >= 0 ? props.rowGap : screen.theme().listRowGap;
-  const int16_t textX = static_cast<int16_t>(listRect.x + screen.theme().listInset + screen.theme().listSidePadding);
-  const int16_t textAvail =
-      static_cast<int16_t>(listRect.right() - screen.theme().listInset - screen.theme().listSidePadding - textX);
-  const int16_t lineHeight = screen.target().lineHeight(screen.theme().bodyText.font);
-  for (int i = props.topIndex; i < listCount() && i < props.topIndex + nav.visibleRows; i++) {
-    if (menuRowItems[i].enabled) continue;
-    int16_t textWidth =
-        screen.target().measureText(screen.theme().bodyText.font, menuRowItems[i].label, screen.theme().bodyText).width;
-    if (textWidth > textAvail) textWidth = textAvail;
-    const int16_t textY =
-        static_cast<int16_t>(listRect.y + (i - props.topIndex) * (rowHeight + rowGap) + (rowHeight - lineHeight) / 2);
-    for (int y = textY; y < textY + lineHeight; y++)
-      for (int x = textX; x < textX + textWidth; x++)
-        if ((x + y) % 2 == 0) renderer.drawPixel(x, y, false);
-  }
+  thinDisabledRows(renderer, screen, props, listRect, listCount(), nav.visibleRows);
 }
 
 void EpubReaderMenuActivity::drawChrome() {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -233,6 +233,7 @@ void SettingsActivity::rebuildRowItems() {
     fui::ListItem item;
     item.label = I18N.get(settings[i].nameId);
     item.actionValue = static_cast<int16_t>(i);
+    item.enabled = !settingIsReadOnly(settings[i]);
     rowItems_.push_back(item);
   }
 }
@@ -248,6 +249,7 @@ void SettingsActivity::onTabAction(const int index) {
 
 void SettingsActivity::activateIndex(const int index) {
   if (optionPopup.isActive()) return;
+  if (index >= 0 && index < static_cast<int>(rowItems_.size()) && !rowItems_[index].enabled) return;
   (void)index;  // toggleCurrentSetting reads the ring position
   // Most rows repaint a different surface (popup, sub-activity, new value);
   // a lingering tap flash would gray an unrelated element.
@@ -298,14 +300,28 @@ void SettingsActivity::navigateButtons() {
   // the visible rows (ring positions 1..N) instead of landing on hidden 0.
   const int count = listCount();
   if (count <= 0) return;
-  buttonNavigator.onNextRelease([this, count] { moveRingTo(ButtonNavigator::nextIndex(ringPos() - 1, count) + 1); });
+  buttonNavigator.onNextRelease(
+      [this, count] { moveRingTo(enabledRingFrom(ButtonNavigator::nextIndex(ringPos() - 1, count) + 1, 1)); });
   buttonNavigator.onPreviousRelease(
-      [this, count] { moveRingTo(ButtonNavigator::previousIndex(ringPos() - 1, count) + 1); });
-  buttonNavigator.onNextContinuous(
-      [this, count] { moveRingTo(ButtonNavigator::nextPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1); });
-  buttonNavigator.onPreviousContinuous([this, count] {
-    moveRingTo(ButtonNavigator::previousPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1);
+      [this, count] { moveRingTo(enabledRingFrom(ButtonNavigator::previousIndex(ringPos() - 1, count) + 1, -1)); });
+  buttonNavigator.onNextContinuous([this, count] {
+    moveRingTo(enabledRingFrom(ButtonNavigator::nextPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1, 1));
   });
+  buttonNavigator.onPreviousContinuous([this, count] {
+    moveRingTo(
+        enabledRingFrom(ButtonNavigator::previousPageIndex(ringPos() - 1, count, activeNav().visibleRows) + 1, -1));
+  });
+}
+
+int SettingsActivity::enabledRingFrom(int ring, const int direction) const {
+  const int count = listCount();
+  if (count <= 0) return ring;
+  for (int checked = 0; checked < count; checked++) {
+    const int row = ring - 1;
+    if (row < 0 || row >= static_cast<int>(rowItems_.size()) || rowItems_[row].enabled) return ring;
+    ring = (direction > 0 ? ButtonNavigator::nextIndex(row, count) : ButtonNavigator::previousIndex(row, count)) + 1;
+  }
+  return ringPos();
 }
 
 bool SettingsActivity::handleButtons() {
@@ -314,6 +330,8 @@ bool SettingsActivity::handleButtons() {
       // Embedded single-category mode (reader menu): the category row is locked.
       if (!finishOnBack) stepTab(1);
     } else {
+      const int row = ringPos() - 1;
+      if (row >= 0 && row < static_cast<int>(rowItems_.size()) && !rowItems_[row].enabled) return true;
       toggleCurrentSetting();
       requestUpdate();
     }
@@ -548,6 +566,12 @@ bool SettingsActivity::settingIsSwitch(const SettingInfo& setting) {
   if (setting.type != SettingType::ENUM) return false;
   if (setting.enumValues.size() != 2 || !setting.enumStringValues.empty()) return false;
   return setting.enumValues[0] == StrId::STR_STATE_OFF && setting.enumValues[1] == StrId::STR_STATE_ON;
+}
+
+bool SettingsActivity::settingIsReadOnly(const SettingInfo& setting) {
+  // Actions carry no value but do something on Confirm, so they stay enabled; a value row with
+  // neither a settings field nor a setter has nothing Confirm could do.
+  return setting.type == SettingType::ENUM && setting.valuePtr == nullptr && !setting.valueSetter;
 }
 
 bool SettingsActivity::settingSwitchState(const SettingInfo& setting) {

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -656,8 +656,12 @@ void SettingsActivity::buildScreen(UiScreen& screen) {
   // common fits-on-one-line case takes the renderer's fast path anyway.
   props.labelText = screen.theme().smallText;
   props.labelText.maxLines = 2;
+  const fui::Rect listRect = screen.body();
   syncTabListViewport(screen, props);
   screen.list(props);
+  // Reader Settings reports the applied dictionary without offering a choice; that row is
+  // disabled, and this is what makes it look it.
+  thinDisabledRows(renderer, screen, props, listRect, listCount(), activeNav().visibleRows);
 }
 
 void SettingsActivity::render(RenderLock&&) {

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -234,6 +234,13 @@ class SettingsActivity final : public UiTabListActivity {
   // rather than opening the option popup.
   static bool settingIsSwitch(const SettingInfo& setting);
   static bool settingSwitchState(const SettingInfo& setting);
+  // A row the user cannot change: an enum with a getter but nothing to write through. Reader
+  // Settings shows the dictionary this way -- the book's language picks it, so the row reports
+  // the choice rather than offering one. Such rows draw disabled and the cursor steps over them.
+  static bool settingIsReadOnly(const SettingInfo& setting);
+  // First ring position at or after `ring` whose row is enabled, walking `direction`. Falls back
+  // to the current position when every row is disabled.
+  int enabledRingFrom(int ring, int direction) const;
   void selectCategory(int categoryIndex);
   void applyUiSettingChange(uint8_t CrossPointSettings::* valuePtr);
 

--- a/src/components/UiAppHelpers.h
+++ b/src/components/UiAppHelpers.h
@@ -135,6 +135,37 @@ inline freeink::ui::BitmapRef listIconFor(const UIIcon icon, const int size = 24
 // The radii are deliberately larger than any switch we draw: fui::toggle clamps the track to
 // height/2 and the knob to its own height/2, so an over-large value is the way to say "fully
 // round" without restating the geometry here.
+// Thin a disabled row's contents with a checkerboard mask, drawn over the finished list.
+//
+// The SDK marks a disabled row by giving it a dithered gray foreground, and GfxRenderer's 1-bit
+// text path cannot draw one -- FreeInkUIGfxRenderer::text reduces any paint to black or white,
+// so a non-solid one is ignored and the row draws exactly like an active one. Knocking out every
+// other pixel is how the legacy themes greyed text, and it is what the reader menu already does;
+// this is that loop, shared, so every list greys the same way.
+//
+// Masks the row's whole content band rather than the label alone, so a disabled row's value or
+// switch dims with its label. Only ever clears pixels, so it thins dark content and leaves the
+// background untouched.
+template <typename Screen>
+void thinDisabledRows(const GfxRenderer& renderer, Screen& screen, const freeink::ui::ListProps& props,
+                      const freeink::ui::Rect& listRect, const int count, const int visibleRows) {
+  if (props.items == nullptr) return;
+  const int16_t rowHeight = props.rowHeight > 0 ? props.rowHeight : screen.theme().rowHeight;
+  const int16_t rowGap = props.rowGap >= 0 ? props.rowGap : screen.theme().listRowGap;
+  const int16_t inset = static_cast<int16_t>(screen.theme().listInset + screen.theme().listSidePadding);
+  const int16_t left = static_cast<int16_t>(listRect.x + inset);
+  const int16_t right = static_cast<int16_t>(listRect.right() - inset);
+  for (int i = props.topIndex; i < count && i < props.topIndex + visibleRows; i++) {
+    if (props.items[i].enabled) continue;
+    const int16_t top = static_cast<int16_t>(listRect.y + (i - props.topIndex) * (rowHeight + rowGap));
+    for (int y = top; y < top + rowHeight; y++) {
+      for (int x = left; x < right; x++) {
+        if ((x + y) % 2 == 0) renderer.drawPixel(x, y, false);
+      }
+    }
+  }
+}
+
 inline void applySwitchStyle(freeink::ui::ListProps& props) {
   props.toggleRadius = 0xFF;      // clamped to height/2 -> pill ends
   props.toggleKnobRadius = 0xFF;  // clamped to knobHeight/2 -> circular knob


### PR DESCRIPTION
Reader Settings reports which dictionary the book's language resolved to rather than offering a choice, so that row is built with a getter and no setter. Confirm on it did nothing while it still drew and focused like any other row.

## Unselectable

The row now draws disabled and the cursor steps over it. The rule is general rather than a special case for this row: an enum row with neither a settings field nor a setter has nothing Confirm could do. Action rows keep their enabled state, since they carry no value but still act — without that distinction every action row in Settings would have gone grey.

Three places needed it: the row's `enabled` flag, the button navigation ring, and both Confirm paths (`activateIndex` for touch, `handleButtons` for the physical button).

## Actually looking disabled

`enabled = false` alone changed nothing visually. The SDK marks a disabled row by giving it a dithered gray foreground, and `FreeInkUIGfxRenderer::text` reduces any paint to a single black/white bool:

```cpp
const bool black = !style.inverted && style.color != Color::White;
```

so a non-solid paint is ignored outright. Every row in the firmware that asks to be disabled has been drawing like an active one.

The reader menu already worked around this by knocking out every other pixel of a disabled row's text after the list is drawn — the same checkerboard the legacy themes used. That loop moves to a shared helper in `UiAppHelpers.h` and Reader Settings uses it too, so the dictionary row greys exactly like the menu's unavailable actions.

One deliberate difference from the menu's original loop: the helper masks the row's whole content band rather than the label alone, so a disabled row's value or switch dims along with its label. The menu's disabled rows carry no value, so it renders identically there.

## Testing

Device-tested on the X4: the dictionary row greys and is skipped, the rows around it still select and change, and the reader menu's unavailable actions look as they did before the helper replaced their inline loop.