### PR TITLE
fix: drop the redundant grayscale settle pass at sleep entry (#135)

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -527,11 +527,16 @@ void SleepActivity::onEnter() {
   // a scrubbed base. Still never the flashing GC waveform: the OEM X4 firmware's only clean
   // refresh in normal operation is the single-pass 0xD7 sequence, never the multi-flash GC
   // waveform (0xF7) that FULL_REFRESH selects (#2471's blinking complaint).
-  // preconditionGrayscale() settles the gray planes on X3 and is a documented no-op on X4.
+  // The scrub is the HALF pass alone. No preconditionGrayscale() here: that is the
+  // settle pass for an imminent grayscale plane write (see XtcReaderActivity), and
+  // every grayscale sleep screen below reaches the panel through
+  // displayGrayscaleBase(), which fires the same AA-pre-BW(mid) bank itself. Calling
+  // it here bought nothing on X4, where it is a documented no-op, and cost X3 a
+  // second full visible pass -- Uc8253X3Driver::preconditionGrayscale() ends in
+  // triggerRefresh() -- for every sleep, grayscale or not.
   // Costs one HALF (~1s) at sleep entry, and only when needed.
   if (renderer.panelHasResidue()) {
     renderer.displayBuffer(HalDisplay::HALF_REFRESH);
-    renderer.preconditionGrayscale();
   }
 
   const bool frameWasInverted = display.isInverted();


### PR DESCRIPTION
Fixes #135.

## Summary

* **What is the goal of this PR?** Stop the X3 refreshing the panel twice when going to sleep, which made shutdown take roughly double the stock firmware's time. The X4 was never affected.
* **What changes are included?**
  * `src/activities/boot_sleep/SleepActivity.cpp` — drop `renderer.preconditionGrayscale()` from the residue scrub in `onEnter()`. The `displayBuffer(HalDisplay::HALF_REFRESH)` scrub stays.

### Why it was X3-only

The scrub block ran two things:

```cpp
if (renderer.panelHasResidue()) {
  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
  renderer.preconditionGrayscale();
}
```

`preconditionGrayscale()` is the settle pass for an *imminent grayscale plane write*, not a scrub — `PanelDriver.h` documents it as "fire after the BW base frame is displayed, before grayscale planes are written."

* `Uc8179Driver::preconditionGrayscale()` (X4) is deliberately empty — *"Intentionally no extra pass."* It cost nothing, so the asymmetry stayed invisible.
* `Uc8253X3Driver::preconditionGrayscale()` ends in `triggerRefresh()` — a second full visible panel pass, fired on **every** sleep, including blank, default and custom B/W sleep screens where no grayscale plane is ever written.

### Why removing it is safe, not just cheaper

It was redundant even on the grayscale sleep screens. Every one of them (`renderCoverSleepScreen`, `renderCustomSleepScreen`, the transparent overlay path) reaches the panel through `displayGrayscaleBase(HalDisplay::HALF_REFRESH)` before writing planes — and `Uc8253X3Driver::displayGrayscaleBase()` fires the same `AA-pre-BW(mid)` bank itself, on both its differential branch and its `cleanBaseNeeded` fallback. That is exactly what the X4 driver's comment points at:

> The correct stock transition has to run while DTM1 still contains the previous page and is therefore performed by `displayGrayscaleBase()`.

The HALF pass is the part that actually scrubs residue, and it stays. The ghosting this block was added for is not what the settle pass fixed: the X4 has been ghost-free at sleep the whole time with the precondition compiled out as a no-op.

`XtcReaderActivity`'s paired `displayBuffer(HALF)` + `preconditionGrayscale()` is deliberately untouched — there grayscale planes really are written immediately after, which is the call's intended use.

### Matching the log

The attached capture shows the two bursts for one sleep, each a `926 / 454 / 430 / 47x ms` `X3_DRF` sequence, before the closing `X3 power-down (51 ms)`:

```
[19356] X3_DRF (926 ms) … [21415] X3_DRF (378 ms)     <- HALF scrub + settle pass
[24798] X3_DRF (926 ms) … [26461] X3_DRF (480 ms)     <- the sleep screen itself
[29560] X3 power-down (51 ms)
```

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — **not needed: nothing under those paths is modified.** The fix is one deleted call in `src/`; the driver behaviour it describes is read-only evidence.

Bug fix restoring stock-comparable sleep timing. Deliberately fixed in `src/` rather than by changing the X3 driver: `preconditionGrayscale()` is correct as written and is still used correctly by `XtcReaderActivity` — the caller was wrong, not the driver.

## Additional Context

* **Memory / flash impact:** Flash 5,875,817 / 6,553,600 (89.7%), 8 bytes below `develop` — the removed call. RAM unchanged at 16.8% (55,060 / 327,680).
* **Expected effect on device:** one visible panel pass at sleep instead of two on X3, roughly halving the reported shutdown time; X4 behaviour is bit-identical since the removed call compiled to nothing there.
* **Areas to focus on:** the ghosting regression this block originally guarded against (grain plus a negative reader-menu ghost frozen for hours). My argument that the HALF pass alone is sufficient rests on the X4 having always run without the settle pass — worth a confirming look on an X3 that sleeps straight out of an image page or a FAST-turn reader view, which is where residue is highest.
* **Not verified on hardware** — I have no X3. Build passes. The on-device check is: sleep from a reader page and confirm a single refresh before power-down, then wake and confirm no grain or ghost on the sleep image.
* `./bin/clang-format-fix -g` could not be run — it needs clang-format 21 and this environment has 18. Only a comment block and one deleted line changed, all within the 120-column limit; the PR format check is the real gate.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff)_