### PR TITLE
perf: stop the Library cover scan repeating work

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -136,8 +136,9 @@ void RecentBooksActivity::runCoverJob() {
   const bool isXtc = FsHelpers::hasXtcExtension(result.book.path);
   if (!isEpub && !isXtc) {
     const manga::MangaBook mangaBook(result.book.path);
-    const int targetHeight = coverJob_.targetHeight > 0 ? coverJob_.targetHeight : coverJob_.gridHeight;
-    if (targetHeight > 0 && !thumbHeightValid(mangaBook.getThumbBmpPath(targetHeight), targetHeight)) {
+    for (const int targetHeight : coverJob_.targetHeights) {
+      if (targetHeight <= 0 || coverWorkerShouldCancel(this)) continue;
+      if (thumbHeightValid(mangaBook.getThumbBmpPath(targetHeight), targetHeight)) continue;
       Storage.remove(mangaBook.getThumbBmpPath(targetHeight).c_str());
       mangaBook.generateThumbBmp(targetHeight, &coverWorkerShouldCancel, this);
     }
@@ -146,9 +147,12 @@ void RecentBooksActivity::runCoverJob() {
   } else if (isEpub) {
     Epub epub(result.book.path, "/.crosspoint");
     const bool loaded = epub.load(true, true, &coverWorkerShouldCancel, this);
-    const int targetHeight = coverJob_.targetHeight > 0 ? coverJob_.targetHeight : coverJob_.gridHeight;
-    if (loaded && !coverWorkerShouldCancel(this) && targetHeight > 0 &&
-        !thumbHeightValid(epub.getThumbBmpPath(targetHeight), targetHeight)) {
+    // Every requested height, off the one load. A cancel between sizes still leaves the ones
+    // already written on disk, so the next pass has less to do rather than starting over.
+    for (const int targetHeight : coverJob_.targetHeights) {
+      if (targetHeight <= 0) continue;
+      if (!loaded || coverWorkerShouldCancel(this)) break;
+      if (thumbHeightValid(epub.getThumbBmpPath(targetHeight), targetHeight)) continue;
       epub.generateThumbBmp(targetHeight, &coverWorkerShouldCancel, this);
     }
     result.hasGridThumb = loaded && thumbHeightValid(epub.getThumbBmpPath(coverJob_.gridHeight), coverJob_.gridHeight);
@@ -166,9 +170,10 @@ void RecentBooksActivity::runCoverJob() {
   } else {
     Xtc xtc(result.book.path, "/.crosspoint");
     const bool loaded = xtc.load();
-    const int targetHeight = coverJob_.targetHeight > 0 ? coverJob_.targetHeight : coverJob_.gridHeight;
-    if (loaded && !coverWorkerShouldCancel(this) && targetHeight > 0 &&
-        !thumbHeightValid(xtc.getThumbBmpPath(targetHeight), targetHeight)) {
+    for (const int targetHeight : coverJob_.targetHeights) {
+      if (targetHeight <= 0) continue;
+      if (!loaded || coverWorkerShouldCancel(this)) break;
+      if (thumbHeightValid(xtc.getThumbBmpPath(targetHeight), targetHeight)) continue;
       xtc.generateThumbBmp(targetHeight, &coverWorkerShouldCancel, this);
     }
     result.hasGridThumb = loaded && thumbHeightValid(xtc.getThumbBmpPath(coverJob_.gridHeight), coverJob_.gridHeight);
@@ -183,6 +188,9 @@ void RecentBooksActivity::runCoverJob() {
 
 bool RecentBooksActivity::postCoverJob(CoverJob&& job) {
   if (!coverWorkerTask_ || coverWorkerBusy_.load(std::memory_order_acquire) || coverResult_.pending) return false;
+  // Preserves the old "no explicit target means the grid height" fallback in one place, now that
+  // callers queue a set rather than picking a single size.
+  if (job.targetHeights[0] == 0) job.addTargetHeight(job.gridHeight);
   coverJob_ = std::move(job);
   coverResult_ = CoverResult{};
   coverWorkerCancelRequested_ = false;
@@ -514,10 +522,15 @@ bool RecentBooksActivity::stepLibraryScan() {
       CoverJob job;
       job.book = book;
       job.gridHeight = thumbH;
-      job.targetHeight =
-          coverIsMangaTemplate
-              ? (mangaGridMissing ? thumbH : (mangaHomeMissing ? metrics.homeCoverHeight : SHELF_THUMB_HEIGHT))
-              : thumbH;
+      // All three at once. Picking one meant the next pass came back for the next size and
+      // reopened the book to get it.
+      if (coverIsMangaTemplate) {
+        if (mangaGridMissing) job.addTargetHeight(thumbH);
+        if (mangaHomeMissing) job.addTargetHeight(metrics.homeCoverHeight);
+        if (mangaShelfMissing) job.addTargetHeight(SHELF_THUMB_HEIGHT);
+      } else {
+        job.addTargetHeight(thumbH);
+      }
       if (!postCoverJob(std::move(job))) scan_.thumbIndex++;
       return false;
     }
@@ -597,7 +610,11 @@ bool RecentBooksActivity::stepLibraryScan() {
     CoverJob job;
     job.book = book;
     job.gridHeight = thumbH;
-    job.targetHeight = gridThumbOk ? SHELF_THUMB_HEIGHT : thumbH;
+    // Both missing sizes off one open. This used to hand over whichever single height was
+    // outstanding, so a book needing the grid AND the shelf thumb was opened, parsed and its
+    // cover decoded twice -- the dominant cost in the whole scan.
+    if (!gridThumbOk) job.addTargetHeight(thumbH);
+    if (!shelfThumbOk) job.addTargetHeight(SHELF_THUMB_HEIGHT);
     job.fileSize = bookSize;
     job.modifiedStamp = bookStamp;
     if (!postCoverJob(std::move(job))) {

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -164,6 +164,11 @@ void RecentBooksActivity::runCoverJob() {
     // low-heap moment costs the cover forever. Requires !cancelled: a cancelled load leaves the
     // metadata cache unpopulated, which hasCoverImage() cannot distinguish from a coverless book.
     result.coverKnownAbsent = loaded && !result.hasGridThumb && !coverWorkerShouldCancel(this) && !epub.hasCoverImage();
+    // Deliberately NOT extended to a book that failed to OPEN. contentaccess::open() reports a
+    // missing credential and an OOM through the same channel as a bad container, and the index
+    // entry is keyed on size+stamp -- so recording "no cover" would outlive the credential being
+    // added and the cover would never come back. It stays retryable; what it must not do is
+    // stall the scan, which the completed flag below handles.
     if (loaded && !result.hasGridThumb && !result.coverKnownAbsent) {
       LOG_ERR("RBA", "Cover thumb failed for %s; will retry", result.book.path.c_str());
     }
@@ -181,7 +186,14 @@ void RecentBooksActivity::runCoverJob() {
     if (loaded && !xtc.getTitle().empty()) result.book.title = xtc.getTitle();
   }
 
-  result.completed = !coverWorkerCancelSeen_ && !coverWorkerExitRequested_ && !coverWorkerCancelRequested_;
+  // "Completed" must mean the job ran its course, not that nobody touched a button while it did.
+  // coverWorkerCancelSeen_ is the honest signal: shouldCancel() sets it only when the job
+  // actually consulted it and bailed. coverWorkerCancelRequested_ alone is just "a key went
+  // down", and including it stalled the cursor on any job that never consults shouldCancel --
+  // notably a contentaccess::open() failure, which gives up in ~380ms without asking. That book
+  // was then retried forever and every book behind it stayed coverless (device log: the same
+  // unopenable EPUB reloaded at [177406], [182039], [563346]).
+  result.completed = !coverWorkerCancelSeen_ && !coverWorkerExitRequested_;
   result.pending = true;
   coverResult_ = std::move(result);
 }

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -174,9 +174,25 @@ class RecentBooksActivity final : public Activity {
   struct CoverJob {
     RecentBook book;
     int gridHeight = 0;
-    int targetHeight = 0;
+    // Every thumb height this book still needs, generated in ONE job. Opening the book is what
+    // costs (measured on device: 213ms typical, 2347ms worst, against milliseconds to scale the
+    // cover once it is open), so a job per height paid that price again for each size. Unused
+    // slots are 0. Three: the grid cell, the home cover, and SHELF_THUMB_HEIGHT.
+    static constexpr int MAX_TARGET_HEIGHTS = 3;
+    int targetHeights[MAX_TARGET_HEIGHTS] = {0, 0, 0};
     uint32_t fileSize = 0;
     uint32_t modifiedStamp = 0;
+
+    void addTargetHeight(const int h) {
+      if (h <= 0) return;
+      for (int& slot : targetHeights) {
+        if (slot == h) return;  // already queued
+        if (slot == 0) {
+          slot = h;
+          return;
+        }
+      }
+    }
   };
   struct CoverResult {
     bool pending = false;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make Library cover loading stop repeating work. Two independent bugs found by reading the device serial log while browsing: the scan re-opened a book once per thumbnail size, and it could pin its cursor on one book and re-attempt it forever.
* **What changes are included?**

### `1a4f540` — one book open produces every missing thumb size

`CoverJob` carried a single `targetHeight`, so a book needing both the grid thumb and the shelf thumb was opened, parsed and cover-decoded **once per size**. Opening is the entire cost — 213 ms typical, 2692 ms for a protected book — while scaling the cover once it is open is the cheap part. Manga was worse: three sizes, one picked per pass through a priority chain.

The job now carries a set of heights and the worker generates each missing one off the single open. Same change in all three branches (epub, xtc, manga). Cancellation still applies between sizes, and anything already written stays on disk, so an interrupted job leaves the next pass *less* to do rather than starting over.

Verified on device — one load, two thumbs, no reload between them:

```
[61289] Loading ePub: .../A Short History of Nearly Everything 2.0.epub
[63981] Loaded ePub
[64042] Generating thumb BMP  -> [76963] done   (thumb_207)
[77025] Generating thumb BMP  -> [88257] done   (thumb_54)
```

### `515596d` — the scan no longer stalls on a job that ran to completion

The cover scan pinned its cursor on one book and re-attempted it indefinitely, so every book behind it stayed coverless and browsing the Library stayed busy:

```
[177406] Loading ePub: .../A Short History of Nearly Everything 2.0.epub
[177752] [ERR] content unavailable: cannot open protected content: not a zip container
[182039] ... same book again
[563346] ... and again
```

`completed` was `!cancelSeen && !exitRequested && !cancelRequested`, but `cancelRequested` only means "a key went down". `cancelSeen` is the honest signal — `shouldCancel()` sets it when a job actually consulted it and bailed. A `contentaccess::open()` failure gives up in ~380 ms **without ever asking**, so it always ran its course, yet any keypress during it marked the job incomplete and held the cursor. Browsing presses keys constantly, which is why it was worst exactly then.

Dropping `cancelRequested` lets a job that finished advance the cursor; a job that genuinely bailed mid-decode still retries. After the fix the cursor moves on (`[88257]` finishes that book, `[89935]` starts the next).

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — this fixes CrossPoint's own Library scan.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in scope: reading experience, and less repeated SD/decode work on the tightest target.

## Additional Context

**Verified on device (X4):** both behaviours reproduced from the serial log, fixed, and re-confirmed from the log — the excerpts above are from the actual runs. `pio run -e overlay` builds and `./bin/clang-format-fix` (clang-format 21.1.8) leaves the tree unchanged.

**Deliberately not done**, so these are decisions rather than omissions:

* **An unopenable book is still retried, not recorded as permanently coverless.** Tempting — it costs ~380 ms per Library visit — but `contentaccess::open()` reports a missing credential and an OOM through the same channel as a bad container, and the index entry is keyed on size+stamp, so the flag would outlive the credential being added. The same book proved the point: a later pass opened it fine (`content accessor open; on-read path active`) and produced both thumbs. Marking it would have lost that cover permanently. This is the hazard `CLAUDE.md`'s "never persist a transient failure as a permanent truth" section describes.
* **The 1024-byte chunk in `Epub::generateThumbBmp`'s three cover extractions is unchanged.** `extractItemToFile` right below uses a heap-gated 16 KB with a comment recording 4 KB ≈ 100 KB/s, so raising it looked obvious. It was instrumented first, and the measurement did not justify it: the slow case in the log is a *protected* book, whose read path ignores `chunkSize` entirely (the SDK's `decryptToSink` owns its own chunking), and a plain book's whole cover generation is ~1.3 s end to end, leaving at most a few hundred ms for extraction. The instrumentation was removed rather than committed.

**Not addressed:** `epub_2097650876` is probed for both thumb sizes on every scan pass but never loaded, so its cover never appears — a different mechanism from either fix here. And the remaining slowness on protected books (7.5 s to extract a cover) is inside `freeink-sdk`'s `decryptToSink`, reachable from neither this repo nor the content-access overlay.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
