### PR TITLE
fix: stop retrying cover work that can never succeed

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -830,7 +830,7 @@ bool Epub::generateThumbBmp(int height, BmpConvertCancelFn shouldCancel, void* c
     int THUMB_TARGET_WIDTH = (height * 2) / 3;
     int THUMB_TARGET_HEIGHT = height;
     const bool success = JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(
-        coverJpg, thumbBmp, THUMB_TARGET_WIDTH, THUMB_TARGET_HEIGHT, shouldCancel, cancelCtx);
+        coverJpg, thumbBmp, THUMB_TARGET_WIDTH, THUMB_TARGET_HEIGHT, shouldCancel, cancelCtx, &coverUnsupported_);
     // Explicitly close() files before calling Storage.remove()
     coverJpg.close();
     thumbBmp.close();

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -36,6 +36,8 @@ class Epub {
   contentaccess::HandlePtr itemSource;
   // User-presentable reason load() refused the book (empty otherwise).
   std::string accessError;
+  // Set by generateThumbBmp() via the converter's outUnsupported flag; see coverUnsupported().
+  mutable bool coverUnsupported_ = false;
 
   bool findContentOpfFile(std::string* contentOpfFile, BmpConvertCancelFn shouldCancel = nullptr,
                           void* cancelCtx = nullptr) const;
@@ -61,6 +63,11 @@ class Epub {
   const std::string& getPath() const;
   // Empty unless load() refused the book because its content is not readable here.
   const std::string& getAccessError() const { return accessError; }
+  // True when the last generateThumbBmp() failed because the cover image itself can never be
+  // converted by this build (currently: beyond the JPEG decoder's dimension limits) -- as
+  // opposed to a low-heap moment, a cancellation, or a decode error, which are all retryable.
+  // Lets a caller record "no usable cover" instead of re-attempting it on every pass forever.
+  bool coverUnsupported() const { return coverUnsupported_; }
   const std::string& getTitle() const;
   const std::string& getAuthor() const;
   const std::string& getLanguage() const;

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -531,7 +531,9 @@ int bmpDrawCallback(JPEGDRAW* pDraw) {
 // Internal implementation with configurable target size and bit depth
 bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth,
                                                      int targetHeight, bool oneBit, bool crop,
-                                                     BmpConvertCancelFn shouldCancel, void* cancelCtx) {
+                                                     BmpConvertCancelFn shouldCancel, void* cancelCtx,
+                                                     bool* outUnsupported) {
+  if (outUnsupported) *outUnsupported = false;
   LOG_DBG("JPG", "Converting JPEG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   if (ESP.getFreeHeap() < MIN_FREE_HEAP) {
@@ -565,8 +567,12 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
   constexpr int MAX_IMAGE_HEIGHT = 3072;
 
   if (srcWidth <= 0 || srcHeight <= 0 || srcWidth > MAX_IMAGE_WIDTH || srcHeight > MAX_IMAGE_HEIGHT) {
-    LOG_DBG("JPG", "Image too large or invalid (%dx%d), max supported: %dx%d", srcWidth, srcHeight, MAX_IMAGE_WIDTH,
+    // ERR, not DBG: this is permanent for this file and it is why a cover never appears, so a
+    // release build (LOG_LEVEL=1, no DBG) has to be able to say so. Every other failure here is
+    // transient and already logs at ERR or is a deliberate cancellation.
+    LOG_ERR("JPG", "Image too large or invalid (%dx%d), max supported: %dx%d", srcWidth, srcHeight, MAX_IMAGE_WIDTH,
             MAX_IMAGE_HEIGHT);
+    if (outUnsupported) *outUnsupported = true;
     return false;
   }
 
@@ -789,7 +795,7 @@ bool JpegToBmpConverter::jpegFileToBmpStreamWithSize(HalFile& jpegFile, Print& b
 // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering
 bool JpegToBmpConverter::jpegFileTo1BitBmpStreamWithSize(HalFile& jpegFile, Print& bmpOut, int targetMaxWidth,
                                                          int targetMaxHeight, BmpConvertCancelFn shouldCancel,
-                                                         void* cancelCtx) {
+                                                         void* cancelCtx, bool* outUnsupported) {
   return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetMaxWidth, targetMaxHeight, true, true, shouldCancel,
-                                     cancelCtx);
+                                     cancelCtx, outUnsupported);
 }

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.h
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.h
@@ -12,13 +12,20 @@ using BmpConvertCancelFn = bool (*)(void* ctx);
 class JpegToBmpConverter {
   static bool jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth, int targetHeight,
                                           bool oneBit, bool crop = true, BmpConvertCancelFn shouldCancel = nullptr,
-                                          void* cancelCtx = nullptr);
+                                          void* cancelCtx = nullptr, bool* outUnsupported = nullptr);
 
  public:
   static bool jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop = true);
   // Convert with custom target size (for thumbnails)
   static bool jpegFileToBmpStreamWithSize(HalFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering
+  // outUnsupported (optional): set true when the conversion failed for a reason that will NEVER
+  // succeed for this file -- currently a source image beyond MAX_IMAGE_WIDTH/HEIGHT. Left alone
+  // for every other failure (out of memory, cancelled by a button press, decode error), which
+  // are all "not right now" and must stay retryable. Without this the caller cannot tell the two
+  // apart and has to assume transient, which retries an unconvertible cover on every pass
+  // forever (X3 report).
   static bool jpegFileTo1BitBmpStreamWithSize(HalFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight,
-                                              BmpConvertCancelFn shouldCancel = nullptr, void* cancelCtx = nullptr);
+                                              BmpConvertCancelFn shouldCancel = nullptr, void* cancelCtx = nullptr,
+                                              bool* outUnsupported = nullptr);
 };

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -10,6 +10,22 @@
 #include <algorithm>
 
 namespace {
+// [HEIGHT] is the ONLY placeholder this build knows how to fill (UITheme::getCoverThumbPath).
+// Older firmware wrote a [WIDTH]x[HEIGHT] template; substituting just [HEIGHT] leaves a literal
+// "[WIDTH]" in the filename, so the path can never exist and every Home and Library pass re-probes
+// it forever (X3 device log: ".../epub_5391773237008108432/thumb_[WIDTH]x231.bmp", alongside a
+// 19-digit 64-bit hash this build also no longer produces).
+//
+// Only the PATH is dropped, never the book: with no cover path the ordinary generator writes a
+// current-format thumb on the next pass, which is also what repairs the stale directory name.
+bool coverPathResolvable(const std::string& coverBmpPath) {
+  std::string rest = coverBmpPath;
+  for (size_t at = rest.find("[HEIGHT]"); at != std::string::npos; at = rest.find("[HEIGHT]")) {
+    rest.erase(at, 8);
+  }
+  return rest.find('[') == std::string::npos && rest.find(']') == std::string::npos;
+}
+
 constexpr size_t LIBRARY_CACHE_MAX_BOOKS = 2048;
 
 class JsonFileReader {
@@ -71,6 +87,10 @@ bool RecentBooksStore::fromJson(JsonVariantConst doc, const size_t maxBooks) {
     book.title = obj["title"] | "";
     book.author = obj["author"] | "";
     book.coverBmpPath = obj["coverBmpPath"] | "";
+    if (!coverPathResolvable(book.coverBmpPath)) {
+      LOG_DBG("RBS", "Dropping unresolvable cover path %s", book.coverBmpPath.c_str());
+      book.coverBmpPath.clear();
+    }
     recentBooks.push_back(std::move(book));
   }
 

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -164,6 +164,15 @@ void RecentBooksActivity::runCoverJob() {
     // low-heap moment costs the cover forever. Requires !cancelled: a cancelled load leaves the
     // metadata cache unpopulated, which hasCoverImage() cannot distinguish from a coverless book.
     result.coverKnownAbsent = loaded && !result.hasGridThumb && !coverWorkerShouldCancel(this) && !epub.hasCoverImage();
+    // The other permanent outcome: the book HAS a cover, but it can never be converted by this
+    // build (source beyond the JPEG decoder's dimension limits). Distinguished at the source by
+    // the converter -- a low-heap moment, a cancellation and a decode error all leave this false
+    // and stay retryable. Without it an unconvertible cover is re-extracted and re-decoded on
+    // every Library pass forever, which on a tight device is a hot loop of SD reads (X3 report).
+    if (loaded && !result.hasGridThumb && !coverWorkerShouldCancel(this) && epub.coverUnsupported()) {
+      LOG_ERR("RBA", "Cover unconvertible for %s; recording as coverless", result.book.path.c_str());
+      result.coverKnownAbsent = true;
+    }
     // Deliberately NOT extended to a book that failed to OPEN. contentaccess::open() reports a
     // missing credential and an OOM through the same channel as a bad container, and the index
     // entry is keyed on size+stamp -- so recording "no cover" would outlive the credential being


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop two classes of cover-thumbnail work being retried forever when it can never succeed. Both came out of an X3 serial log where the Home and Library scans re-probed and re-attempted the same books on every pass.
* **What changes are included?** Two independent fixes.

### `d5477e4` — drop cover paths this build cannot resolve

The X3 log carried this on every Home and Library pass:

```
[HOME] Failed to open file for reading:
  /.crosspoint/epub_5391773237008108432/thumb_[WIDTH]x231.bmp
```

Two fingerprints of an older firmware in one record. `[HEIGHT]` is the only placeholder this build substitutes (`UITheme::getCoverThumbPath`), so a `[WIDTH]x[HEIGHT]` template resolves to a filename containing a literal `[WIDTH]` — a path that can never exist. The directory name is a 19-digit 64-bit hash, where every other entry in the same log is ≤10 digits.

Records are now validated where they are read back (`RecentBooksStore::fromJson`), which is the single funnel. Only the **path** is dropped, never the book: with no cover path the ordinary generator writes a current-format thumb on the next pass, which also repairs the stale directory name.

The predicate is deliberately "does anything bracketed remain after `[HEIGHT]` is removed" rather than a `[WIDTH]` special case, so any other placeholder an older or newer build may have written is caught the same way.

### `fac03bd` — stop retrying a cover that can never be converted

```
[ERR] [EBP] Failed to generate thumb BMP from JPG cover image
[ERR] [RBA] Cover thumb failed for /books/Memory From Mars JP...; will retry
[ERR] [RBA] Cover thumb failed ...; will retry          <- 2s later, same book
```

The JPEG converter has exactly two failure paths that log at DBG and are therefore invisible on a release build (`LOG_LEVEL=1`): a source image beyond `MAX_IMAGE_WIDTH/HEIGHT` (2048×3072), and a cancellation from a button press. Everything else logs at ERR, and the X3 log has ERR enabled with no `[JPG]` line at all — so it hit one of those two, and **the caller cannot tell which**. It must therefore assume transient and retry. One of the two is permanent, and retrying it re-extracts and re-decodes the cover on every Library pass for the life of the book.

Distinguished at the source, per `CLAUDE.md`'s rule about not conflating "nothing to produce" with "could not produce it now": the converter reports the dimension rejection through an optional `outUnsupported` flag. Out of memory, cancellation and decode errors deliberately leave it false and stay retryable. The dimension log is promoted DBG → ERR — it is permanent and it is *why* a cover never appears, so a release build has to be able to say so.

`runCoverJob()` records that case as `coverKnownAbsent`, the same flag a book that declares no cover uses, so the scan skips it on later visits. The out-param defaults to `nullptr`, so the `MangaPanel` caller is unchanged.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — these are bugs in CrossPoint's own cover pipeline.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

Squarely in scope: less repeated SD/decode work on the tightest hardware.

## Additional Context

**Verification is partial, and worth stating precisely.**

* `pio run -e overlay` builds; `./bin/clang-format-fix` (clang-format 21.1.8) leaves the tree unchanged.
* The path predicate is covered by a host test: current format, plain paths, raw manga page sources, the empty string, `[WIDTH]x[HEIGHT]`, a bare `[WIDTH]x231`, an unknown `[SCALE]` placeholder, and a stray bracket.
* Flashed to an **X4** and exercised: covers still generate (one EPUB open producing both thumb sizes), manga covers still resolve, Home still shows recent covers, and — importantly — `Dropping unresolvable cover path` never appears on a healthy card, so the predicate is not rejecting legitimate paths.
* **Neither X3 scenario could be reproduced here**: no X3 hardware, and no card carries a legacy `[WIDTH]` record or an oversized cover. Both fixes are reasoned from the log and the code, not observed working.

**Note on the reporter's build.** Their log is from `1.5.1-nightly`, which predates the cover-scan stall fix in #149. If the X3 hit the *cancellation* branch rather than the dimension branch, that half is already fixed and this PR is the remaining half. Either way the ambiguity is removed: a cover that fails now names the reason in the log instead of going silent.

**Explicitly not included.** Two further changes were prototyped against this and **reverted**:

* Letting a cover conversion run to completion instead of cancelling on keypress. On the measured hardware a 1600×2400 PNG cover costs ~9.5 s *per thumbnail* (PNG cannot decode at reduced scale the way JPEG does), and finishing it means the UI shares the single core for that whole time.
* Moving background workers below the UI in priority to pay for the above. This is actively wrong here: `RecentBooksActivity::skipLoopDelay()` makes the main loop `yield()` while a job runs, and `yield()` only rotates between tasks of equal priority — so demoting the worker stops it being scheduled at all. Observed on device: zero progress for 280 s.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
