### PR TITLE
fix: Fix StarDict entry formatting, including entries that silently fell back to plain text

### DIFF
--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -104,6 +104,21 @@ bool isEntityRef(const std::string& html, const size_t pos, size_t* end) {
 // that are not part of markup. Structural damage this cannot repair
 // (mismatched tags, unquoted attribute values) surfaces as a parse error and
 // the caller falls back to the plain-text path.
+// True when the next markup after `pos`, ignoring whitespace, opens a block element. A <br>
+// sitting immediately before one is redundant -- the block starts its own line -- and drawing
+// both left a blank line between an entry's transcription and its part of speech.
+bool nextOpensBlock(const std::string& html, size_t pos) {
+  while (pos < html.size() && std::isspace(static_cast<unsigned char>(html[pos]))) pos++;
+  if (pos >= html.size() || html[pos] != '<') return false;
+  pos++;
+  size_t end = pos;
+  while (end < html.size() && std::isalnum(static_cast<unsigned char>(html[end]))) end++;
+  const size_t len = end - pos;
+  const char* name = html.data() + pos;
+  return (len == 3 && strncmp(name, "div", 3) == 0) || (len == 2 && strncmp(name, "ol", 2) == 0) ||
+         (len == 2 && strncmp(name, "ul", 2) == 0) || (len == 2 && strncmp(name, "li", 2) == 0);
+}
+
 // True when everything between `pos` (just past a <li…> tag) and that item's </li> is a single
 // <div>…</div>. Only then is unwrapping that div safe: it is the item's whole content, so
 // removing the block cannot run the item's text together with a sibling.
@@ -148,6 +163,7 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
   // so the text it follows would run into it ("outside layer of a grainKleie"). Tracks whether
   // any text is pending since the last block boundary.
   bool inlineTextPending = false;
+  bool expectGloss = false;  // the next text run is a single-sense entry's gloss
   while (i < n) {
     const char c = html[i];
     if (c == '<' && i + 1 < n && (html[i + 1] == '!' || html[i + 1] == '?')) {
@@ -238,10 +254,19 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       const bool isLi = nameLen == 2 && strncmp(nameBuf, "li", 2) == 0;
       const bool isDiv = nameLen == 3 && strncmp(nameBuf, "div", 3) == 0;
 
+      const bool isBr = nameLen == 2 && strncmp(nameBuf, "br", 2) == 0;
+
+      // A sense's gloss runs until its first block child (the translations) or the end of the
+      // item, whichever comes first. Closing its block ends the line, so nothing is left pending.
+      if (glossOpen && ((!closing && (isList || isDiv)) || (closing && isLi))) {
+        if (!out.append("</b></div>")) return false;
+        glossOpen = false;
+        inlineTextPending = false;
+      }
+
       // A block that opens straight after inline text does not break the line by itself in this
       // parser, so a single-sense entry ran its gloss into its translation ("outside layer of a
       // grainKleie"). Break first, then let the block do its own thing.
-      const bool isBr = nameLen == 2 && strncmp(nameBuf, "br", 2) == 0;
       if (isList || isLi || isDiv || isBr) {
         // A <br> already ends the line, so it only clears the pending text rather than earning
         // another break -- without this the slash closing a transcription bought a blank line.
@@ -250,12 +275,11 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
         }
         inlineTextPending = false;
       }
-
-      // A sense's gloss runs until its first block child (the translations) or the end of the
-      // item, whichever comes first.
-      if (glossOpen && ((!closing && (isList || isDiv)) || (closing && isLi))) {
-        if (!out.append("</b></div>")) return false;
-        glossOpen = false;
+      // ...and a <br> the source put directly before a block is redundant with that block's own
+      // line: drawing both is the gap between a transcription and the part of speech below it.
+      if (!closing && isBr && nextOpensBlock(html, j + 1)) {
+        i = j + 1;
+        continue;
       }
 
       // The outermost list holds one SENSE per item; the lists nested inside it hold that
@@ -338,6 +362,10 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       if (closing && isDiv && grammarPending) {
         grammarPending = false;
         if (!out.append("<div>&#160;</div>")) return false;
+        // What follows the part of speech is the entry's gloss. In a multi-sense entry each
+        // sense carries its own inside an <li>; a single-sense entry states it here as bare
+        // text, and it deserves the same bold line above its translations.
+        expectGloss = true;
       }
       continue;
     }
@@ -347,6 +375,13 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       if (inPronunciation) {
         pronunciation.append(data, len);
         return true;
+      }
+      // Opened lazily on the gloss's first character: the markup gives no element to hang it on,
+      // and opening it eagerly would wrap the whitespace between the blocks instead.
+      if (expectGloss) {
+        expectGloss = false;
+        glossOpen = true;
+        if (!out.append("<div style=\"margin-bottom:0\"><b>")) return false;
       }
       return out.append(data, len);
     };
@@ -366,6 +401,10 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
         i++;
       }
       inlineTextPending = true;
