### PR TITLE
fix: read length in the chapter class scan must be signed

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -45,9 +45,12 @@ void collectHtmlClasses(const std::string& path, std::vector<std::string>& out, 
     if (out.size() < maxOut) out.push_back(token);
     token.clear();
   };
-  size_t n;
+  // Signed: HalFile::read() returns -1 on a read error, and an unsigned n would turn
+  // that into 0xFFFFFFFF -- passing the `> 0` test and sending the inner loop 4 GB
+  // past a 512-byte buffer.
+  int n;
   while ((n = f.read(buf.get(), READ_CHUNK)) > 0 && out.size() < maxOut) {
-    for (size_t i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
       const char c = static_cast<char>(buf[i]);
       if (inValue) {
         if (c == '"') {
@@ -70,6 +73,13 @@ void collectHtmlClasses(const std::string& path, std::vector<std::string>& out, 
         matched = (c == NEEDLE[0]) ? 1 : 0;
       }
     }
+  }
+  if (n < 0) {
+    // A partial list is worse than none: the caller filters the CSS cache on it, so
+    // missing classes drop rules and the chapter gets cached UNSTYLED -- one bad read
+    // frozen into a permanent layout. Fall back to unfiltered, as the OOM path does.
+    LOG_ERR("SCT", "class scan read failed, discarding partial list: %s", path.c_str());
+    out.clear();
   }
 }
 }  // namespace


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a load access fault that reboots the device while building a chapter section.
* **What changes are included?** `collectHtmlClasses()` in `lib/Epub/Epub/Section.cpp` now holds the read length in an `int`, and discards a partial class list when the read fails.

### The defect

```cpp
size_t n;
while ((n = f.read(buf.get(), READ_CHUNK)) > 0 && out.size() < maxOut) {
  for (size_t i = 0; i < n; i++) {
    const char c = static_cast<char>(buf[i]);
```

`HalFile::read()` returns `int`, and `-1` on a read error ([HalStorage.h:89](../blob/develop/lib/hal/HalStorage.h#L89)). Stored in a `size_t` that is `0xFFFFFFFF`, which passes the **unsigned** `> 0` guard. The inner loop then scans 4 GB from a 512-byte buffer until it leaves DRAM.

### Evidence

From a core dump (`coredump` partition, `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y`) taken off a device that rebooted while opening a book, decoded against the matching `firmware.elf`:

```
pc = 0x420920b4   ra = 0x420920ca   sp = 0x3fcb8300
0x420920b4: collectHtmlClasses at lib/Epub/Epub/Section.cpp:51
            (inlined by) Section::startBuild at lib/Epub/Epub/Section.cpp:550
```

The faulting instruction is the `buf[i]` load:

```
420920ae:  li   s7,0        ; i = 0
420920b0:  lw   a5,4(sp)    ; buf.get()
420920b2:  add  a5,a5,s7    ; buf + i
420920b4:  lbu  s6,0(a5)    ; <-- fault
420920cc:  addi s7,s7,1     ; i++
```

`s7` is the index and held **`0x003A455C` (3 818 844)** on a 512-byte buffer. The faulting address `a5 = 0x40060000` is where DRAM ends above the buffer at `0x3FCBBAA4`. The panic carried no reason string because a load access fault is a CPU exception, not `abort()` — `panicMessage` is only written by `__wrap_panic_abort` ([HalSystem.cpp:28](../blob/develop/lib/hal/HalSystem.cpp#L28)).

### The partial-list hazard

The caller filters the CSS cache load on this list:

```cpp
collectHtmlClasses(ctx->parsePath, usedClasses, 64);
if (!ctx->cssParser->loadFromCache(&usedClasses)) { ... }
```

A short list silently drops rules, so the chapter renders unstyled — and is then **cached as a valid section**. One transient SD read error would be frozen into a permanent wrong layout. This is the failure mode CLAUDE.md's "never persist a transient failure as a permanent truth" section describes, and the adjacent OOM path already handles it by leaving `out` empty so the CSS loads unfiltered. The read-error path now does the same.

### Provenance

`size_t n` dates from `17c3af3`, not from the recent `eb8279a` that moved this buffer off the render task stack — that commit only changed `buf` to `buf.get()` and `sizeof(buf)` to `READ_CHUNK` on these lines. The overrun behaves identically with the buffer on the stack or on the heap.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — it is a crash in existing code.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** none. Same buffer, same loop; the index and length types change.
* **Risk:** low. On a successful read (`n > 0`) the behaviour is byte-for-byte identical. Behaviour changes only on `n < 0`, which previously could not return at all.
* **Cache versioning:** no format change, so `SECTION_FILE_VERSION` is untouched. A chapter cached unstyled by an earlier bad read will not self-heal, though — clearing `.crosspoint/` is the fix for an affected book.
* **Verification performed:** `pio run -e default` succeeds. Not reproduced on hardware: the trigger is a failing SD read, which I cannot force. The evidence is the core dump above rather than a live repro.
* `./bin/clang-format-fix -g` was **not** run — the wrapper requires clang-format 21 and this environment has 18. Please let the formatting CI job be the authority.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGZLt4qDx2VAnnsAXwupff)_