### PR TITLE
chore: reduce SleepActivity divergence from upstream

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -492,30 +492,6 @@ void releaseSdFontCachesForDecode(const GfxRenderer& renderer) {
 
 }  // namespace
 
-// Real hardware never reaches loop() while asleep: enterDeepSleep() ends by
-// calling powerManager.startDeepSleep(gpio), which is esp_deep_sleep_start()
-// on-device -- a no-return call, so wake only happens via a full chip reset
-// handled by main.cpp's boot routing. The emulator's startDeepSleep() is a
-// no-op (no real low-power state to enter), so execution falls through and
-// SleepActivity keeps running -- but with no loop() override, nothing could
-// ever exit it. This mirrors main.cpp's post-wake routing (resume the last
-// open book, or go home) so Confirm/Enter acts as a wake shortcut in the
-// emulator; it's unreachable on real hardware since loop() is never called
-// there while asleep.
-void SleepActivity::loop() {
-  if (!mappedInput.wasPressed(MappedInputManager::Button::Confirm)) return;
-
-  if (!APP_STATE.openEpubPath.empty() && APP_STATE.lastSleepFromReader) {
-    const auto path = APP_STATE.openEpubPath;
-    APP_STATE.openEpubPath = "";
-    APP_STATE.readerActivityLoadCount++;
-    APP_STATE.saveToFile();
-    activityManager.goToReader(path);
-  } else {
-    activityManager.goHome();
-  }
-}
-
 void SleepActivity::onEnter() {
   Activity::onEnter();
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -495,26 +495,6 @@ void releaseSdFontCachesForDecode(const GfxRenderer& renderer) {
 void SleepActivity::onEnter() {
   Activity::onEnter();
 
-  // Whatever paints below freezes on the glass for the entire sleep. If the panel carries
-  // residue -- FAST-turn ghosts, gray charge from an image page, a popup's inverted remnant --
-  // the single sleep-time HALF pass cannot scrub it, and it stays visible for hours (grain
-  // across the page plus a negative ghost of the reader menu, photographed on device). Re-drive
-  // the current content with the clean single-pass waveform first, so the sleep frame lands on
-  // a scrubbed base. Still never the flashing GC waveform: the OEM X4 firmware's only clean
-  // refresh in normal operation is the single-pass 0xD7 sequence, never the multi-flash GC
-  // waveform (0xF7) that FULL_REFRESH selects (#2471's blinking complaint).
-  // The scrub is the HALF pass alone. No preconditionGrayscale() here: that is the
-  // settle pass for an imminent grayscale plane write (see XtcReaderActivity), and
-  // every grayscale sleep screen below reaches the panel through
-  // displayGrayscaleBase(), which fires the same AA-pre-BW(mid) bank itself. Calling
-  // it here bought nothing on X4, where it is a documented no-op, and cost X3 a
-  // second full visible pass -- Uc8253X3Driver::preconditionGrayscale() ends in
-  // triggerRefresh() -- for every sleep, grayscale or not.
-  // Costs one HALF (~1s) at sleep entry, and only when needed.
-  if (renderer.panelHasResidue()) {
-    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
-  }
-
   const bool frameWasInverted = display.isInverted();
 
   // Sleep screens always use normal polarity. This activity draws directly

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -11,7 +11,6 @@ class SleepActivity final : public Activity {
   explicit SleepActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, bool fromTimeout = false)
       : Activity("Sleep", renderer, mappedInput), fromTimeout(fromTimeout) {}
   void onEnter() override;
-  void loop() override;
 
  private:
   void renderDefaultSleepScreen() const;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Shrink the fork's divergence in `SleepActivity` (was +127/−43 against the upstream sync point).
* **What changes are included?** Two commits, deliberately separate:
  1. `chore:` delete the emulator-only `SleepActivity::loop()` override — dead code, no behaviour change.
  2. `revert:` drop the sleep-entry HALF scrub — **this one changes behaviour.**

### 1. The `loop()` override — dead code

It let the emulator leave the sleep screen on Confirm: the emulator's `startDeepSleep()` is a no-op, so execution falls through where hardware never returns. `platformio.ini` has no emulator environment, and that override's own comment was the only mention of an emulator anywhere in the tree.

It is also unreachable by construction on device, twice over:

* `esp_deep_sleep_start()` does not return.
* `PowerManager::deepSleep()` parks in a `while (true)` behind it.

Once `enterDeepSleep()` is entered, nothing in the activity loop runs again.

### 2. The sleep-entry scrub — behaviour change

`onEnter()` re-drove the current content with a HALF pass whenever `panelHasResidue()` was set, so the sleep frame landed on a scrubbed base. Upstream does not do this.

**Consequence:** residue present when sleep is entered — FAST-turn ghosts, gray charge from an image page — now freezes into the sleep frame for the whole sleep. That is what the scrub was added to prevent, so expect it to come back. It is a separate commit precisely so it can be reverted without disturbing the dead-code removal.

### What stays, and why

`releaseAllFontMemory()` cannot be reverted to upstream's `releaseSdFontCaches()`. It is not a rename — the two do different things, and upstream's version no longer compiles here:

```cpp
// upstream
void FontCacheManager::releaseSdFontCaches() {
  if (fontDecompressor_) fontDecompressor_->clearCache();
  for (auto& [id, font] : sdCardFonts_) font->releaseResidentCaches();
}
```

`SdCardFont::releaseResidentCaches()` does not exist in this tree any more, and `FontDecompressor::clearCache()` has a different meaning here — per-render pool hygiene called all over the UI, with the actual release moved to `freeGlyphSlab()`. Reverting the call site would mean reverting the fork's font-cache rework underneath it.

The legacy overlay directories also stay: they keep existing SD cards working.

### Context

Found while auditing this file against `upstream/develop` after a device sat unresponsive on the sleep screen and recovered only via the hardware reset button.

**Neither commit fixes or diagnoses that failure.** The `loop()` override could not have caused it — the two barriers above are enough to say it was never reached, independently of the real cause.

A candidate for the real cause, stated as a hypothesis and not a finding: `PowerManager::waitForPowerButtonRelease()` is an unbounded `while (digitalRead(pin) == pressedLevel) delay(50);` with no timeout, reached after the sleep path has already switched the battery MOSFET off via GPIO13 and cut rails via `powerDownRailsForSleep()`. If that read never clears, the wake source is never armed and `esp_deep_sleep_start()` is never called. That would match the symptoms — sleep frame already on the panel, serial already torn down by `logSerial.end()`, `delay(50)` feeding the idle task so no watchdog fires.

It is equally consistent with the device having entered deep sleep normally and the GPIO wake simply not firing; from outside the two are indistinguishable. There is no serial capture or core dump of the event, and `esptool` connecting afterwards proves nothing either way, since it resets the chip via RTS on connect. That is SDK code, tracked separately.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this removes fork-only code in favour of upstream behaviour.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** slightly smaller. One virtual override and one refresh path removed.
* **Timing:** sleep entry loses up to one HALF pass (~1 s) when residue was present. Sleeping is that much faster now.
* **Risk:** commit 1 none identified — no caller, no reachable path, no remaining references. Commit 2 is the ghosting trade-off described above.
* **Verification performed:** `pio run -e default` succeeds. `clang-format --dry-run --Werror` clean (verified with clang-format 21.1.2).
* **Not verified on hardware.** The visible check for commit 2 is: read an image-heavy page, sleep, and confirm whether the ghost in the sleep frame is acceptable.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
