### PR TITLE
fix: scrub image-page ghosting when a reader overlay opens

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1070,7 +1070,8 @@ void EpubReaderActivity::openReaderMenu() {
           renderer, mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent, SETTINGS.orientation,
           !sectionFootnotes.empty() || !currentPageFootnotes.empty(), !cachedBookmarks.empty(), hasWordLookup,
           useVerticalText(), useFurigana(), hasPageText, /*imageReaderMinimal=*/false, /*mangaMode=*/false,
-          /*hideGenericLookup=*/isJapaneseBook()),
+          /*hideGenericLookup=*/isJapaneseBook(), /*showPanelsOnlyToggle=*/false, /*panelsOnlyEnabled=*/false,
+          /*scrubOnEnter=*/shownPageHasImages_),
       [this](const ActivityResult& result) {
         const auto& menu = std::get<MenuResult>(result.data);
         applyOrientation(menu.orientation);
@@ -1300,7 +1301,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       }
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
       startActivityForResult(
-          std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent),
+          std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent,
+                                                               /*scrubOnEnter=*/shownPageHasImages_),
           [this](const ActivityResult& result) {
             if (result.isCancelled) {
               openReaderMenu();
@@ -1372,7 +1374,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     }
     case EpubReaderMenuActivity::MenuAction::BOOKMARKS: {
       startActivityForResult(
-          std::make_unique<EpubReaderBookmarksActivity>(renderer, mappedInput, epub, epub->getPath()),
+          std::make_unique<EpubReaderBookmarksActivity>(renderer, mappedInput, epub, epub->getPath(),
+                                                        /*scrubOnEnter=*/shownPageHasImages_),
           progressChangeResultHandler);
       break;
     }
@@ -2154,6 +2157,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // Contract: nothing between here and waitRefreshComplete() may touch the framebuffer. The tail
     // is safe (its glyph warm renders in scan mode, which draws nothing); popups, screenshots and
     // the image warm are not, and run after the wait.
+    shownPageHasImages_ = imagePageDisplayed;
     const bool overlapRefresh = !imagePageDisplayed && renderer.supportsAsyncRefresh();
     if (!imagePageDisplayed) {  // image pages already displayed (double-fast + grayscale planes)
       renderStatusBar();
@@ -3099,6 +3103,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   const auto tPrewarm = millis();
 
   const bool pageHasImages = page->hasImages();
+  shownPageHasImages_ = pageHasImages;
   const bool pageHasImagesNeedingDecode = pageHasImages && page->hasImagesNeedingDecode();
   const bool manualRefreshPending = !grayscaleRefineOnly && forcedRefreshPending;
   if (!grayscaleRefineOnly) forcedRefreshPending = false;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1300,16 +1300,15 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         }
       }
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
-      startActivityForResult(
-          std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent,
-                                                               /*scrubOnEnter=*/shownPageHasImages_),
-          [this](const ActivityResult& result) {
-            if (result.isCancelled) {
-              openReaderMenu();
-            } else {
-              jumpToPercent(std::get<PercentResult>(result.data).percent);
-            }
-          });
+      startActivityForResult(std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent,
+                                                                                  /*scrubOnEnter=*/shownPageHasImages_),
+                             [this](const ActivityResult& result) {
+                               if (result.isCancelled) {
+                                 openReaderMenu();
+                               } else {
+                                 jumpToPercent(std::get<PercentResult>(result.data).percent);
+                               }
+                             });
       break;
     }
     case EpubReaderMenuActivity::MenuAction::DICTIONARY: {
@@ -1373,10 +1372,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::BOOKMARKS: {
-      startActivityForResult(
-          std::make_unique<EpubReaderBookmarksActivity>(renderer, mappedInput, epub, epub->getPath(),
-                                                        /*scrubOnEnter=*/shownPageHasImages_),
-          progressChangeResultHandler);
+      startActivityForResult(std::make_unique<EpubReaderBookmarksActivity>(renderer, mappedInput, epub, epub->getPath(),
+                                                                           /*scrubOnEnter=*/shownPageHasImages_),
+                             progressChangeResultHandler);
       break;
     }
     case EpubReaderMenuActivity::MenuAction::WORD_LOOKUP: {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -287,6 +287,9 @@ class EpubReaderActivity final : public ReaderActivity {
   // would misread every press as "past the last page" and jump to the next spine (observed:
   // a press during the build teleported the reader to the end of the book).
   std::atomic<bool> verticalBuildInProgress_{false};
+  // True when the page currently on the panel drew images. Overlays opened on top
+  // of it need a HALF pass to scrub the charge a FAST diff leaves behind.
+  bool shownPageHasImages_ = false;
   // Early target/currently shown page; seeded before the hook so build-time turns work.
   // Written on the render task, read by pageTurn() on the loop() task.
   std::atomic<int> earlyDisplayedPage_{-1};

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -18,8 +18,8 @@ constexpr int ENTER_DELETE_MODE_MS = 700;
 }  // namespace
 
 EpubReaderBookmarksActivity::EpubReaderBookmarksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                                         const std::shared_ptr<Epub>& epub,
-                                                         const std::string& epubPath, const bool scrubOnEnter)
+                                                         const std::shared_ptr<Epub>& epub, const std::string& epubPath,
+                                                         const bool scrubOnEnter)
     : UiListActivity("EpubReaderBookmarks", renderer, mappedInput, /*wantsTouchLongPress=*/true),
       scrubOnEnter_(scrubOnEnter),
       epub(epub),

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -18,8 +18,10 @@ constexpr int ENTER_DELETE_MODE_MS = 700;
 }  // namespace
 
 EpubReaderBookmarksActivity::EpubReaderBookmarksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                                         const std::shared_ptr<Epub>& epub, const std::string& epubPath)
