### PR TITLE
feat: X4 Pro touch support for the manga reader, word lookup and Library

### DIFF
--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -258,6 +258,14 @@ void ActivityManager::goToFullScreenMessage(std::string message, EpdFontFamily::
 }
 
 void ActivityManager::goHome(HomeMenuItem initialMenuItem, bool cleanInitialRefresh) {
+  // Home's first paint is FAST, which cannot clear what a reader leaves behind: dense text and
+  // grayscale image planes deposit charge (see GfxRenderer::panelResidue_), and it showed as the
+  // previous page ghosting through Home's cover tile. Scrub on the way out of a reader -- and
+  // ONLY then. The light list screens (FileBrowser, Settings, ReadingStats) leave nothing to
+  // clear, and scrubbing on every return made the most-visited screen the slowest one: 1690ms
+  // plus repaints, against 502ms everywhere else.
+  const bool leftReaderFrame = currentActivity && currentActivity->isReaderActivity();
+
   if (initialMenuItem == HomeMenuItem::NONE && currentActivity) {
     const auto& activityName = currentActivity->name;
     if (activityName == "FileBrowser") {
@@ -272,7 +280,8 @@ void ActivityManager::goHome(HomeMenuItem initialMenuItem, bool cleanInitialRefr
       initialMenuItem = HomeMenuItem::SETTINGS_MENU;
     }
   }
-  replaceActivity(std::make_unique<HomeActivity>(renderer, mappedInput, initialMenuItem, cleanInitialRefresh));
+  replaceActivity(
+      std::make_unique<HomeActivity>(renderer, mappedInput, initialMenuItem, cleanInitialRefresh || leftReaderFrame));
 }
 void ActivityManager::goToCrashReport() { replaceActivity(std::make_unique<CrashActivity>(renderer, mappedInput)); }
 

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -92,6 +92,8 @@ class ActivityManager {
   void goToBoot();
   void goToFullScreenMessage(std::string message, EpdFontFamily::Style style = EpdFontFamily::REGULAR);
   void goToCrashReport();
+  // cleanInitialRefresh forces the scrubbing HALF pass on Home's first paint. goHome() also
+  // sets it on its own when the outgoing screen was a reader -- see the implementation.
   void goHome(HomeMenuItem initialMenuItem = HomeMenuItem::NONE, bool cleanInitialRefresh = false);
 
   // This will move current activity to stack instead of deleting it

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -928,7 +928,11 @@ void RecentBooksActivity::loop() {
       return;
     }
 
-    if (shelfContentIndex < static_cast<int>(shelfBooks.size())) {
+    // The click that opened this shelf is still down: only a press that STARTS here may act, or
+    // its release opens the focused book the instant the shelf appears (see shelfConfirmPressSeen).
+    if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) shelfConfirmPressSeen = true;
+
+    if (shelfConfirmPressSeen && shelfContentIndex < static_cast<int>(shelfBooks.size())) {
       // Shelves are where manga folders are browsed; without this they had no route to stats.
       if (mappedInput.isPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() >= LONG_PRESS_MS) {
         longPressFired = true;
@@ -976,6 +980,7 @@ void RecentBooksActivity::loop() {
         if (itemIdx < static_cast<int>(shelves.size())) {
           LOG_DBG("RBA", "Opening shelf: %s", shelves[itemIdx].folderPath.c_str());
           openShelfIndex = itemIdx;
+          shelfConfirmPressSeen = false;
           shelfContentIndex = 0;
           shelfScrollRow = 0;
           loadShelfBooks(shelves[itemIdx].folderPath);
@@ -1085,6 +1090,7 @@ void RecentBooksActivity::loop() {
         } else if (hit < static_cast<int>(shelves.size())) {
           LOG_DBG("RBA", "Tapped shelf: %s", shelves[hit].folderPath.c_str());
           openShelfIndex = hit;
+          shelfConfirmPressSeen = false;
           shelfContentIndex = 0;
           shelfScrollRow = 0;
           loadShelfBooks(shelves[hit].folderPath);

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -247,6 +247,32 @@ int RecentBooksActivity::getVisibleRows(int cellHeight, int contentHeight) const
   return std::max(1, (contentHeight + GRID_ROW_GAP) / (cellHeight + GRID_ROW_GAP));
 }
 
+int RecentBooksActivity::gridIndexAtPoint(const int x, const int y, const int contentTop, const int contentHeight,
+                                          const int scrollRowIn, const int itemCount) const {
+  if (itemCount <= 0) return -1;
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const int cellWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / GRID_COLS;
+  if (cellWidth <= 0) return -1;
+  const int cellHeight = getCellHeight(cellWidth);
+  const int rowStride = cellHeight + GRID_ROW_GAP;
+  const int visibleRows = getVisibleRows(cellHeight, contentHeight);
+  if (cellHeight <= 0 || visibleRows <= 0) return -1;
+
+  const int localX = x - metrics.contentSidePadding;
+  if (localX < 0 || localX >= cellWidth * GRID_COLS) return -1;
+  const int localY = y - contentTop;
+  if (localY < 0) return -1;
+
+  const int row = localY / rowStride;
+  // Full rows only -- the peek row below them is a hint, not a target (see the header).
+  if (row >= visibleRows) return -1;
+  // The GRID_ROW_GAP band between two rows belongs to neither.
+  if (localY - row * rowStride >= cellHeight) return -1;
+
+  const int index = (scrollRowIn + row) * GRID_COLS + localX / cellWidth;
+  return index < itemCount ? index : -1;
+}
+
 int RecentBooksActivity::getContentItemCount() const {
   if (selectedTab == 0) return static_cast<int>(recentBooks.size());
   return static_cast<int>(shelves.size());
@@ -871,6 +897,37 @@ void RecentBooksActivity::loop() {
       return;
     }
 
+    // Touch: same three gestures as the grid below. contentTop here is the loop-local one --
+    // the shelf detail view draws no tab bar, so its content starts higher than the tabbed views.
+    const int shelfCount = static_cast<int>(shelfBooks.size());
+    int shelfTouchX = 0;
+    int shelfTouchY = 0;
+    if (mappedInput.wasScreenLongPress(shelfTouchX, shelfTouchY)) {
+      const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      if (hit >= 0) {
+        shelfContentIndex = hit;
+        showBookStats(shelfBooks[hit].path, shelfBooks[hit].title);
+      }
+      return;
+    }
+    if (mappedInput.wasScreenTouchDown(shelfTouchX, shelfTouchY)) {
+      const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      if (hit >= 0 && hit != shelfContentIndex) {
+        shelfContentIndex = hit;
+        requestUpdate();
+      }
+      return;
+    }
+    if (mappedInput.wasScreenTapped(shelfTouchX, shelfTouchY)) {
+      const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      if (hit >= 0) {
+        shelfContentIndex = hit;
+        LOG_DBG("RBA", "Tapped shelf book: %s", shelfBooks[hit].path.c_str());
+        onSelectBook(shelfBooks[hit].path);
+      }
+      return;
+    }
+
     if (shelfContentIndex < static_cast<int>(shelfBooks.size())) {
       // Shelves are where manga folders are browsed; without this they had no route to stats.
       if (mappedInput.isPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() >= LONG_PRESS_MS) {
@@ -967,6 +1024,75 @@ void RecentBooksActivity::loop() {
       requestUpdate();
     }
     return;
+  }
+
+  // --- Touch, main (tabbed) view ------------------------------------------------------------
+  // Without this the Library is button-only: covers, tabs and shelves have no tap target, which
+  // on a board with no front buttons leaves selecting a book to next/prev plus a remapped power
+  // click, and reaching the Shelves tab to holding next (#129).
+  {
+    const auto& m = UITheme::getInstance().getMetrics();
+    const int tabBarY = m.topPadding + m.headerHeight;
+    // The tabbed views start BELOW the tab bar, unlike the loop-local contentTop above.
+    const int gridTop = tabBarY + m.tabBarHeight + m.verticalSpacing;
+    const int gridHeight = renderer.getScreenHeight() - gridTop - m.buttonHintsHeight - m.verticalSpacing;
+    const int itemCount = getContentItemCount();
+
+    // Tab bar: two equal columns across the full width, matching GUI.drawTabBar's rect.
+    int tab = -1;
+    const auto tabTouch = mappedInput.colTouch(tab, 0, renderer.getScreenWidth() / TAB_COUNT, TAB_COUNT, tabBarY,
+                                               tabBarY + m.tabBarHeight);
+    if (tabTouch == MappedInputManager::RowTouch::Tap && tab >= 0 && tab != selectedTab) {
+      selectedTab = tab;
+      if (selectedTab == 1 && !shelvesLoaded) loadShelves();
+      contentIndex = 0;
+      scrollRow = 0;
+      requestUpdate();
+      return;
+    }
+    if (tabTouch != MappedInputManager::RowTouch::None) return;
+
+    int gx = 0;
+    int gy = 0;
+    // Long press first: wasScreenLongPress suppresses the rest of the contact, so the lift
+    // cannot also tap the screen this opens.
+    if (mappedInput.wasScreenLongPress(gx, gy)) {
+      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      // Stats are for books; a shelf has none.
+      if (hit >= 0 && selectedTab == 0 && hit < static_cast<int>(recentBooks.size())) {
+        contentIndex = hit + 1;
+        showBookStats(recentBooks[hit].path, recentBooks[hit].title);
+      }
+      return;
+    }
+    if (mappedInput.wasScreenTouchDown(gx, gy)) {
+      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      if (hit >= 0 && contentIndex != hit + 1) {
+        contentIndex = hit + 1;  // index 0 is the tab bar
+        requestUpdate();
+      }
+      return;
+    }
+    if (mappedInput.wasScreenTapped(gx, gy)) {
+      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      if (hit >= 0) {
+        contentIndex = hit + 1;
+        if (selectedTab == 0) {
+          if (hit < static_cast<int>(recentBooks.size())) {
+            LOG_DBG("RBA", "Tapped recent book: %s", recentBooks[hit].path.c_str());
+            onSelectBook(recentBooks[hit].path);
+          }
+        } else if (hit < static_cast<int>(shelves.size())) {
+          LOG_DBG("RBA", "Tapped shelf: %s", shelves[hit].folderPath.c_str());
+          openShelfIndex = hit;
+          shelfContentIndex = 0;
+          shelfScrollRow = 0;
+          loadShelfBooks(shelves[hit].folderPath);
+          requestUpdate();
+        }
+      }
+      return;
+    }
   }
 
   // Release, not press: leaving on the press edge hands the release of the same

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -23,6 +23,12 @@ class RecentBooksActivity final : public Activity {
   int scrollRow = 0;
 
   bool longPressFired = false;
+  // A shelf opens on the Confirm PRESS, so the release of that same physical click arrives with
+  // the shelf's book list already on screen -- where it read as "open the focused book", opening
+  // one the moment a shelf was entered. Cleared on entry and set by a FRESH press, so only a
+  // click that both started and ended inside the shelf view can act. Same guard as
+  // EpubReaderWordLookupActivity::confirmPressSeen, which is entered mid-press the same way.
+  bool shelfConfirmPressSeen = false;
 
   // Books tab
   std::vector<RecentBook> recentBooks;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -65,6 +65,13 @@ class RecentBooksActivity final : public Activity {
 
   int getVisibleRows(int cellHeight, int contentHeight) const;
   int getCellHeight(int cellWidth) const;
+  // Absolute grid item index under a screen point, or -1 for a miss. Derives the cell grid the
+  // same way renderBooksTab()/renderShelvesTab()/renderShelfBooksView() do, so the hit targets
+  // are exactly the drawn cells. Deliberately stops at visibleRows: those renderers draw one
+  // EXTRA "peek" row as a more-below hint, and it sits half-behind the button hints -- letting a
+  // tap land there would open a book the reader cannot actually see. contentTop differs between
+  // the tabbed views and the shelf detail view (no tab bar), so the caller passes it in.
+  int gridIndexAtPoint(int x, int y, int contentTop, int contentHeight, int scrollRowIn, int itemCount) const;
   // Cover height of one grid cell, published by the render task and read by the scan task.
   // The scan also derives the same geometry before the first render, so it never generates a
   // theme-sized thumb that the grid cannot draw.

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -618,6 +618,27 @@ bool EpubReaderWordLookupActivity::handleSelectInput() {
     return true;
   }
 
+  // A tap straight on a word selects it AND looks it up. On a board with no front buttons (X4
+  // Pro) the column jumps below are unreachable and Confirm may not exist either, which left the
+  // panel openable but not usable (#128). A direct tap needs neither axis: it reaches any word on
+  // the page in one gesture. A tap that hits no word is ignored rather than moving the cursor
+  // somewhere arbitrary.
+  int tapX = 0;
+  int tapY = 0;
+  if (mappedInput.hasTouch() && mappedInput.wasScreenTapped(tapX, tapY)) {
+    const int hit = selectableIndexAtPoint(tapX, tapY);
+    if (hit >= 0) {
+      // Straight to the definition, so the parked-move guard above does not apply: the tap names
+      // its own target, so there is no pending arrival whose word would be the wrong entry.
+      pending.kind = PendingMove::Kind::None;
+      cursorIndex = hit;
+      refreshCursorBoxes();
+      enterDefinition();
+      return false;
+    }
+    return true;
+  }
+
   // Side buttons step word by word (down a column is the same gesture as a page turn), front
   // Left/Right jump columns. Button::Up/Down are the physical side buttons whatever the page-turn
   // layout setting is, so this mapping holds on every device that has them.
@@ -628,39 +649,59 @@ bool EpubReaderWordLookupActivity::handleSelectInput() {
   return true;
 }
 
+int EpubReaderWordLookupActivity::buildBoxesFor(const int selectableIndex, HighlightBox* out) const {
+  int count = 0;
+  if (selectableIndex < 0 || static_cast<size_t>(selectableIndex) >= scan.selectToAllIdx.size()) return 0;
+
+  const size_t start = scan.selectToAllIdx[static_cast<size_t>(selectableIndex)];
+  if (start >= scan.allGlyphs.size()) return 0;
+
+  const size_t span = std::max<size_t>(scan.selectableGlyphs[static_cast<size_t>(selectableIndex)].matchLen, 1);
+  const size_t end = std::min(start + span, scan.allGlyphs.size());
+  const int cellPx = selectCtx.cellPx;
+
+  size_t i = start;
+  while (i < end && count < kMaxHighlightBoxes) {
+    const uint16_t column = scan.allGlyphs[i].column;
+    size_t j = i + 1;
+    while (j < end && scan.allGlyphs[j].column == column) j++;
+    const auto& firstCell = scan.allGlyphs[i];
+    const auto& lastCell = scan.allGlyphs[j - 1];
+    const int top = std::min(firstCell.y, lastCell.y) + selectCtx.marginTop;
+    const int bottom = std::max(firstCell.y, lastCell.y) + selectCtx.marginTop + cellPx;
+    HighlightBox& box = out[count++];
+    // Cell-exact, no padding: the cell IS the em box, so the box lands clear of the
+    // neighbouring column's ink and of any ruby, which is drawn outside the cell.
+    box.x = static_cast<int16_t>(firstCell.x + selectCtx.marginLeft);
+    box.y = static_cast<int16_t>(top);
+    box.w = static_cast<int16_t>(cellPx);
+    box.h = static_cast<int16_t>(bottom - top);
+    i = j;
+  }
+  return count;
+}
+
+int EpubReaderWordLookupActivity::selectableIndexAtPoint(const int x, const int y) const {
+  // Linear over the page's selectable words, rebuilding each candidate's boxes through
+  // buildBoxesFor so the hit test and the drawn highlight can never disagree. A few hundred
+  // iterations of integer compares is nothing against the e-ink refresh a tap triggers.
+  HighlightBox boxes[kMaxHighlightBoxes];
+  const int total = static_cast<int>(scan.selectToAllIdx.size());
+  for (int idx = 0; idx < total; idx++) {
+    const int count = buildBoxesFor(idx, boxes);
+    for (int b = 0; b < count; b++) {
+      const HighlightBox& box = boxes[b];
+      if (x >= box.x && x < box.x + box.w && y >= box.y && y < box.y + box.h) return idx;
+    }
+  }
+  return -1;
+}
+
 void EpubReaderWordLookupActivity::refreshCursorBoxes() {
   // Built in locals first: the scan reads below are the slow part, and the render task must never
   // observe a half-built set. Only the publish at the end runs with the render task locked out.
   HighlightBox boxes[kMaxHighlightBoxes];
-  int count = 0;
-
-  if (cursorIndex >= 0 && static_cast<size_t>(cursorIndex) < scan.selectToAllIdx.size()) {
-    const size_t start = scan.selectToAllIdx[static_cast<size_t>(cursorIndex)];
-    if (start < scan.allGlyphs.size()) {
-      const size_t span = std::max<size_t>(scan.selectableGlyphs[static_cast<size_t>(cursorIndex)].matchLen, 1);
-      const size_t end = std::min(start + span, scan.allGlyphs.size());
-      const int cellPx = selectCtx.cellPx;
-
-      size_t i = start;
-      while (i < end && count < kMaxHighlightBoxes) {
-        const uint16_t column = scan.allGlyphs[i].column;
-        size_t j = i + 1;
-        while (j < end && scan.allGlyphs[j].column == column) j++;
-        const auto& firstCell = scan.allGlyphs[i];
-        const auto& lastCell = scan.allGlyphs[j - 1];
-        const int top = std::min(firstCell.y, lastCell.y) + selectCtx.marginTop;
-        const int bottom = std::max(firstCell.y, lastCell.y) + selectCtx.marginTop + cellPx;
-        HighlightBox& box = boxes[count++];
-        // Cell-exact, no padding: the cell IS the em box, so the box lands clear of the
-        // neighbouring column's ink and of any ruby, which is drawn outside the cell.
-        box.x = static_cast<int16_t>(firstCell.x + selectCtx.marginLeft);
-        box.y = static_cast<int16_t>(top);
-        box.w = static_cast<int16_t>(cellPx);
-        box.h = static_cast<int16_t>(bottom - top);
-        i = j;
-      }
-    }
-  }
+  const int count = buildBoxesFor(cursorIndex, boxes);
 
   // Publish as one unit. The critical section spans a ~32-byte copy, which is what it takes to
   // stop the render task from pairing this move's count with the previous move's rectangles.

--- a/src/activities/reader/EpubReaderWordLookupActivity.h
+++ b/src/activities/reader/EpubReaderWordLookupActivity.h
@@ -139,6 +139,14 @@ class EpubReaderWordLookupActivity final : public Activity {
   PendingMove pending;
 
   void renderSelect();
+  // Screen boxes for one selectable word, written into `out` (at most kMaxHighlightBoxes),
+  // returning how many. The single source of truth for glyph->screen geometry: both the drawn
+  // highlight and the tap hit-test go through it, so they cannot drift apart. Main task only
+  // (it reads the scan vectors).
+  int buildBoxesFor(int selectableIndex, HighlightBox* out) const;
+  // Selectable index whose word covers the screen point, or -1 for a tap that missed every word
+  // (a gutter, a margin, unscanned text). Main task only.
+  int selectableIndexAtPoint(int x, int y) const;
   // Rebuild cursorBoxes for the current cursor. Main task only (it reads the scan vectors).
   // A match that wraps from the foot of one column to the head of the next becomes one box per
   // column, so the highlight never covers the gutter between them.

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -518,6 +518,14 @@ void MangaReaderActivity::loop() {
   clearEndOfBookOptionsIfNeeded();
   if (handleEndOfBookMenu()) return;
 
+  // Same touch contract as every other reader (EpubReaderActivity, XtcReaderActivity,
+  // TxtReaderActivity): outer-third taps or horizontal swipes turn the page, a centre tap opens
+  // the menu. Both helpers gate on SETTINGS.touchReaderControls and hasTouch(), so tap-vs-swipe
+  // mode and the global opt-out are inherited and non-touch boards see no change. Read once per
+  // tick, before any early return can swallow the gesture.
+  const auto touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
+  const bool touchMenu = ReaderUtils::isTouchMenuGesture(renderer, mappedInput);
+
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
     showBookmarkMessage = false;
     requestUpdate();
@@ -525,7 +533,7 @@ void MangaReaderActivity::loop() {
 
   if (automaticPageTurnActive) {
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+        mappedInput.wasReleased(MappedInputManager::Button::Back) || touchMenu) {
       automaticPageTurnActive = false;
       requestUpdate();
       return;
@@ -561,7 +569,12 @@ void MangaReaderActivity::loop() {
       requestUpdate();
       return;
     }
-    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    // A tap anywhere on the overlay looks the word up, matching Confirm: the overlay is a
+    // full-screen text panel, so there is no page-turn zone here to keep clear.
+    int overlayTapX = 0;
+    int overlayTapY = 0;
+    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
+        (mappedInput.hasTouch() && mappedInput.wasScreenTapped(overlayTapX, overlayTapY))) {
       launchWordLookup();
       return;
     }
@@ -589,7 +602,7 @@ void MangaReaderActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) || touchMenu) {
     if (ignoreNextConfirmRelease) {
       ignoreNextConfirmRelease = false;
     } else if (viewMode == ViewMode::PanelZoom || viewMode == ViewMode::FullPage) {
@@ -598,7 +611,9 @@ void MangaReaderActivity::loop() {
     }
   }
 
-  const auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
+  auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
+  prevTriggered = prevTriggered || touch.prev;
+  nextTriggered = nextTriggered || touch.next;
   if (!prevTriggered && !nextTriggered) {
     // Idle tick: after a dwell, warm the pixel cache the user is most likely to need next so the
     // render hits it instead of a fresh JPEG decode. Dwell gates and ordering rationale live with


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the manga reader, the word lookup panel and the Library usable by touch on an X4 Pro, which has a GT911 digitiser and **no bottom front buttons** (`BoardConfig.h:348`) — so on those screens some actions were not merely awkward but unreachable.
* **What changes are included?**

Closes #127, closes #128, closes #129. Plus two pre-existing bugs found while testing — see the second table.

The touch stack itself was already complete and in use (`MappedInputManager`: `wasScreenTapped`, `wasScreenTouchDown`, `wasScreenLongPress`, `rowTouch`, `colTouch`, `hasTouch`; the left-edge back swipe is already folded into `wasReleased(Button::Back)` at `MappedInputManager.cpp:301`). Every commit here wires an existing helper into a screen that never consumed one — no new input plumbing.

| Issue | Screen | Change |
|---|---|---|
| #127 | Manga reader | Wires `ReaderUtils::detectTouchPageTurn()` and `isTouchMenuGesture()` — the same two helpers `EpubReaderActivity.cpp:653`, `XtcReaderActivity.cpp:76` and `TxtReaderActivity.cpp:67` already use. ORing into the existing `prev/nextTriggered` pair means panel-aware paging (`nextPanel()` in zoom, `nextPage()` otherwise) falls out of the existing branch. Both helpers self-gate on `SETTINGS.touchReaderControls` / `tapForReaderMenu` / `hasTouch()`, so tap-vs-swipe mode and the global opt-out are inherited. |
| #128 | Word lookup | A tap selects the word under the finger **and** opens its definition. Stepping words is on the side buttons and jumping columns on front Left/Right, so on a Pro a word was reachable only down a column and, with Confirm also unreachable, could not be looked up at all. A direct tap needs neither axis. |
| #129 | Library | `gridIndexAtPoint()` hit-tests the cover grid, the tab strip and the shelf detail view. Previously only a vertical swipe worked: selecting a book meant next/prev plus a power button remapped to Confirm, and the Shelves tab was reachable only by holding next — the workaround the reporter had to discover. |

### Two unrelated fixes riding along

Both are pre-existing and were hit while testing the above on device. Flagged because a reviewer looking for touch changes will not expect a refresh-policy change.

| Commit | Bug |
|---|---|
| `37726c7` | A shelf opens on the Confirm **press**, so the **release** of that same click landed in the shelf's book list and read as "open the focused book" — entering any shelf immediately opened its first book. Device log, 161 ms apart: `[273434] Opening shelf: /English` → `[273595] Selected shelf book: /English/1984.epub`. Guarded with `shelfConfirmPressSeen`, the same guard `EpubReaderWordLookupActivity::confirmPressSeen` uses for the same reason. |
| `4d38074` | Returning to Home from a book left the previous frame ghosting through the cover tile. Home's first paint only scrubs when `cleanInitialRefresh` is set, and exactly one caller (the wake path) set it. `goHome()` now sets it itself when the outgoing activity reports `isReaderActivity()`. |

On that last one: scrubbing on **every** route home was tried first and reverted — it cost 1690 ms plus repaints on the most-visited screen in the UI, against 502 ms everywhere else, and the light list screens leave nothing to clear. Only the readers drive the dense text and grayscale image planes whose charge `GfxRenderer::panelResidue_` describes.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — these are unreachable controls and two bugs in CrossPoint's own screens.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in scope: reading experience and device support.

## Additional Context

**⚠️ The touch behaviour is UNVERIFIED.** The only device available here is a plain X4, which has no digitiser. #127–#129 are reasoned from the code and compile, but no tap has ever been dispatched against them. Please leave the three issues open until the original reporter confirms on a Pro. What *was* verified on an X4:

* `pio run -e overlay` builds; `./bin/clang-format-fix` (clang-format 21.1.8) leaves the tree unchanged.
* Flashed and exercised: button navigation is unchanged everywhere (every touch read is `hasTouch()`-gated, directly or via `SETTINGS.touchReaderControls`, so non-touch boards take no new path).
* Both riding-along fixes were reproduced from the serial log, fixed, and re-verified on device.

**Deliberately not done**, so it is a decision rather than an omission:

* `MangaWordLookupActivity` — draws no page behind it, headword and definition only, so there are no word boxes to tap. Its actual Pro gap is that entry stepping defaults to front Left/Right, which the existing `wordLookupSideButtons` setting already moves to the side buttons.
* Tap-to-dismiss on the definition view — the left-edge back swipe already exits on touch boards, and a screen-wide dismiss target is mostly a way to lose your place by brushing the panel.

**Risk areas for review:** `gridIndexAtPoint()` stops at `visibleRows` on purpose — the renderers draw one extra "peek" row half-behind the button hints, and a tap landing there would open a book the reader cannot see. And in the word lookup, the per-word geometry moved out of `refreshCursorBoxes()` into `buildBoxesFor()` so the hit test and the drawn highlight cannot drift apart; the `boxMux` publish stayed exactly where it was, since the render task reads those boxes concurrently.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
