### PR TITLE
fix: stop an image page overlaying the one before it

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1982,11 +1982,15 @@ void GfxRenderer::displayBuffer(const HalDisplay::RefreshMode refreshMode) const
     frameTimed = false;
   }
   panelResidue_ = refreshMode == HalDisplay::FAST_REFRESH;
+  // A HALF/FULL pass drives every pixel to its target, which re-establishes the B/W baseline in
+  // the controller's RED RAM. A FAST pass does not, so a gray plane sitting there survives it.
+  if (refreshMode != HalDisplay::FAST_REFRESH) grayPlanesResident_ = false;
   display.displayBuffer(refreshMode, fadingFix);
 }
 
 void GfxRenderer::displayBufferAsync(const HalDisplay::RefreshMode refreshMode) const {
   panelResidue_ = refreshMode == HalDisplay::FAST_REFRESH;
+  if (refreshMode != HalDisplay::FAST_REFRESH) grayPlanesResident_ = false;
   // The async path has no turn-off-screen hook, which the sunlight fading fix
   // relies on; keep those users on the blocking path.
   if (fadingFix) {
@@ -2828,6 +2832,7 @@ void GfxRenderer::displayGrayscaleBase(HalDisplay::RefreshMode fallback) const {
   // Grayscale pipeline in progress: the plane passes that follow leave gray
   // charge no single HALF scrubs (see panelResidue_), whatever the fallback.
   panelResidue_ = true;
+  grayPlanesResident_ = true;
   display.displayGrayscaleBase(fallback, fadingFix);
 }
 
@@ -2856,12 +2861,14 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
 void GfxRenderer::displayGrayBuffer() const {
-  panelResidue_ = true;  // gray plane drive: charge a HALF alone cannot scrub
+  panelResidue_ = true;        // gray plane drive: charge a HALF alone cannot scrub
+  grayPlanesResident_ = true;  // RED RAM now holds a gray plane, not the B/W baseline
   display.displayGrayBuffer(fadingFix);
 }
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
-  panelResidue_ = true;  // tiled gray planes (X4 image pages): same charge as displayGrayBuffer
+  panelResidue_ = true;        // tiled gray planes (X4 image pages): same charge as displayGrayBuffer
+  grayPlanesResident_ = true;  // RED RAM now holds a gray plane, not the B/W baseline
   // Guard the uint16_t casts below: a negative would wrap to a huge length.
   assert(yStart >= 0 && numRows > 0 && yStart <= static_cast<int>(panelHeight) - numRows);
   display.writeGrayscalePlaneStrip(lsbPlane, scratch, static_cast<uint16_t>(yStart), static_cast<uint16_t>(numRows));

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -77,6 +77,15 @@ class GfxRenderer {
   // display path is const).
   mutable bool panelResidue_ = false;
 
+  // Narrower than panelResidue_, and for a different failure: a grayscale pass leaves the
+  // controller's RED RAM holding a gray PLANE instead of the previous B/W frame (the SDK tracks
+  // the same thing as _redRamSynced). A FAST refresh is a differential update against that RAM,
+  // so the next one diffs against a gray plane and the old picture survives underneath the new
+  // one. Only a HALF/FULL pass, which drives every pixel to its target, restores a usable
+  // baseline. panelResidue_ cannot answer this: any FAST refresh sets it, so it is true almost
+  // always and would force a scrub on every image page.
+  mutable bool grayPlanesResident_ = false;
+
   // Tiled grayscale strip target. When active, drawPixel()/clearScreen()
   // operate on a caller-owned scratch holding one horizontal band of physical
   // rows [_stripY0, _stripY0 + _stripRows) (panelWidthBytes wide) instead of
@@ -224,6 +233,10 @@ class GfxRenderer {
   // writes) that a static screen -- the sleep image -- would freeze in place.
   // Cleared by any HALF or FULL pass. See panelResidue_.
   [[nodiscard]] bool panelHasResidue() const { return panelResidue_; }
+  // True while the controller's RED RAM still holds a grayscale plane rather than a B/W
+  // baseline, so a FAST (differential) refresh would diff against it. Callers that are about to
+  // put a fresh full-screen image up must take a HALF pass instead. See grayPlanesResident_.
+  [[nodiscard]] bool panelHasGrayPlanes() const { return grayPlanesResident_; }
   // Non-blocking refresh: starts the waveform and returns so CPU work (e.g.
   // grayscale strip rendering) can overlap the panel's refresh time. The
   // framebuffer must stay untouched until waitRefreshComplete(). Falls back to

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3111,7 +3111,15 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   // image pages: a FAST refresh otherwise runs directly over the
   // retained frame after a silent restart (for example, when returning from
   // KOReader sync), leaving the old UI mixed with the image.
-  const bool cleanImageBasePending = !grayscaleRefineOnly && (manualRefreshPending || pagesUntilFullRefresh == 0);
+  // panelHasGrayPlanes(): the page we are leaving ran a grayscale pass, so the controller's RED
+  // RAM holds a gray plane rather than the previous B/W frame. A FAST refresh is a differential
+  // update against that RAM, so the incoming image would be diffed against a gray plane and the
+  // OLD picture stays visible under the new one (two image pages in a row -- a cover followed by
+  // an illustration -- overlaid). The `pagesUntilFullRefresh = 1` set below already routes the
+  // next ORDINARY page onto the HALF cleanup for the same reason; it cannot help here, because
+  // an image page reaching this branch reads that same counter as 1, not 0, and picks FAST.
+  const bool cleanImageBasePending =
+      !grayscaleRefineOnly && (manualRefreshPending || pagesUntilFullRefresh == 0 || renderer.panelHasGrayPlanes());
   const bool needsTextGrayscale = SETTINGS.textAntiAliasing;
   const bool needsAnyGrayscale = needsTextGrayscale || pageHasImages;
   const bool tiledGrayscale = needsAnyGrayscale && renderer.supportsStripGrayscale();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix two image pages in a row — a cover followed by an illustration — drawing the second *over* the first instead of replacing it.
* **What changes are included?**

A grayscale pass leaves the controller's RED RAM holding a gray **plane** rather than the previous B/W frame (the SDK tracks the same thing as `Ssd1677Driver::_redRamSynced`). A FAST refresh is a *differential* update against that RAM, so the incoming image gets diffed against a gray plane and the old picture survives underneath it. Device log:

```
[296600] Page render (tiled): gray_lsb=407ms gray_msb=129ms   <- gray planes written
[296634] Loading file: EPUB/xhtml/cover.xhtml                  <- turn to the other image page
[297453] Wait complete: refresh (417 ms)                       <- FAST, not the clean HALF
[297499] Page render (image BW)
```

**The hazard was already known.** The image branch in `EpubReaderActivity` sets `pagesUntilFullRefresh = 1` so the next *ordinary* page takes the HALF cleanup, with a comment naming this exact failure (#2190). It could not cover this case: an image page reaching that same branch reads the counter as `1`, not `0`, and therefore picks FAST. Image → text was protected; **image → image never was**. That is why the repro needs two image pages back to back.

`GfxRenderer` now mirrors the SDK's flag as `grayPlanesResident_` — set wherever gray planes are driven (`displayGrayscaleBase`, `displayGrayBuffer`, `writeGrayscalePlaneStrip`) and cleared by any HALF/FULL pass, since only those drive every pixel and restore a usable baseline. `panelHasGrayPlanes()` then feeds `cleanImageBasePending`.

Deliberately **not** `panelHasResidue()`: any FAST refresh sets that, so it is true almost always and would force a scrub on every image page. Only the image page directly following a grayscale pass pays a HALF here; text pages are untouched.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — this is a rendering bug in CrossPoint's own reader.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in scope: reading experience.

## Additional Context

**Verified on device (X4):** reproduced on a book whose first page is a cover and second an illustration, fixed, and confirmed by the reporter. `pio run -e overlay` builds; `./bin/clang-format-fix` (clang-format 21.1.8) leaves the tree unchanged.

**Cost:** one extra HALF refresh, only on an image page that directly follows a grayscale pass. No change to text pages or to the ordinary refresh cadence.

**Focus for review:** the clear condition. `grayPlanesResident_` is cleared on any non-FAST `displayBuffer`/`displayBufferAsync`. If a panel exists where a HALF pass does *not* restore the B/W baseline, that assumption is where it would break.

**Testing note:** during investigation the X4 fast-DU shortcut (`-DFREEINK_X4_FAST_DU_SHORTCUT`) was briefly enabled locally to measure refresh timings. It was removed before verifying this fix, so the result above is against stock refresh behaviour.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