+                                                         const std::shared_ptr<Epub>& epub,
+                                                         const std::string& epubPath, const bool scrubOnEnter)
     : UiListActivity("EpubReaderBookmarks", renderer, mappedInput, /*wantsTouchLongPress=*/true),
+      scrubOnEnter_(scrubOnEnter),
       epub(epub),
       epubPath(epubPath) {}
 
@@ -258,5 +260,8 @@ void EpubReaderBookmarksActivity::render(RenderLock&&) {
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-  renderer.displayBuffer();
+  // See EpubReaderMenuActivity: scrub the image page's gray charge once on entry.
+  const bool scrub = scrubOnEnter_ && firstPaint_;
+  firstPaint_ = false;
+  renderer.displayBuffer(scrub ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
 }

--- a/src/activities/reader/EpubReaderBookmarksActivity.h
+++ b/src/activities/reader/EpubReaderBookmarksActivity.h
@@ -28,11 +28,16 @@ class EpubReaderBookmarksActivity final : public UiListActivity {
 
  public:
   explicit EpubReaderBookmarksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                       const std::shared_ptr<Epub>& epub, const std::string& epubPath);
+                                       const std::shared_ptr<Epub>& epub, const std::string& epubPath,
+                                       bool scrubOnEnter);
   void onEnter() override;
   void render(RenderLock&&) override;
 
  private:
+  // Set when the reader page underneath drew images: its gray charge survives a FAST
+  // diff and would show through this screen. Scrubbed once on the first paint.
+  const bool scrubOnEnter_;
+  bool firstPaint_ = true;
   int listCount() const override { return static_cast<int>(bookmarks.size()); }
   void buildScreen(UiScreen& screen) override;
   void activateIndex(int index) override;

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -17,8 +17,9 @@ EpubReaderMenuActivity::EpubReaderMenuActivity(
     const int totalPages, const int bookProgressPercent, const uint8_t currentOrientation, const bool hasFootnotes,
     const bool hasBookmarks, const bool hasWordLookup, const bool verticalEnabled, const bool furiganaEnabled,
     const bool hasPageText, const bool imageReaderMinimal, const bool mangaMode, const bool hideGenericLookup,
-    const bool showPanelsOnlyToggle, const bool panelsOnlyEnabled)
+    const bool showPanelsOnlyToggle, const bool panelsOnlyEnabled, const bool scrubOnEnter)
     : UiListActivity("EpubReaderMenu", renderer, mappedInput),
+      scrubOnEnter_(scrubOnEnter),
       menuItems(buildMenuItems(hasFootnotes, hasBookmarks, hasWordLookup, imageReaderMinimal, mangaMode,
                                hideGenericLookup, showPanelsOnlyToggle)),
       hasPageText(hasPageText),
@@ -307,5 +308,10 @@ void EpubReaderMenuActivity::render(RenderLock&&) {
   renderUi();
 
   drawFooter();
-  renderer.displayBuffer();
+  // A reader page with images leaves gray charge that a FAST diff cannot drive out,
+  // so the page shows through this screen. One HALF pass on entry scrubs it; moving
+  // the selection afterwards stays fast.
+  const bool scrub = scrubOnEnter_ && firstPaint_;
+  firstPaint_ = false;
+  renderer.displayBuffer(scrub ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
 }

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -43,12 +43,17 @@ class EpubReaderMenuActivity final : public UiListActivity {
                                   const bool verticalEnabled = false, const bool furiganaEnabled = true,
                                   const bool hasPageText = true, const bool imageReaderMinimal = false,
                                   const bool mangaMode = false, const bool hideGenericLookup = false,
-                                  const bool showPanelsOnlyToggle = false, const bool panelsOnlyEnabled = false);
+                                  const bool showPanelsOnlyToggle = false, const bool panelsOnlyEnabled = false,
+                                  const bool scrubOnEnter = false);
 
   void render(RenderLock&&) override;
   bool handleHomeGesture() override;
 
  private:
+  // Set when the reader page underneath drew images: its gray charge survives a FAST
+  // diff and would show through this screen. Scrubbed once on the first paint.
+  const bool scrubOnEnter_;
+  bool firstPaint_ = true;
   struct MenuItem {
     MenuAction action;
     StrId labelId;

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
@@ -25,8 +25,12 @@ constexpr int kLargeStep = 10;
 
 EpubReaderPercentSelectionActivity::EpubReaderPercentSelectionActivity(GfxRenderer& renderer,
                                                                        MappedInputManager& mappedInput,
-                                                                       const int initialPercent)
-    : Activity("EpubReaderPercentSelection", renderer, mappedInput), UiAppHost(renderer), percent(initialPercent) {}
+                                                                       const int initialPercent,
+                                                                       const bool scrubOnEnter)
+    : Activity("EpubReaderPercentSelection", renderer, mappedInput),
+      UiAppHost(renderer),
+      scrubOnEnter_(scrubOnEnter),
+      percent(initialPercent) {}
 
 void EpubReaderPercentSelectionActivity::onEnter() {
   Activity::onEnter();
@@ -190,5 +194,8 @@ void EpubReaderPercentSelectionActivity::render(RenderLock&&) {
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), "-", "+");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-  renderer.displayBuffer();
+  // See EpubReaderMenuActivity: scrub the image page's gray charge once on entry.
+  const bool scrub = scrubOnEnter_ && firstPaint_;
+  firstPaint_ = false;
+  renderer.displayBuffer(scrub ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
 }

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.h
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.h
@@ -9,7 +9,7 @@ class EpubReaderPercentSelectionActivity final : public Activity, private UiAppH
  public:
   // Slider-style percent selector for jumping within a book.
   explicit EpubReaderPercentSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                              int initialPercent);
+                                              int initialPercent, bool scrubOnEnter = false);
 
   void onEnter() override;
   void onExit() override;
@@ -17,6 +17,10 @@ class EpubReaderPercentSelectionActivity final : public Activity, private UiAppH
   void render(RenderLock&&) override;
 
  private:
+  // Set when the reader page underneath drew images: its gray charge survives a FAST
+  // diff and would show through this screen. Scrubbed once on the first paint.
+  const bool scrubOnEnter_;
+  bool firstPaint_ = true;
   // The UiAppHost app hosts the shared slider dialog (drag slider, -/+ zones,
   // touch Cancel/OK); the header stays on GUI.drawHeader.
   static void percentScreen(UiScreen& screen, void* user);

