### PR TITLE
fix: 288-byte footnote record aborts the section build

### DIFF
--- a/lib/Epub/Epub/FootnoteEntry.h
+++ b/lib/Epub/Epub/FootnoteEntry.h
@@ -1,19 +1,52 @@
 #pragma once
 
+#include <HalStorage.h>
+
+#include <algorithm>
 #include <cstring>
+#include <string>
 
 #define FOOTNOTE_NUMBER_LEN 32
 #define FOOTNOTE_HREF_LEN 256
-// ponytail: bumped from 96 to 256; calibre-generated EPUBs with long filenames
-// and URL-encoded characters routinely exceed 96 chars (e.g.
-// "Author-Title_split_NNN.html#_ftnN" encoded is ~150 chars).
+// The href's fixed width is the ON-DISK field only. In RAM it is a std::string: a
+// 288-byte fixed record made every footnote container a large-element vector, and the
+// section-wide table (128 entries) then needed 37KB *contiguous* to grow into -- which
+// aborts through operator new once a reading session has fragmented the heap. As a
+// string the record is ~36 bytes, so the same table wants ~4.6KB contiguous plus one
+// small allocation per href.
+static_assert(FOOTNOTE_HREF_LEN % 32 == 0, "href padding is written/read in 32-byte chunks");
 
 struct FootnoteEntry {
   char number[FOOTNOTE_NUMBER_LEN];
-  char href[FOOTNOTE_HREF_LEN];
+  std::string href;
 
-  FootnoteEntry() {
-    number[0] = '\0';
-    href[0] = '\0';
-  }
+  FootnoteEntry() { number[0] = '\0'; }
 };
+
+// Fixed-width href I/O, so the section-file format is unchanged by the in-RAM shrink.
+// Both helpers work in 32-byte chunks rather than on a FOOTNOTE_HREF_LEN stack buffer.
+inline bool writeFootnoteHref(HalFile& f, const std::string& href) {
+  const size_t len = std::min(href.size(), static_cast<size_t>(FOOTNOTE_HREF_LEN - 1));
+  if (len > 0 && f.write(href.data(), len) != len) return false;
+  char zeros[32] = {};
+  for (size_t left = FOOTNOTE_HREF_LEN - len; left > 0;) {
+    const size_t n = std::min(left, sizeof(zeros));
+    if (f.write(zeros, n) != n) return false;
+    left -= n;
+  }
+  return true;
+}
+
+inline bool readFootnoteHref(HalFile& f, std::string& href) {
+  href.clear();
+  char chunk[32];
+  bool ended = false;
+  for (size_t done = 0; done < FOOTNOTE_HREF_LEN; done += sizeof(chunk)) {
+    if (f.read(chunk, sizeof(chunk)) != static_cast<int>(sizeof(chunk))) return false;
+    if (ended) continue;
+    const size_t n = strnlen(chunk, sizeof(chunk));
+    href.append(chunk, n);
+    if (n < sizeof(chunk)) ended = true;
+  }
+  return true;
+}

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -252,8 +252,7 @@ bool Page::serialize(HalFile& file) const {
   serialization::writePod(file, fnCount);
   for (uint16_t i = 0; i < fnCount; i++) {
     const auto& fn = footnotes[i];
-    if (file.write(fn.number, sizeof(fn.number)) != sizeof(fn.number) ||
-        file.write(fn.href, sizeof(fn.href)) != sizeof(fn.href)) {
+    if (file.write(fn.number, sizeof(fn.number)) != sizeof(fn.number) || !writeFootnoteHref(file, fn.href)) {
       LOG_ERR("PGE", "Failed to write footnote");
       return false;
     }
@@ -322,13 +321,11 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
   page->footnotes.resize(fnCount);
   for (uint16_t i = 0; i < fnCount; i++) {
     auto& entry = page->footnotes[i];
-    if (file.read(entry.number, sizeof(entry.number)) != sizeof(entry.number) ||
-        file.read(entry.href, sizeof(entry.href)) != sizeof(entry.href)) {
+    if (file.read(entry.number, sizeof(entry.number)) != sizeof(entry.number) || !readFootnoteHref(file, entry.href)) {
       LOG_ERR("PGE", "Failed to read footnote %u", i);
       return nullptr;
     }
     entry.number[sizeof(entry.number) - 1] = '\0';
-    entry.href[sizeof(entry.href) - 1] = '\0';
   }
 
   return page;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -117,9 +117,8 @@ class Page {
     FootnoteEntry entry;
     strncpy(entry.number, number, sizeof(entry.number) - 1);
     entry.number[sizeof(entry.number) - 1] = '\0';
-    strncpy(entry.href, href, sizeof(entry.href) - 1);
-    entry.href[sizeof(entry.href) - 1] = '\0';
-    footnotes.push_back(entry);
+    entry.href.assign(href, strnlen(href, FOOTNOTE_HREF_LEN - 1));
+    footnotes.push_back(std::move(entry));
   }
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset, bool skipRuby = false) const;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -811,7 +811,7 @@ bool Section::commitBuildFile(const uint8_t version, const uint32_t bytesConsume
       if (asPartial && pageIdx >= builtPageCount_) continue;
       serialization::writePod(file, pageIdx);
       file.write(reinterpret_cast<const uint8_t*>(fn.number), sizeof(fn.number));
-      file.write(reinterpret_cast<const uint8_t*>(fn.href), sizeof(fn.href));
+      writeFootnoteHref(file, fn.href);
     }
     serialization::writePod(file, footnoteTableOffset);
   }
@@ -1257,13 +1257,12 @@ bool Section::loadSectionFootnotes(std::vector<std::pair<uint16_t, FootnoteEntry
     FootnoteEntry fn;
     serialization::readPod(f, pageIdx);
     if (f.read(reinterpret_cast<uint8_t*>(fn.number), sizeof(fn.number)) != sizeof(fn.number) ||
-        f.read(reinterpret_cast<uint8_t*>(fn.href), sizeof(fn.href)) != sizeof(fn.href)) {
+        !readFootnoteHref(f, fn.href)) {
       out.clear();
       return false;
     }
     fn.number[sizeof(fn.number) - 1] = '\0';
-    fn.href[sizeof(fn.href) - 1] = '\0';
-    out.push_back({pageIdx, fn});
+    out.push_back({pageIdx, std::move(fn)});
   }
   return true;
 }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1431,8 +1431,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       }
       self->insideFootnoteLink = true;
       self->footnoteLinkDepth = self->depth;