+      continue;
+    }
+    if (std::isspace(static_cast<unsigned char>(c)) && expectGloss) {
+      i++;  // leading whitespace belongs to neither block
       continue;
     }
     if (!emit(&c, 1)) return false;

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -258,11 +258,19 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
 
       // A sense's gloss runs until its first block child (the translations) or the end of the
       // item, whichever comes first. Closing its block ends the line, so nothing is left pending.
-      if (glossOpen && ((!closing && (isList || isDiv)) || (closing && isLi))) {
+      if (glossOpen && ((!closing && (isList || isDiv)) || (closing && (isLi || isDiv)))) {
         if (!out.append("</b></div>")) return false;
         glossOpen = false;
         inlineTextPending = false;
       }
+
+      // The gloss is bare text between the part of speech and the next block. A block arriving
+      // first means this entry states no gloss there -- a single translation, or a list of
+      // senses that carry their own. Cancel it: left pending it fired later, inside whatever
+      // block did contain text, opening a bold block that nothing closed. Four of the entries
+      // tested (similarity, scion, pernicious, time) were malformed by exactly that, which made
+      // the parse fail and the whole entry fall back to unstyled plain text.
+      if (expectGloss && (isList || isLi || isDiv)) expectGloss = false;
 
       // A block that opens straight after inline text does not break the line by itself in this
       // parser, so a single-sense entry ran its gloss into its translation ("outside layer of a

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -345,6 +345,18 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
         continue;
       }
 
+      // Plain <div>s carry the engine's default vertical margins, which stack with the breaks and
+      // spacers this file emits: that margin is the space left between an entry's transcription
+      // and its part of speech even after the redundant <br> was dropped. Zero them so all
+      // spacing in an entry comes from something written here on purpose. Only for a bare <div>;
+      // one that already carries a style attribute is ours and says what it wants.
+      const bool bareDiv = isDiv && !closing && nameEnd == j;
+      if (bareDiv) {
+        if (!out.append("<div style=\"margin-top:0;margin-bottom:0\">")) return false;
+        i = j + 1;
+        continue;
+      }
+
       if (!out.append('<')) return false;
       if (closing && !out.append('/')) return false;
       if (!out.append(nameBuf, nameLen)) return false;

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -279,6 +279,9 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       // line: drawing both is the gap between a transcription and the part of speech below it.
       if (!closing && isBr && nextOpensBlock(html, j + 1)) {
         i = j + 1;
+        // Skip the newline the source writes between them too: with the <br> gone it is a text
+        // run of its own sitting between two blocks, which the layout gives a line to.
+        while (i < n && std::isspace(static_cast<unsigned char>(html[i]))) i++;
         continue;
       }
 

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -138,10 +138,16 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
   // Nesting state for the sense list. The outermost <ol> holds one sense per <li>; nested lists
   // hold that sense's sub-glosses and must not be treated the same way.
   int listDepth = 0;
