### PR TITLE
fix: home screen stub button, and the class-scan buffer on the render stack

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -21,7 +21,16 @@ void collectHtmlClasses(const std::string& path, std::vector<std::string>& out, 
   if (!HalStorage::getInstance().openFileForRead("SCT", path, f)) return;
   constexpr char NEEDLE[] = "class=\"";
   constexpr size_t NLEN = sizeof(NEEDLE) - 1;
-  uint8_t buf[512];
+  constexpr size_t READ_CHUNK = 512;
+  // Heap, not stack: 512 bytes is twice the project's stack-local ceiling, and this
+  // runs on the ActivityManagerRender task, which also carries full page rendering
+  // (GfxRenderer, font cache, SD I/O) in the same 8 KB. A crash dump from a chapter
+  // build showed this buffer's contents live on that stack.
+  auto buf = makeUniqueNoThrow<uint8_t[]>(READ_CHUNK);
+  if (!buf) {
+    LOG_ERR("SCT", "OOM: %u bytes for class scan", static_cast<unsigned>(READ_CHUNK));
+    return;  // out stays empty: the caller then loads the CSS cache unfiltered, as before
+  }
   size_t matched = 0;
   bool inValue = false;
   std::string token;
@@ -37,7 +46,7 @@ void collectHtmlClasses(const std::string& path, std::vector<std::string>& out, 
     token.clear();
   };
   size_t n;
-  while ((n = f.read(buf, sizeof(buf))) > 0 && out.size() < maxOut) {
+  while ((n = f.read(buf.get(), READ_CHUNK)) > 0 && out.size() < maxOut) {
     for (size_t i = 0; i < n; i++) {
       const char c = static_cast<char>(buf[i]);
       if (inValue) {

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -347,7 +347,6 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
 
   const int pageHeight = renderer.getScreenHeight();
   constexpr int buttonWidth = 80;
-  constexpr int smallButtonHeight = 15;
   constexpr int buttonHeight = LyraMetrics::values.buttonHintsHeight;
   constexpr int buttonY = LyraMetrics::values.buttonHintsHeight;  // Distance from bottom
   constexpr int textYOffset = 7;                                  // Distance from top of button to text baseline
@@ -359,21 +358,17 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   const char* labels[] = {btn1, btn2, btn3, btn4};
 
   for (int i = 0; i < 4; i++) {
+    // An empty label means the button does nothing on this screen, so draw nothing.
+    // The short stub that used to mark the slot still read as a pressable button and
+    // drew presses that could not do anything -- on the home screen it outlived the
+    // Resume action it once labelled. BaseTheme and RoundedRaffTheme already leave an
+    // unused slot blank; this matches them.
+    if (labels[i] == nullptr || labels[i][0] == '\0') continue;
     const int x = buttonPositions[i];
-    if (labels[i] != nullptr && labels[i][0] != '\0') {
-      // Draw the filled background and border for a FULL-sized button
-      renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius, Color::White);
-      renderer.drawRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, 1, cornerRadius, true, true, false,
-                               false, true);
-      drawHintLabel(renderer, SMALL_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight,
-                    textYOffset);
-    } else {
-      // Draw the filled background and border for a SMALL-sized button
-      renderer.fillRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, cornerRadius,
-                               Color::White);
-      renderer.drawRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, 1, cornerRadius, true,
-                               true, false, false, true);
-    }
+    renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius, Color::White);
+    renderer.drawRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, 1, cornerRadius, true, true, false,
+                             false, true);
+    drawHintLabel(renderer, SMALL_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight, textYOffset);
   }
 
   renderer.setOrientation(orig_orientation);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Two fixes from the same device report: the home screen's bottom-left button that survived #137, and a 512-byte stack buffer implicated by the crash dump taken on the same firmware.
* **What changes are included?**
  * `src/components/themes/lyra/LyraTheme.cpp` — `drawButtonHints()` skips a slot whose label is empty instead of drawing a stub.
  * `lib/Epub/Epub/Section.cpp` — `collectHtmlClasses()`'s read chunk moves from the stack to `makeUniqueNoThrow`.

Both were reproduced on the `1.5.1-overlay` build of `927c36e` (develop head at 21:49 UTC, i.e. after the #137/#138/#139 merges and the upstream sync).

---

### 1. The bottom-left button that #137 didn't remove

`LyraTheme` was the only theme that painted anything for an empty label:

```cpp
} else {
  // Draw the filled background and border for a SMALL-sized button
  renderer.fillRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, ...);
  renderer.drawRoundedRect(x, pageHeight - smallButtonHeight, ...);
}
```

A 15 px stub with the same fill and border as a real button. `BaseTheme` skips empty slots outright; `RoundedRaffTheme` suppresses the text via `backDisabled` and draws group frames rather than per-button boxes. So #137's `mapLabels("", ...)` removed the word and the binding, and Lyra kept drawing the box — which is exactly why it still looked like a button that does nothing.

`Lyra3CoversTheme` ("Lyra Extended") inherits the method and is covered by the same change.

**Deliberate side effect:** screens that leave slots empty on purpose lose their placeholder nubs too — `WifiSelectionActivity` passes `mapLabels("", tr(STR_DONE), "", "")` and currently shows three. That is the point of the change, and it aligns Lyra with the other two themes.

### 2. The class-scan buffer on the render task's stack

The crash dump (X4, **empty panic reason** — so a CPU exception, not an `abort()`/assert, since `panicMessage` is only ever written by `__wrap_panic_abort`) contains a contiguous run of raw chapter markup on the stack:

```
0x3FCB5E40  0x73616C63  ->  "clas"
0x3FCB5E50  0x00223D73  ->  "s=\""
            class="noteref" … href="notes.xhtml#chap13_en23" … role="doc-noteref"
            …"the Manson crater was of the right age to have been involved with the dinosaurs' extinction"…
```

Those are the literal `NEEDLE` bytes of `collectHtmlClasses()` followed by its buffer contents — `buf[512]`, live on the stack at the fault.

Why that matters:

* **512 bytes is twice** the ceiling CLAUDE.md sets for stack locals.
* It runs on the **`ActivityManagerRender` task**, whose 8 KB stack also carries full page rendering — GfxRenderer, font cache, SD I/O.
* The call site (`Section.cpp:541`) sits **directly after the low-heap guard** that releases font memory below 64 KB `maxAlloc`, so this frame is at its deepest precisely when memory is tightest.

The fix allocates the chunk with `makeUniqueNoThrow` instead. On OOM the scan returns with `out` empty, which makes the caller load the CSS cache unfiltered — identical to a chapter whose scan finds no classes, so no new failure mode. The scan logic is untouched and was already bounded (`token` capped at 48 chars, `matched` bounded by `NLEN`, reads bounded by the chunk size); only the chunk's storage moves.

**Honest scope:** this is the defect I can *prove* from the dump — a rule violation in the frame the dump implicates, on the task where the fault occurred. I cannot prove it is the sole cause, because the SD report carries no panic reason and no resolvable symbols. A serial log (`scripts/debugging_monitor.py`) across a reproduction would give the exception type and a decodable backtrace and would settle it.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme — it adjusts an existing theme's rendering.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. — n/a, none of those paths are touched.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff