### PR TITLE
fix: leave the library on the Back release edge (#136)

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -854,7 +854,7 @@ void RecentBooksActivity::loop() {
       renderer.getScreenHeight() - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing;
 
   if (openShelfIndex >= 0) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       openShelfIndex = -1;
       shelfBooks.clear();
       shelfBookProgress.clear();
@@ -969,7 +969,9 @@ void RecentBooksActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+  // Release, not press: leaving on the press edge hands the release of the same
+  // physical click to whichever activity comes next, which then acts on it too.
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     if (contentIndex > 0) {
       contentIndex = 0;
       scrollRow = 0;


### PR DESCRIPTION
Fixes #136.

## Summary

* **What is the goal of this PR?** Stop the Library's Back press from registering twice. Opening the Library and going back registered the click on two screens; the second registration landed on the home screen and opened the last book.
* **What changes are included?**
  * `src/activities/home/RecentBooksActivity.cpp` — both `Button::Back` handlers move from `wasPressed()` to `wasReleased()`.

### Root cause

One physical click produces two edges, and the activity switch happened *between* them. `RecentBooksActivity` was the only screen leaving on the **press** edge:

```
press    RecentBooksActivity::loop() -> onGoHome()
         ActivityManager tears the activity down and enters HomeActivity,
         in the same tick (the pending-action drain runs right after loop())
release  arrives with HomeActivity current -> HomeActivity reads it as its own
```

`HomeActivity` bound Back to "open the most recently read book", so that stale release resumed reading. The attached log shows it as two panel refreshes 467 ms apart — `X3_DRF` at `77544` and `78011` — for a single press.

`InputManager` is not at fault: `pressedEvents`/`releasedEvents` are cleared at the top of every `update()` and recomputed from the state delta, so no event is sticky. The mismatch is purely that the transition consumed one edge and left the other for whoever came next.

### The fix

Handle Back on release in both handlers, matching `UiListActivity` and the 45 other `wasReleased(Button::Back)` sites in `src/`. An edge that starts inside an activity now also ends there, so nothing is left over for its successor.

Touch is unaffected: `MappedInputManager::wasReleased(Back)` short-circuits on `wasBackGesture()` exactly as `wasPressed(Back)` did, so the left-edge swipe still goes back.

### Note on #137

[#137](https://github.com/eszter007/matcha-reader/pull/137) removed the Home screen's Back → resume binding, so on current `develop` the visible consequence is already gone — the stale release now lands on a screen with no Back handler. This PR fixes the mechanism that produced it, so the bug cannot come back the moment anything is bound to Back on the home screen again.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — n/a, this PR touches none of those. The fix stays in `src/` deliberately; see below.

Bug fix to existing behaviour, no new surface.

## Additional Context

* **Memory / flash impact:** none. `pio run -e default` reports RAM 16.8% (55,060 / 327,680) and Flash 89.7% (5,875,825 / 6,553,600) — byte-identical to `develop`, as expected for swapping which edge a predicate reads.
* **Other screens use the same press-edge pattern and have the same latent bleed** — I left them alone as out of scope for this issue, but flagging them:
  * `WifiSelectionActivity.cpp:596, 613, 677` — cancel scan / cancel auto-connect / skip save, each followed by `onComplete()`
  * `CalibreConnectActivity.cpp:124, 143` — the second one samples Back inside a tight polling loop, where press-edge sampling looks deliberate

  These all cancel blocking network work, where reacting on press is plausibly intentional, so they deserve their own judgement rather than a blanket sweep.
* **Considered and rejected:** a general guard in `ActivityManager` that masks the release edge of any button held across a switch. It would cover the press-edge screens above too, but it puts suppression state in shared input plumbing for what is really a convention violation in one file, and I can't exercise the hold-across-transition cases on hardware. Worth doing only if the press-edge screens are kept as-is deliberately.
* **Unrelated log noise seen in the same capture**, not touched here: `[LIB] Failed to open file for reading: /.crosspoint/epub_*/progress.bin` is logged at error level for books that simply have no saved progress yet — an expected-missing file, three lines per Library open.
* **Not verified on hardware.** Build passes. The on-device check is: Home → Library → Back returns to Home and stays there; and inside a shelf, Back closes the shelf without also leaving the Library.
* `./bin/clang-format-fix -g` could not be run — it needs clang-format 21 and this environment has 18. The changed lines are within the 120-column limit; the PR format check is the real gate.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff)_