### PR TITLE
fix: stop list presses being dropped during a refresh

### DIFF
--- a/src/activities/UiListActivity.cpp
+++ b/src/activities/UiListActivity.cpp
@@ -67,19 +67,41 @@ bool UiListActivity::routeListTouch() {
   return static_cast<bool>(route);  // dispatched to the action handler
 }
 
+int UiListActivity::selectionCursor() { return pendingSelection_ >= 0 ? pendingSelection_ : activeNav().selected; }
+
 void UiListActivity::moveSelectionTo(const int index) {
   {
-    // The render task reads nav mid-build (syncToProps, layout feedback); a
-    // press landing during a render would otherwise tear selection/viewport.
-    RenderLock lock(*this);
+    // TRY the lock, never block on it. The render task holds it for the whole render INCLUDING
+    // the panel wait (~502ms for a FAST refresh), and buttons are polled -- InputManager::update()
+    // runs on this same loop -- so blocking here stops input being sampled at all, and a press
+    // that both starts and ends inside a refresh is lost outright. That is what made tapping
+    // through a list feel like it was ignoring presses.
+    //
+    // The lock itself is still required to mutate nav: the render task reads selection/viewport
+    // mid-build (syncToProps, layout feedback), so an unlocked write would tear them. When it is
+    // busy, park the target and let loop() apply it the moment the render finishes.
+    RenderLock lock{RenderLock::Try{}};
+    if (!lock.held()) {
+      pendingSelection_ = index;
+      return;
+    }
     auto& n = activeNav();
     n.selected = index;
     n.follow(listCount());
+    pendingSelection_ = -1;
   }
   requestUpdate();
 }
 
 void UiListActivity::loop() {
+  // Apply a move parked while the render task held the lock. Re-parks itself if the next render
+  // is already running, so it simply retries on the following tick.
+  if (pendingSelection_ >= 0) {
+    const int parked = pendingSelection_;
+    pendingSelection_ = -1;
+    moveSelectionTo(parked);
+  }
+
   if (handleCustomInput()) return;
   if (handleButtons()) return;
   if (routeListTouch()) return;
@@ -107,16 +129,18 @@ void UiListActivity::loop() {
 void UiListActivity::navigateButtons() {
   const int count = listCount();
   auto& n = activeNav();
-  buttonNavigator.onNextRelease([this, count, &n] { moveSelectionTo(ButtonNavigator::nextIndex(n.selected, count)); });
+  buttonNavigator.onNextRelease(
+      [this, count] { moveSelectionTo(ButtonNavigator::nextIndex(selectionCursor(), count)); });
   buttonNavigator.onPreviousRelease(
-      [this, count, &n] { moveSelectionTo(ButtonNavigator::previousIndex(n.selected, count)); });
+      [this, count] { moveSelectionTo(ButtonNavigator::previousIndex(selectionCursor(), count)); });
   // Page by the rows the last build actually drew (pageRows), not the
   // fixed-height visibleRows estimate: with wrapped labels the estimate
   // overshoots and rows between pages would never be shown.
   buttonNavigator.onNextContinuous(
-      [this, count, &n] { moveSelectionTo(ButtonNavigator::nextPageIndex(n.selected, count, n.pageRows())); });
-  buttonNavigator.onPreviousContinuous(
-      [this, count, &n] { moveSelectionTo(ButtonNavigator::previousPageIndex(n.selected, count, n.pageRows())); });
+      [this, count, &n] { moveSelectionTo(ButtonNavigator::nextPageIndex(selectionCursor(), count, n.pageRows())); });
+  buttonNavigator.onPreviousContinuous([this, count, &n] {
+    moveSelectionTo(ButtonNavigator::previousPageIndex(selectionCursor(), count, n.pageRows()));
+  });
 }
 
 void UiListActivity::syncListViewport(UiScreen& screen, fui::ListProps& props, const bool hasSubtitle) {

--- a/src/activities/UiListActivity.h
+++ b/src/activities/UiListActivity.h
@@ -82,7 +82,17 @@ class UiListActivity : public Activity, protected UiAppHost {
   freeink::ui::ListNav nav;
   ButtonNavigator buttonNavigator;
 
+  // Where the cursor is heading, including a move parked by moveSelectionTo() because the render
+  // task held the lock. Navigation must step from THIS, not from nav.selected: while a move is
+  // parked nav.selected still holds the old row, so two presses in one refresh would both compute
+  // the same target and the second would be swallowed.
+  int selectionCursor();
+
  private:
+  // A selection move that arrived while a render was in flight, applied by loop() as soon as the
+  // lock frees. -1 when nothing is parked. See moveSelectionTo().
+  int pendingSelection_ = -1;
+
   static void screenTrampoline(UiScreen& screen, void* user);
   static void rowActionTrampoline(const freeink::ui::ActionEvent& event, void* user);
   // Named apart from UiAppHost::routeTouch so the host overload stays visible


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop list screens silently dropping button presses that land while the panel is refreshing.
* **What changes are included?**

`UiListActivity::moveSelectionTo()` took a **blocking** `RenderLock`. The render task holds that lock for the whole render *including the panel wait* — ~502 ms for a FAST refresh, measured on device as a real BUSY-pin poll. Buttons are polled: `InputManager::update()` runs on the same main loop. So while `moveSelectionTo` blocked, input was not sampled at all, and any press that both started **and** ended inside a refresh was lost outright. Device log on a list screen:

```
[168824] [LOOP] New max loop duration: 516 ms (activity: 516 ms)
```

Tapping through a file list at a normal pace swallowed roughly every other press, which reads as the device ignoring you rather than as latency.

It now uses `RenderLock::Try` and parks the move when the lock is busy; `loop()` applies it as soon as the render finishes. `RenderLock`'s own comment asks for exactly this:

> Use this from any task that must never wait on a render (e.g. the input-polling loop task).

The lock is still taken to *mutate* nav — the render task reads selection/viewport mid-build (`syncToProps`, layout feedback), so an unlocked write would tear them.

Navigation also steps from a new `selectionCursor()` rather than `nav.selected`: while a move is parked `nav.selected` still holds the old row, so two presses inside one refresh would otherwise both compute the same target and the second would be swallowed a different way.

Covers every screen deriving from `UiListActivity` — settings, file browser, the reader menu, chapter selection, bookmarks.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — this is an input-handling bug in CrossPoint's own list base.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in scope: usability and code health.

## Additional Context

**This does not make navigation faster, and is not meant to.** Per-step latency is ~502 ms of panel waveform against 25–32 ms of CPU render; that is the hardware's floor and no software change moves it. What this fixes is presses not landing at all.

For the record, since it came out of the same investigation: a windowed partial refresh was prototyped and **abandoned** — a 248×292 window measured 517 ms against 502 ms for the whole frame, because the panel runs the same waveform regardless of `setRamArea`. Nothing from that experiment is in this PR.

**Verified on device (X4):** `pio run -e overlay` builds; `./bin/clang-format-fix` (clang-format 21.1.8) leaves the tree unchanged; list navigation exercised in settings and the file browser.

**Focus for review:** the parked-move retry in `loop()`. It re-parks itself if the next render is already running, so it retries on the following tick rather than spinning; worth a second pair of eyes on the case where renders arrive back to back.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
