### PR TITLE
fix: guard extensionless filenames in the file browser

### DIFF
--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -459,6 +459,7 @@ bool FileBrowserActivity::handleButtons() {
 }
 
 std::string getFileName(std::string filename) {
+  if (filename.empty()) return filename;
   if (filename.back() == '/') {
     filename.pop_back();
     if (!UITheme::getInstance().getTheme().showsFileIcons()) {
@@ -467,14 +468,18 @@ std::string getFileName(std::string filename) {
     return filename;
   }
   const auto pos = filename.rfind('.');
+  if (pos == std::string::npos) return filename;
   return filename.substr(0, pos);
 }
 
 std::string getFileExtension(const std::string& filename) {
-  if (filename.back() == '/') {
+  if (filename.empty() || filename.back() == '/') {
     return "";
   }
   const auto pos = filename.rfind('.');
+  // A name without a dot has no extension. substr(npos) throws out_of_range,
+  // and with -fno-exceptions that lands in abort().
+  if (pos == std::string::npos) return "";
   return filename.substr(pos);
 }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a device panic (`abort()`) that fires when the file browser lists a directory containing a file with no extension.
* **What changes are included?** `getFileExtension()` and `getFileName()` in `src/activities/home/FileBrowserActivity.cpp` now handle `rfind('.') == npos` and an empty name.

### The defect

```cpp
std::string getFileExtension(const std::string& filename) {
  if (filename.back() == '/') return "";
  const auto pos = filename.rfind('.');
  return filename.substr(pos);   // pos == npos here
}
```

`std::string::substr(pos)` throws `std::out_of_range` when `pos > size()`. `npos` always is. The firmware builds with `-fno-exceptions`, so libstdc++ routes the throw through `std::terminate()` into `abort()` — an immediate reboot, no log line.

`rebuildRowItems()` ([FileBrowserActivity.cpp:145-146](../blob/develop/src/activities/home/FileBrowserActivity.cpp#L145)) calls this for every entry in `files`, so one extensionless file anywhere in a browsed directory takes the device down on entering that folder. Directories are unaffected (they carry a trailing `/` and return early).

`getFileName()` used `substr(0, npos)`, which is well-defined, but shared the unguarded `filename.back()` on a potentially empty name. Guarded for symmetry.

### How the crash was traced

From a device panic report — `Panic reason: abort() was called at PC 0x42215f1d on core 0` — against the flashed `firmware.bin`:

* ESP-IDF's `abort()` reports `__builtin_return_address(0) - 3`, giving `0x42215f20`. That address is present in the stack dump.
* Disassembling the image's irom segment at `0x42215f20` yields `__cxxabiv1::__terminate(handler)`, entered from `std::terminate()` at `0x42215f60`.
* The rodata pointers in the surrounding frames resolve to `"basic_string::substr"` and `"%s: __pos (which is %zu) > this->size() (which is %zu)"`, with the spilled arguments alongside: `__pos = 0xFFFFFFFF`, `size = 0x10`. A 16-character name with no dot.
* The application frame `0x420ec3d0` disassembles to the body of `getFileExtension`:

```
420ec38e:  lbu  a4,-1(a5)      ; filename.back()
420ec392:  li   a5,47          ; '/'
420ec398:  bne  a4,a5,...      ; not a directory
420ec3ba:  li   a1,46          ; '.'
420ec3c0:  jal  0x4207f112     ; rfind('.') -> npos
420ec3cc:  jal  0x42061c46     ; substr(npos)
```

with its caller at `0x420ecf68` striding a 24-byte `std::string` array — `rebuildRowItems()`.

### Related sites checked

Every other `substr()` call in `src/` and `lib/` that takes a `find`/`rfind` result as a *position* already guards `npos`: `lib/Xtc/Xtc.cpp:99`, `lib/Epub/Epub/blocks/ImageBlock.cpp:573`, `lib/Epub/Epub/converters/ImageDecoderFactory.cpp:25`, `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:1007`, `src/util/UrlUtils.cpp`, `src/util/NextBookFinder.cpp`, `src/activities/util/BmpViewerActivity.cpp`. This was the only unguarded one. `FileBrowserActivity.cpp:573` uses `rfind('/') + 1`, which wraps `npos` to `0` and is safe.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — it is a crash in existing code.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** none meaningful — two comparisons and two early returns. `getFileExtension` now avoids one `std::string` allocation in the no-extension case.
* **Risk:** low. Behaviour changes only on inputs that previously aborted (no dot) or were undefined (empty name). Files with an extension take the identical path.
* **Verification performed:** `pio run -e default` succeeds (RAM 16.8%, Flash 89.7%). Not verified on hardware — please confirm by browsing a directory containing an extensionless file, which reliably reboots the device before this change.
* `./bin/clang-format-fix -g` was **not** run: the wrapper requires clang-format 21 and this environment only has 18. The change follows the surrounding style, but please let the formatting CI job be the authority.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff)_