-      strncpy(self->currentFootnote.href, href, sizeof(self->currentFootnote.href) - 1);
-      self->currentFootnote.href[sizeof(self->currentFootnote.href) - 1] = '\0';
+      self->currentFootnote.href.assign(href, strnlen(href, FOOTNOTE_HREF_LEN - 1));
       self->currentFootnote.number[0] = '\0';
       self->currentFootnoteLinkTextLen = 0;
 
@@ -2125,15 +2124,14 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
   // Closing a footnote link — create entry from collected text and href
   if (self->insideFootnoteLink && self->depth == self->footnoteLinkDepth) {
-    if (self->currentFootnote.number[0] != '\0' && self->currentFootnote.href[0] != '\0') {
+    if (self->currentFootnote.number[0] != '\0' && !self->currentFootnote.href.empty()) {
       FootnoteEntry entry;
       strncpy(entry.number, self->currentFootnote.number, sizeof(entry.number) - 1);
       entry.number[sizeof(entry.number) - 1] = '\0';
-      strncpy(entry.href, self->currentFootnote.href, sizeof(entry.href) - 1);
-      entry.href[sizeof(entry.href) - 1] = '\0';
+      entry.href = self->currentFootnote.href;
       int wordIndex =
           self->wordsExtractedInBlock + (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);
-      self->pendingFootnotes.push_back({wordIndex, entry});
+      self->pendingFootnotes.push_back({wordIndex, std::move(entry)});
     }
     self->insideFootnoteLink = false;
   }
@@ -2438,7 +2436,7 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const
   wordsExtractedInBlock += line->wordCount();
   auto footnoteIt = pendingFootnotes.begin();
   while (footnoteIt != pendingFootnotes.end() && footnoteIt->first <= wordsExtractedInBlock) {
-    currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href);
+    currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href.c_str());
     if (sectionFootnoteData.size() < MAX_SECTION_FOOTNOTES) {
       sectionFootnoteData.push_back({static_cast<uint16_t>(completedPageCount), footnoteIt->second});
     }