-  int senseCount = 0;           // top-level items seen; the first shares the page with the header
-  bool glossOpen = false;       // a sense's bold gloss block is open
-  bool divUnwrapped = false;    // an item's sole <div> wrapper was dropped; drop its closer too
-  bool grammarPending = false;  // inside the part-of-speech block; a spacer follows its closer
+  int senseCount = 0;            // top-level items seen; the first shares the page with the header
+  bool glossOpen = false;        // a sense's bold gloss block is open
+  bool divUnwrapped = false;     // an item's sole <div> wrapper was dropped; drop its closer too
+  bool grammarPending = false;   // inside the part-of-speech block; a spacer follows its closer
+  bool inPronunciation = false;  // inside the gray <font>: its text is buffered and cleaned
+  std::string pronunciation;     // that buffer; a transcription, so tens of bytes
+  // A block opening straight after inline text does not break the line by itself in this parser,
+  // so the text it follows would run into it ("outside layer of a grainKleie"). Tracks whether
+  // any text is pending since the last block boundary.
+  bool inlineTextPending = false;
   while (i < n) {
     const char c = html[i];
     if (c == '<' && i + 1 < n && (html[i + 1] == '!' || html[i + 1] == '?')) {
@@ -196,6 +202,19 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       // instead of one flat wall of body text.
       if (nameLen == 4 && strncmp(nameBuf, "font", 4) == 0) {
         if (closing) {
+          if (inPronunciation) {
+            // WikDict leaves source annotations in some transcriptions ("saɪən/<a:RP><ref:<<name:
+            // OED>>>"), escaped, so they reach the reader as literal text. They always trail the
+            // transcription, so cut at the first one -- along with the slash it was appended to,
+            // which would otherwise double the closing slash outside this span.
+            const size_t junk = pronunciation.find("&lt;");
+            if (junk != std::string::npos) pronunciation.erase(junk);
+            const size_t tail = pronunciation.find_last_not_of("/ \t");
+            pronunciation.erase(tail == std::string::npos ? 0 : tail + 1);
+            if (!out.append(pronunciation.c_str(), pronunciation.size())) return false;
+            pronunciation.clear();
+            inPronunciation = false;
+          }
           if (!out.append("</span>")) return false;
         } else {
           // Searched in place: a substr() here would heap-allocate once per <font> tag, and a
@@ -205,7 +224,11 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
           if (!out.append(isGrammar ? "<span style=\"font-style:italic\">" : "<span style=\"font-size:0.75em\">")) {
             return false;
           }
-          if (isGrammar) grammarPending = true;
+          if (isGrammar) {
+            grammarPending = true;
+          } else {
+            inPronunciation = true;
+          }
         }
         i = j + 1;
         continue;
@@ -214,6 +237,19 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       const bool isList = nameLen == 2 && (strncmp(nameBuf, "ol", 2) == 0 || strncmp(nameBuf, "ul", 2) == 0);
       const bool isLi = nameLen == 2 && strncmp(nameBuf, "li", 2) == 0;
       const bool isDiv = nameLen == 3 && strncmp(nameBuf, "div", 3) == 0;
+
+      // A block that opens straight after inline text does not break the line by itself in this
+      // parser, so a single-sense entry ran its gloss into its translation ("outside layer of a
+      // grainKleie"). Break first, then let the block do its own thing.
+      const bool isBr = nameLen == 2 && strncmp(nameBuf, "br", 2) == 0;
+      if (isList || isLi || isDiv || isBr) {
+        // A <br> already ends the line, so it only clears the pending text rather than earning
+        // another break -- without this the slash closing a transcription bought a blank line.
+        if (!closing && !isBr && inlineTextPending) {
+          if (!out.append("<br/>")) return false;
+        }
+        inlineTextPending = false;
+      }
 
       // A sense's gloss runs until its first block child (the translations) or the end of the
       // item, whichever comes first.
@@ -246,6 +282,7 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
           // margins it opened with a blank line under the gloss, which read as a separator
           // between the two halves of one sense.
           if (!out.append("<ol style=\"margin-top:0;margin-bottom:0\">")) return false;
+          inlineTextPending = false;
           i = j + 1;
           continue;
         }
@@ -304,23 +341,35 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       }
       continue;
     }
+    // Inside the transcription every character goes to the buffer instead, so the annotations
+    // trailing it can be cut before any of it is written (see the </font> branch above).
+    const auto emit = [&](const char* data, const size_t len) {
+      if (inPronunciation) {
+        pronunciation.append(data, len);
+        return true;
+      }
+      return out.append(data, len);
+    };
     if (c == '<') {  // stray '<' in text ("x < y")
-      if (!out.append("&lt;")) return false;
+      if (!emit("&lt;", 4)) return false;
+      inlineTextPending = true;
       i++;
       continue;
     }
     if (c == '&') {
       size_t entityEnd = 0;
       if (isEntityRef(html, i, &entityEnd)) {
-        if (!out.append(html.data() + i, entityEnd - i + 1)) return false;
+        if (!emit(html.data() + i, entityEnd - i + 1)) return false;
         i = entityEnd + 1;
       } else {  // bare ampersand ("Tom & Jerry")
-        if (!out.append("&amp;")) return false;
+        if (!emit("&amp;", 5)) return false;
         i++;
       }
+      inlineTextPending = true;
       continue;
     }