--- a/src/activities/reader/MangaBookmarksActivity.cpp
+++ b/src/activities/reader/MangaBookmarksActivity.cpp
@@ -208,5 +208,10 @@ void MangaBookmarksActivity::render(RenderLock&&) {
   const auto labels = mappedInput.mapLabels(backLabel, confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-  renderer.displayBuffer();
+  // Every manga page is an image, so the page underneath always leaves gray charge a
+  // FAST diff shows through. Unconditional here, unlike the EPUB overlays, which only
+  // scrub when the page they cover actually drew images.
+  const bool scrub = firstPaint_;
+  firstPaint_ = false;
+  renderer.displayBuffer(scrub ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
 }

--- a/src/activities/reader/MangaBookmarksActivity.h
+++ b/src/activities/reader/MangaBookmarksActivity.h
@@ -31,6 +31,8 @@ class MangaBookmarksActivity final : public Activity {
   void render(RenderLock&&) override;
 
  private:
+  // Scrubs the manga page's gray charge on the first paint; see the .cpp.
+  bool firstPaint_ = true;
   // Calculate the vertical space to reserve for button hints based on orientation
   int getGutterBottom(const GfxRenderer& renderer);
 

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -1741,7 +1741,8 @@ void MangaReaderActivity::launchMenu() {
                                                /*imageReaderMinimal=*/false, /*mangaMode=*/true,
                                                /*hideGenericLookup=*/false,
                                                /*showPanelsOnlyToggle=*/bookHasPanelCropCapability,
-                                               /*panelsOnlyEnabled=*/panelsOnlyMode),
+                                               /*panelsOnlyEnabled=*/panelsOnlyMode,
+                                               /*scrubOnEnter=*/true),
       [this](const ActivityResult& result) {
         const auto& menu = std::get<MenuResult>(result.data);
         // Apply orientation change
@@ -1768,7 +1769,8 @@ void MangaReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction
     if (!book || book->getPageCount() == 0) return;
     const int totalPages = static_cast<int>(book->getPageCount());
     const int initialPercent = totalPages > 0 ? static_cast<int>((currentPage + 1) * 100 / totalPages) : 0;
-    startActivityForResult(std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent),
+    startActivityForResult(std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent,
+                                                                               /*scrubOnEnter=*/true),
                            [this](const ActivityResult& result) {
                              if (!result.isCancelled && book) {
                                const int percent = std::get<PercentResult>(result.data).percent;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -1770,7 +1770,7 @@ void MangaReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction
     const int totalPages = static_cast<int>(book->getPageCount());
     const int initialPercent = totalPages > 0 ? static_cast<int>((currentPage + 1) * 100 / totalPages) : 0;
     startActivityForResult(std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent,
-                                                                               /*scrubOnEnter=*/true),
+                                                                                /*scrubOnEnter=*/true),
                            [this](const ActivityResult& result) {
                              if (!result.isCancelled && book) {
                                const int percent = std::get<PercentResult>(result.data).percent;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop the page underneath from ghosting through the reader overlays — the menu, the bookmarks list and the percent selector — when it drew images.
* **What changes are included?** `EpubReaderActivity` records whether the page on the panel drew images and passes that to its three overlays, which spend one `HALF_REFRESH` on their first paint. The manga reader's overlays do the same unconditionally.

### The defect

All the overlays painted with the no-argument form:

```cpp
renderer.displayBuffer();     // default = HalDisplay::FAST_REFRESH
```

A fast refresh runs a shortened waveform that cannot drive out the gray charge an image page leaves. Opened over a full-page cover, the whole image stays visible behind the menu.

`EpubReaderActivity` already handles this for its own page turns — an image page sets `pagesUntilFullRefresh = 1` so the next ordinary page takes the HALF path, which the comment at [EpubReaderActivity.cpp:3155-3159](../blob/develop/src/activities/reader/EpubReaderActivity.cpp#L3155) describes as *"the HALF ghost-cleanup path, which drives every pixel to its target regardless of residue"*. The overlays are separate activities and never inherited that knowledge.

### Why not `panelHasResidue()`

It looks like the obvious predicate and is the wrong one. [GfxRenderer.cpp:1984](../blob/develop/lib/GfxRenderer/GfxRenderer.cpp#L1984) sets it after **any** fast refresh:

```cpp
panelResidue_ = refreshMode == HalDisplay::FAST_REFRESH;
```

so it is true after an ordinary text page turn as well. Keying the overlays off it would put a ~1.7 s HALF pass on nearly every menu open. The flag conflates light fast-refresh residue with the heavy gray-plane charge only image pages leave.

### What this uses instead

| Reader | Overlays | Condition |
|---|---|---|
| `EpubReaderActivity` | menu, bookmarks, percent | `shownPageHasImages_` — from `page->hasImages()` (horizontal) and `imagePageDisplayed` (vertical), recorded where the page is displayed |
| `MangaReaderActivity` | menu, percent (shared) + `MangaBookmarksActivity` | always: every manga page is an image |
| `XtcReaderActivity` | menu, percent (shared) | never: it draws no images, so it keeps the fast paint |

`MangaBookmarksActivity` carries the first-paint HALF itself rather than taking a flag it would always be handed as `true`.

Text pages keep the fast paint, so the extra refresh time is spent only where there is something to scrub.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the reader compensates for its own page turns but not for overlays.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** two bools per overlay activity and one in `EpubReaderActivity`. No allocation, no new code paths at render time.
* **Timing:** one HALF pass (~1.7 s instead of ~0.5 s) on the first paint of an overlay opened over an image page, and only there. Repaints while moving the selection stay on `FAST_REFRESH`. In the manga reader that cost applies to every overlay open, which is correct — there is no non-image page to spare.
* **Anti-aliased text:** with `SETTINGS.textAntiAliasing` on, plain text pages also run the grayscale path (`needsAnyGrayscale = needsTextGrayscale || pageHasImages`) and leave some charge. The ghosting there is thin enough to be invisible in practice, so this PR deliberately keys on images only.
* **Verification performed:** `pio run -e default` succeeds. Formatting verified with clang-format 21.1.2 (`--dry-run --Werror` clean on every file this PR touches).
* **Not verified on hardware.** The visible checks are: opening the menu on a page with a full-width image and confirming the image no longer shows through; a text page's menu still opening at fast-refresh speed; and the manga menu/bookmarks opening clean.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
