### PR TITLE
fix: drop the Resume shortcut from the home screen

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -332,14 +332,6 @@ void HomeActivity::loop() {
     return;
   }
 
-  // Back is otherwise unused on the home menu: open the most recently read
-  // book directly (recentBooks is most-recent-first and already pruned of
-  // files missing from the SD card).
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && !recentBooks.empty()) {
-    onSelectBook(recentBooks[0].path);
-    return;
-  }
-
   const int coverColumnCount = std::max(1, metrics.homeRecentBooksCount);
   const int recentCount = std::min(static_cast<int>(recentBooks.size()), coverColumnCount);
   const int coverColumnWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / coverColumnCount;
@@ -470,8 +462,10 @@ void HomeActivity::render(RenderLock&&) {
       [&menuItems](int index) { return std::string(menuItems[index]); },
       [&menuIcons](int index) { return menuIcons[index]; });
 
-  const auto labels = mappedInput.mapLabels(recentBooks.empty() ? "" : tr(STR_RESUME), tr(STR_SELECT), tr(STR_DIR_UP),
-                                            tr(STR_DIR_DOWN));
+  // Back carries no action on the home menu, so it gets no hint. It used to open
+  // the most recent book, which sits under a button the reader otherwise treats
+  // as "go back" and was too easy to hit by accident.
+  const auto labels = mappedInput.mapLabels("", tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   lastRenderValid = true;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Remove the bottom-left **Resume** button from the Home screen. It bound `Button::Back` to "open the most recently read book" — Back is the one button a reader presses without looking, expecting to go back, so the shortcut fired by accident and dropped them into a book.
* **What changes are included?**
  * `src/activities/home/HomeActivity.cpp` — drop the `Button::Back` handler that called `onSelectBook(recentBooks[0].path)`, and pass `""` instead of `tr(STR_RESUME)` as the Back label to `mapLabels()`, so `drawButtonHints()` skips the empty slot and draws no hint there.

Nothing is lost: the most recent book stays one press away via the **Reading Mode** menu entry and the cover tile, both deliberate targets.

`STR_RESUME` is left in `lib/I18n/translations/*.yaml` even though it is now unreferenced. `.cplang` language packs index strings positionally and store a `key_count` alongside `LANG_PACK_VERSION`, so removing the key would shift every later index and silently mis-render packs written by older builds. That cleanup belongs with a pack-version bump, not here.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — n/a, this PR touches none of those.

This is a removal, not a feature: it makes an existing screen behave the way its buttons already read.

## Additional Context

* **Memory / flash impact:** negligible and slightly negative. `pio run -e default` after the change: RAM 16.8% (55,060 / 327,680 bytes), Flash 89.7% (5,875,825 / 6,553,600 bytes) — 72 bytes RAM and a few hundred bytes of flash below the same build before it, from the dropped branch and hint string reference.
* **Areas to focus on:** the Back button now has no action on the home menu at all. If a future change wants something there, it should be a target the reader aims at rather than the back-affordance.
* **Orientation:** the hint bar is unaffected — `drawButtonHints()` already skips empty labels, and `mapLabels()`/`mapFrontLabels()` still place the remaining three by the user's front-button configuration, so custom button remaps and all four orientations behave as before.
* **Not verified on hardware.** Build passes; the on-device check is that the Home screen shows three hints instead of four and that pressing Back there does nothing.
* `./bin/clang-format-fix -g` could not be run — it requires clang-format 21 and this environment has 18. The changed lines are within the 120-column limit and match the surrounding style; the PR format check is the real gate.
* Docs: `README.md` (Japanese learning features) and `USER_GUIDE.md` §3.1 do not document this shortcut, so neither needed an update.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff)_