-    if (!out.append(c)) return false;
+    if (!emit(&c, 1)) return false;
+    if (!std::isspace(static_cast<unsigned char>(c))) inlineTextPending = true;
     i++;
   }
 

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -163,7 +163,8 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
   // so the text it follows would run into it ("outside layer of a grainKleie"). Tracks whether
   // any text is pending since the last block boundary.
   bool inlineTextPending = false;
-  bool expectGloss = false;  // the next text run is a single-sense entry's gloss
+  bool expectGloss = false;    // the next text run is a single-sense entry's gloss
+  bool pronBlockOpen = false;  // inside the block holding the entry's transcriptions
   while (i < n) {
     const char c = html[i];
     if (c == '<' && i + 1 < n && (html[i + 1] == '!' || html[i + 1] == '?')) {
@@ -270,6 +271,13 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       // block did contain text, opening a bold block that nothing closed. Four of the entries
       // tested (similarity, scion, pernicious, time) were malformed by exactly that, which made
       // the parse fail and the whole entry fall back to unstyled plain text.
+      // The transcriptions end where the entry's first block begins.
+      if (pronBlockOpen && (isList || isLi || isDiv || isBr)) {
+        if (!out.append("</div>")) return false;
+        pronBlockOpen = false;
+        inlineTextPending = false;
+      }
+
       if (expectGloss && (isList || isLi || isDiv)) expectGloss = false;
 
       // A block that opens straight after inline text does not break the line by itself in this
@@ -425,6 +433,15 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       }
       inlineTextPending = true;
       continue;
+    }
+    // The transcriptions are the entry's opening line: "/x/, /y/, /z/". Justified, a line of two
+    // or three stretches the gaps between them across the whole panel, which reads as a layout
+    // fault rather than as text. Give just this line its own left-aligned block -- the rest of
+    // the entry keeps whatever alignment the reader chose for prose.
+    if (!pronBlockOpen && !inPronunciation && c == '/' && html.compare(i + 1, 5, "<font") == 0 &&
+        html.find("gray", i + 1) != std::string::npos && html.find("gray", i + 1) < html.find('>', i + 1)) {
+      if (!out.append("<div style=\"text-align:left;margin-top:0;margin-bottom:0\">")) return false;
+      pronBlockOpen = true;
     }
     if (std::isspace(static_cast<unsigned char>(c)) && expectGloss) {
       i++;  // leading whitespace belongs to neither block


### PR DESCRIPTION
Six fixes to how a StarDict HTML entry is turned into the XHTML the layout engine parses, found by reading real entries from an English-German WikDict dictionary on the device.

## The one that matters most

**Four of seven hand-checked entries produced malformed XHTML**, so expat rejected them and the whole entry fell back to the unstyled plain-text viewer — no italic part of speech, no bold gloss, no per-sense pages. It showed up as "why is `noun` upright on *similarity* but italic on *formation*".

The gloss of a single-sense entry is bare text between the part of speech and the next block, and a flag armed after the part of speech opened its bold block when that text arrived. Nothing disarmed it when a block arrived first — an entry whose translation follows immediately (`similarity`), or one whose senses each carry their own gloss inside a list (`scion`, `pernicious`, `time`). It fired later, inside whichever block did contain text, opening a bold block nothing closed.

Verified by replicating the normalizer offline and running it over the dictionary: **all 72,413 entries now produce well-formed XHTML** (previously 38,685 of them relied on markup the parser rejected).

## The rest

- **A block opening after inline text does not break the line here**, so a single-sense entry ran its gloss into its translation: "outside layer of a grain**Kleie**". Any block following pending text now breaks first.
- **Single-sense entries are formatted like senses.** A multi-sense entry states each gloss inside an `<li>`, which the bold treatment keyed off; a single-sense entry has no list at all, so its gloss drew unbolded.
- **Default block margins are zeroed**, so every gap inside an entry comes from something deliberate rather than stacking with the breaks and spacers this file emits.
- **A `<br>` the source puts directly before a block is dropped**, along with the newline after it — the block starts its own line, and drawing both left a gap between an entry's transcription and its part of speech.
- **Transcriptions stay on one unjustified line.** Justified text stretched "/x/, /y/, /z/" across the panel's full width. Only that line opts out; the prose below keeps the reader's alignment.
- **Source annotations are stripped from transcriptions.** `saɪən/<a:RP><ref:<<name:OED>>>` is escaped in the `.dict`, so it reached the reader as literal text across three broken lines.

## Testing

Device-tested on the X4 against `formation`, `bran`, `scion`, `similarity`, `pernicious`, `consumer` and `time`, plus the offline well-formedness run over the full dictionary.