### PR TITLE
fix: two reader cache/resume bugs behind a library-book crash loop

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2845,9 +2845,18 @@ void EpubReaderActivity::runPostRenderTail(const uint16_t viewportWidth, const u
   // Horizontal reports estimatedTotalPages(), not pageCount: during a partial build the estimate
   // is the meaningful total, and it moving is itself worth persisting. Compare against the same
   // value that gets stored, or the guard never settles.
+  // Gated on footnoteDepth == 0: currentSpineIndex points at the footnote/endnote target
+  // while footnoteDepth > 0 (see navigateToHref), not the book position the reader should
+  // resume at. onExit() already special-cases this by saving the pre-footnote origin instead
+  // -- but this per-render autosave runs on every page turn, including turns taken while
+  // reading a multi-page endnote, and would otherwise overwrite that origin with the
+  // in-footnote position before onExit ever runs. If the device then crashes or loses power
+  // while still inside the footnote, the saved resume point is left pointing into the notes
+  // file instead of the book.
   const int page = vertical ? verticalSection->currentPage : section->currentPage;
   const int pageCount = vertical ? verticalSection->pageCount : section->estimatedTotalPages();
-  if (currentSpineIndex != lastSavedSpineIndex || page != lastSavedPage || pageCount != lastSavedPageCount) {
+  if (footnoteDepth == 0 &&
+      (currentSpineIndex != lastSavedSpineIndex || page != lastSavedPage || pageCount != lastSavedPageCount)) {
     if (saveProgress(currentSpineIndex, page, pageCount, verticalOverride, furiganaOverride)) {
       lastSavedSpineIndex = currentSpineIndex;
       lastSavedPage = page;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix two independent bugs found while diagnosing a user-reported library-book crash loop and a follow-up "book won't load" report on a different book. Both are in reading-progress/section-cache persistence: a transient failure (crash mid-footnote, a failed file removal) gets turned into a *permanent* stuck state instead of being handled or retried cleanly.
* **What changes are included?**
  1. `EpubReaderActivity::runPostRenderTail` (`src/activities/reader/EpubReaderActivity.cpp`) now gates its per-page progress autosave on `footnoteDepth == 0`.
  2. `Section::commitBuildFile` (`lib/Epub/Epub/Section.cpp`) now checks the result of the `remove()` call that clears the old cache file before swapping the rebuilt one into place, instead of ignoring it and falling through to a `rename()` that was doomed to fail too.

### Fix 1: footnote autosave (boot loop)

`onExit()` already special-cases footnote reading: if you exit the reader while `footnoteDepth > 0`, it saves the pre-footnote *origin* position instead of wherever you currently are, specifically because "leaving mid-footnote loses the in-RAM return stack."

But `runPostRenderTail()` — which runs after **every** page render — saved `currentSpineIndex`/page unconditionally, with no `footnoteDepth` check. Tapping a footnote/endnote reference calls `navigateToHref()`, which repoints `currentSpineIndex` at the note's target chapter (e.g. `notes.xhtml`). Turning even one page while reading a multi-page endnote silently overwrote the saved resume position with that in-footnote location, defeating `onExit()`'s safeguard before it ever ran.

If the device then crashed or lost power while still inside the footnote, the persisted resume point was left pointing into the notes file. Since the reader always reopens at the last saved position on boot, this turned a one-off crash while reading an endnote into a boot loop: every restart reopened the same page and re-triggered whatever faulted there.

This was diagnosed from a user-submitted crash report where a boot loop's panic dump, decoded from raw stack memory, showed the device mid-render of a paragraph containing an endnote reference (`<sup><a href="notes.xhtml#...">9</a></sup>`) at the moment of the fault. Deleting the affected book's cache confirmed the boot loop was purely the resume position, not a corrupted book file.

**Fix:** gate the autosave on `footnoteDepth == 0`, matching the intent already expressed by `onExit()`.

### Fix 2: cache-swap failure loop (stuck book)

Follow-up serial log from the same user, on a *different* book, showed the reader permanently unable to open a chapter:

```
[ERR] [PGE] Deserialization failed: Unknown tag 78
[ERR] [SCT] Failed to move built section into place
[ERR] [ERS] Background section build failed
[ERR] [SCT] Deserialization failed: Unknown version 123
[ERR] [SCT] Failed to clear cache
```
repeating forever, once per page-turn attempt.

`Section::commitBuildFile()` deletes the old cache file and renames the newly-built one over it, but never checked whether the delete succeeded:

```cpp
if (Storage.exists(filePath.c_str())) {
  Storage.remove(filePath.c_str());   // return value ignored
}
if (!Storage.rename(binTmpPath().c_str(), filePath.c_str())) {
  LOG_ERR("SCT", "Failed to move built section into place");
  Storage.remove(binTmpPath().c_str());  // the freshly-rebuilt GOOD file is discarded here
  return false;
}
```

SdFat's `rename()` won't overwrite an existing destination, so if `remove()` fails for any reason, the follow-up `rename()` fails too — and that failure branch deletes the freshly-rebuilt tmp as cleanup, discarding a successful rebuild while leaving the old (usually already-corrupt, since that's typically why a rebuild was triggered) file untouched. Every subsequent load re-detects the same corruption, retriggers the same rebuild, and hits the same stuck `remove()` again: a permanent retry loop with no way to make progress.

**Fix:** check `remove()`'s result and bail out before attempting `rename()`, so the failure is reported once instead of repeating forever.

**Note on scope of this fix:** this stops the *unproductive infinite retry loop* and makes the failure legible (one clean error instead of a repeating loop). It does not by itself explain *why* `remove()` failed for the affected user in the first place — that could be a lingering open handle or, more likely given `rename()` failed too, an underlying SD-card/filesystem issue. The user is separately checking their card's health; deleting the affected book's whole cache folder was the workaround.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. *(N/A — this only touches reader activity and section-cache logic.)*

## Additional Context

* No memory/flash footprint impact for either fix: no new allocations. Fix 1 adds a boolean check on an existing member variable; fix 2 adds one existing-variable check and a log line.
* I was not able to run `pio run` in this environment (PlatformIO/ESP32 toolchain not installed), so the build has **not** been verified here — please run CI / a local build before merging. Both changes are small, localized conditionals with no new includes or signatures touched.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**
