### PR TITLE
fix(sleep): restore 1-bit alpha-masked PNG transparent sleep overlay

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -717,45 +717,37 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
   // them gives the PNG decoder the roughly 60 KB it needs.
   if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
 
-  ImageDimensions dimensions;
-  if (!PngToFramebufferConverter::getDimensionsStatic(path, dimensions)) return false;
+  ImageDimensions dims{};
+  if (!PngToFramebufferConverter::getDimensionsStatic(path, dims)) return false;
+  if (dims.width <= 0 || dims.height <= 0) return false;
 
-  const auto placement = calculateBitmapPlacement(dimensions.width, dimensions.height, renderer);
-  RenderConfig config;
-  config.x = placement.x;
-  config.y = placement.y;
-  config.maxWidth = renderer.getScreenWidth();
-  config.maxHeight = renderer.getScreenHeight();
-  config.useDithering = false;
-  config.sourceCropX = placement.cropX;
-  config.sourceCropY = placement.cropY;
-  config.useExactDimensions = placement.cropX > 0.0f || placement.cropY > 0.0f;
+  const int pageWidth = renderer.getScreenWidth();
+  const int pageHeight = renderer.getScreenHeight();
+  
+  float scale = 1.0f;
+  if (dims.width > 0 && dims.height > 0) {
+    const float widthScale = static_cast<float>(pageWidth) / static_cast<float>(dims.width);
+    const float heightScale = static_cast<float>(pageHeight) / static_cast<float>(dims.height);
+    scale = std::min(widthScale, heightScale);
+    if (scale > 1.0f) scale = 1.0f;
+  }
+  
+  const int dstWidth = static_cast<int>(dims.width * scale);
+  const int dstHeight = static_cast<int>(dims.height * scale);
+
+  RenderConfig config{};
+  config.x = (pageWidth - dstWidth) / 2;
+  config.y = (pageHeight - dstHeight) / 2;
+  config.maxWidth = pageWidth;
+  config.maxHeight = pageHeight;
+  config.useGrayscale = false;
   config.preserveAlpha = true;
 
   PngToFramebufferConverter converter;
-  LOG_DBG("SLP", "Rendering transparent PNG overlay: %s (%dx%d)", path.c_str(), dimensions.width, dimensions.height);
+  LOG_DBG("SLP", "Rendering transparent PNG overlay: %s (%dx%d)", path.c_str(), dims.width, dims.height);
 
   if (!converter.decodeToFramebuffer(path, renderer, config)) return false;
-  renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
-
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    return true;
-  }
-  renderer.copyGrayscaleLsbBuffers();
-
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    return true;
-  }
-  renderer.copyGrayscaleMsbBuffers();
-
-  renderer.displayGrayBuffer();
-  renderer.setRenderMode(GfxRenderer::BW);
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
   return true;
 }
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -723,7 +723,7 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
 
   const int pageWidth = renderer.getScreenWidth();
   const int pageHeight = renderer.getScreenHeight();
-  
+
   float scale = 1.0f;
   if (dims.width > 0 && dims.height > 0) {
     const float widthScale = static_cast<float>(pageWidth) / static_cast<float>(dims.width);
@@ -731,7 +731,7 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
     scale = std::min(widthScale, heightScale);
     if (scale > 1.0f) scale = 1.0f;
   }
-  
+
   const int dstWidth = static_cast<int>(dims.width * scale);
   const int dstHeight = static_cast<int>(dims.height * scale);
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -724,13 +724,10 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
   const int pageWidth = renderer.getScreenWidth();
   const int pageHeight = renderer.getScreenHeight();
 
-  float scale = 1.0f;
-  if (dims.width > 0 && dims.height > 0) {
-    const float widthScale = static_cast<float>(pageWidth) / static_cast<float>(dims.width);
-    const float heightScale = static_cast<float>(pageHeight) / static_cast<float>(dims.height);
-    scale = std::min(widthScale, heightScale);
-    if (scale > 1.0f) scale = 1.0f;
-  }
+  const float widthScale = static_cast<float>(pageWidth) / static_cast<float>(dims.width);
+  const float heightScale = static_cast<float>(pageHeight) / static_cast<float>(dims.height);
+  float scale = std::min(widthScale, heightScale);
+  if (scale > 1.0f) scale = 1.0f;
 
   const int dstWidth = static_cast<int>(dims.width * scale);
   const int dstHeight = static_cast<int>(dims.height * scale);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Restores the 1-bit transparent PNG overlay rendering logic for the sleep screen so the page content behind the overlay is preserved instead of being cleared.

* **What changes are included?**
Reverts the multi-pass 4-level grayscale PNG decode path in `SleepActivity::renderTransparentOverlayPng` back to single-pass 1-bit decode with `config.preserveAlpha = true;` and a single display refresh (`HalDisplay::HALF_REFRESH`).

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

* The upstream 4-level grayscale implementation called `renderer.clearScreen(0x00)` prior to rendering MSB/LSB passes, erasing the retained reader page from the framebuffer.
* Single-pass 1-bit alpha masking avoids wiping the background and saves unnecessary decoding passes on ESP32-C3.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_