@@ -2531,7 +2529,7 @@ void ChapterHtmlSlimParser::makePages() {
   // edge cases where a footnote's word index equals the exact block size.
   if (!pendingFootnotes.empty() && currentPage) {
     for (const auto& [idx, fn] : pendingFootnotes) {
-      currentPage->addFootnote(fn.number, fn.href);
+      currentPage->addFootnote(fn.number, fn.href.c_str());
       if (sectionFootnoteData.size() < MAX_SECTION_FOOTNOTES) {
         sectionFootnoteData.push_back({static_cast<uint16_t>(completedPageCount), fn});
       }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1065,6 +1065,7 @@ void EpubReaderActivity::openReaderMenu() {
   } else if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
     hasPageText = !section->getTextFromSectionFile().empty();
   }
+  refreshSectionFootnotesIfBuilt();
   startActivityForResult(
       std::make_unique<EpubReaderMenuActivity>(
           renderer, mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent, SETTINGS.orientation,
@@ -3894,7 +3895,16 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
   }
 }
 
+void EpubReaderActivity::refreshSectionFootnotesIfBuilt() {
+  // Nothing to re-read while the build is still running (the table is written last), and a
+  // vertical section never has one. An empty list on a finished section is also the normal
+  // "chapter has no notes" case -- the retry costs one small read on menu/panel open.
+  if (!section || section->isBuilding() || !sectionFootnotes.empty()) return;
+  section->loadSectionFootnotes(sectionFootnotes);
+}
+
 void EpubReaderActivity::openFootnotesPanel() {
+  refreshSectionFootnotesIfBuilt();
   // Prefer the chapter-wide list (section file v32+); fall back to the current page's own
   // footnotes for sections built by older firmware. The panel opens at the footnote nearest
   // the current page: the first one ON the page, else the most recently passed one.

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -161,6 +161,11 @@ class EpubReaderActivity final : public ReaderActivity {
   // Chapter-wide footnote list from the section file's footnote table (v32+): the panel shows
   // ALL of the chapter's notes, opening at the one nearest the current page.
   std::vector<std::pair<uint16_t, FootnoteEntry>> sectionFootnotes;
+  // The chapter-wide table only exists on disk once the build FINALIZES, so a visit that has to
+  // build the section loads nothing at chapter open and nothing re-reads it afterwards -- the
+  // whole chapter's notes silently vanish for that visit (menu entry included). Top the list up
+  // wherever it is consumed instead of trusting the one load.
+  void refreshSectionFootnotesIfBuilt();
   // Flattened entries handed to the footnote panel (must outlive the activity, which keeps a
   // reference); rebuilt on each open.
   std::vector<FootnoteEntry> footnotePanelEntries;

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -18,7 +18,10 @@ void EpubReaderFootnotesActivity::onEnter() {
   selectFootnote(startIndex);
 }
 
-void EpubReaderFootnotesActivity::onExit() { Activity::onExit(); }
+void EpubReaderFootnotesActivity::onExit() {
+  FootnoteText::releaseStaging();
+  Activity::onExit();
+}
 
 void EpubReaderFootnotesActivity::selectFootnote(const int index) {
   if (footnotes.empty()) return;

--- a/src/activities/reader/FootnoteTextExtractor.cpp
+++ b/src/activities/reader/FootnoteTextExtractor.cpp
@@ -11,6 +11,14 @@ namespace {
 
 constexpr size_t PARSE_CHUNK = 1024;
 
+// Fallback staging, used only when the target chapter has no cached HTML. It costs a full ZIP
+// inflate plus an SD write of the WHOLE file (measured 1138ms against 406ms for the parse, which
+// stops the moment the anchor's text is collected), so a chapter's notes -- nearly all pointing
+// at one target -- would pay it per lookup. Keep the staged file and reuse it while the target
+// is unchanged; the panel drops it on exit via releaseStaging().
+std::string stagedPath;  // temp file currently holding a staged item ("" = nothing staged)
+std::string stagedItem;  // spine item href staged at stagedPath
+
 struct ExtractState {
   const char* anchor = nullptr;  // empty string = collect <body>
   std::string* out = nullptr;
@@ -109,18 +117,31 @@ bool extract(Epub& epub, const int currentSpineIndex, const std::string& href, s
   }
   const std::string itemHref = epub.getSpineItem(spineIdx).href;
 
-  // Stream the target item to a temp file (same pattern as Section's HTML staging).
-  const std::string tmpPath = epub.getCachePath() + "/fn_tmp.html";
-  {
+  // The section builder already keeps every chapter it has laid out as raw inflated HTML under
+  // <cache>/html/<spine>.html, keyed on the book alone and known-complete once it exists. A
+  // footnote target that has been read therefore needs no inflate at all -- which is also what
+  // makes the panel survive a tight heap, since the inflate is what fails first there.
+  // Otherwise stage the item ourselves, reusing the previous lookup's staging when the target
+  // is unchanged (a chapter's notes nearly all share one).
+  const std::string cachedHtml = epub.getCachePath() + "/html/" + std::to_string(spineIdx) + ".html";
+  const unsigned long stageStart = millis();
+  const bool cacheHit = Storage.exists(cachedHtml.c_str());
+  const std::string parsePath = cacheHit ? cachedHtml : epub.getCachePath() + "/fn_tmp.html";
+  const bool restaged = !cacheHit && (stagedPath != parsePath || stagedItem != itemHref);
+  if (restaged) {
+    releaseStaging();
     HalFile tmp;
-    if (!Storage.openFileForWrite("FNX", tmpPath, tmp)) return false;
+    if (!Storage.openFileForWrite("FNX", parsePath, tmp)) return false;
     if (!epub.readItemContentsToStream(itemHref, tmp, PARSE_CHUNK)) {
       tmp.close();
-      Storage.remove(tmpPath.c_str());
+      Storage.remove(parsePath.c_str());
       LOG_DBG("FNX", "Failed to stream %s", itemHref.c_str());
       return false;
     }
+    stagedPath = parsePath;
+    stagedItem = itemHref;
   }
+  const unsigned long stageMs = millis() - stageStart;
 
   ExtractState st;
   st.anchor = anchor.c_str();
@@ -129,7 +150,7 @@ bool extract(Epub& epub, const int currentSpineIndex, const std::string& href, s
 
   XML_Parser parser = XML_ParserCreate(nullptr);
   if (!parser) {
-    Storage.remove(tmpPath.c_str());
+    releaseStaging();
     return false;
   }
   st.parser = parser;
@@ -137,10 +158,11 @@ bool extract(Epub& epub, const int currentSpineIndex, const std::string& href, s
   XML_SetElementHandler(parser, startElement, endElement);
   XML_SetCharacterDataHandler(parser, characterData);
 
+  const unsigned long parseStart = millis();
   bool ok = true;
   {
     HalFile f;
-    if (!Storage.openFileForRead("FNX", tmpPath, f)) {
+    if (!Storage.openFileForRead("FNX", parsePath, f)) {
       ok = false;
     } else {
       char buf[PARSE_CHUNK];
@@ -160,10 +182,18 @@ bool extract(Epub& epub, const int currentSpineIndex, const std::string& href, s
     }
   }
   XML_ParserFree(parser);
-  Storage.remove(tmpPath.c_str());
+  const char* source = cacheHit ? "html cache" : (restaged ? "streamed" : "reused");
+  LOG_DBG("FNX", "Extract %s: stage=%lums (%s) parse=%lums", href.c_str(), stageMs, source, millis() - parseStart);
 
   while (!out.empty() && out.back() == ' ') out.pop_back();
   return ok && !out.empty();
+}
+
+void releaseStaging() {
+  if (stagedPath.empty()) return;
+  Storage.remove(stagedPath.c_str());
+  stagedPath.clear();
+  stagedItem.clear();
 }
 
 }  // namespace FootnoteText

--- a/src/activities/reader/FootnoteTextExtractor.h
+++ b/src/activities/reader/FootnoteTextExtractor.h
@@ -19,4 +19,9 @@ namespace FootnoteText {
 // best-effort empty string. maxBytes caps the collected UTF-8 text (never splits mid-glyph).
 bool extract(Epub& epub, int currentSpineIndex, const std::string& href, std::string& out, size_t maxBytes = 2048);
 
+// Delete the temp file extract() keeps staged between lookups (a chapter's notes nearly all share
+// one target, so re-staging it per lookup is what made stepping through the panel slow). Call when
+// the panel closes; extract() re-stages on demand, so calling it early only costs one restream.
+void releaseStaging();
+
 }  // namespace FootnoteText


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix an `abort()` that killed the section build on a footnote-heavy chapter, and repair the two footnote-panel regressions it exposed.
* **What changes are included?**

**1. `fix: stop the footnote table aborting the section build`**

A 61-page chapter died at page 58. Symbolicated: `operator new` → `std::bad_alloc` → `__terminate`, from `vector<pair<uint16_t, FootnoteEntry>>::_M_realloc_append` in `ChapterHtmlSlimParser::addLineToPage`.

`FootnoteEntry` carried `char href[256]`, so the record was 288 bytes and the chapter-wide table (capped at 128) needed **2×N×290 bytes contiguous** to double — 37KB for the 64→128 step, against the `maxAlloc=14324` in the crash log. `std::vector` allocates through throwing `operator new`, which under `-fno-exceptions` is `abort()`, not `nullptr`.

Three more containers had the same shape: the uncapped `pendingFootnotes`, `Page::footnotes`, and `loadSectionFootnotes`' out vector — that last one reserving 128 entries in the reader and then copied into `footnotePanelEntries`, so opening the panel wanted 74KB.

`href` is now a `std::string`: record ~36 bytes, table ~4.6KB contiguous plus one small allocation per href. **The on-disk field stays a fixed `FOOTNOTE_HREF_LEN`**, written/read in 32-byte chunks by `writeFootnoteHref`/`readFootnoteHref` (no 256-byte stack buffer), so the section format is byte-identical and **no cache is invalidated**.

**2. `fix: reload the chapter footnote table once the build finishes`**

`loadSectionFootnotes()` ran once, at chapter open. The table is only written when the build *finalizes*, so any visit that had to build the section read nothing and nothing re-read it — the chapter's notes were absent for the whole visit, menu entry included. Any rebuild looked like the footnotes had vanished. The list is now topped up where it is consumed, once the section has finished building.

**3. `perf: read footnote targets from the cached chapter HTML`**

Every selection change in the panel re-staged the target item: full ZIP inflate plus an SD write of the whole file. Measured **1138ms staging against 406ms parsing**, and a chapter's notes nearly all share one target, so a 37-note panel paid it 37 times (`[LOOP] New max loop duration: 1793 ms` per step). The inflate is also the first thing to fail under heap pressure — it returned false at `maxAlloc=32756` and the panel fell back to displaying the raw href instead of the note.

The section builder already caches every chapter it lays out as raw inflated HTML at `<cache>/html/<spine>.html`, keyed on the book alone and known-complete once it exists. The extractor parses that directly when present: no inflate, no temp file, nothing to fail. Same-file `#anchor` notes always hit it. Staging remains for targets never opened, now reused across lookups and dropped when the panel exits.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this is a crash fix in CrossPoint's own section builder.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in the Phase scope: heap fragmentation and the reading experience.

## Additional Context

**Memory:** peak contiguous demand for the chapter footnote table drops 37KB → ~4.6KB; the reader's panel path drops ~74KB → ~9KB. Flash is ~13KB smaller.

**Cache compatibility:** none. The section file format is unchanged and records written by earlier firmware read back identically — covered by a host round-trip test over empty / 31 / 32 / 33 / 255 / >256-byte hrefs plus a legacy `strncpy`-written record.

**Device verification** (X4, overlay build): the chapter that aborted now builds all 61 pages at `maxAlloc=8180`; footnote panel loads `Chapter footnotes: 37` and extracts via `stage=7ms (html cache) parse=450ms`.

**Focus areas for review:** the fixed-width href padding in `FootnoteEntry.h`, and the `releaseStaging()` lifetime in `FootnoteTextExtractor` (panel `onExit`).

**Not fixed here:** `[ERR] [GFX] No glyph for codepoint 8617` — the ↩ in note text has no glyph in the UI font. Cosmetic, pre-existing.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
