### PR TITLE
fix: correct ruby base grouping and vertical furigana rendering

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -194,7 +194,12 @@ namespace {
 //      (wordNoSpaceBefore cleared) and a text block no longer soft-flushes while the
 //      parser is inside <ruby>. Both change where lines break, so pages cached by
 //      older versions no longer match.
-constexpr uint8_t SECTION_FILE_VERSION = 79;
+// v80: a ruby base wrapped in a styleless inline element (Calibre's
+//      <ruby><span class="xhtml_rb">base</span><rt>...</rt></ruby> rendering of <rb>) is now
+//      flushed at that element's close, so the annotation attaches to its own base instead of
+//      to the preceding word. Annotated words reserve leading for their ruby, so lines move and
+//      pages cached under v79 hold the wrong positions -- and the wrong furigana.
+constexpr uint8_t SECTION_FILE_VERSION = 80;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
+++ b/lib/Epub/Epub/blocks/VerticalTextBlock.cpp
@@ -2,6 +2,7 @@
 
 #include <Utf8.h>
 
+#include <algorithm>
 #include <cstring>
 
 #include "GfxRenderer.h"
@@ -145,6 +146,11 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
     // reach. Every ruby character in the stack is drawn at the same x, so the widest one decides.
     size_t rubyCharCount = 0;
     int rubyInkRight = 0;
+    // Ink band of an UPRIGHT character in this annotation, so a rotated one can be put on the
+    // same line as its neighbours rather than on a band guessed from font metrics. -1 = none
+    // measured, e.g. an annotation that is entirely dashes.
+    int uprightInkTop = -1;
+    int uprightInkHeight = 0;
     {
       const auto* p = reinterpret_cast<const unsigned char*>(rubyText.c_str());
       while (*p) {
@@ -154,6 +160,10 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
         if (measureGlyphInk(renderer, rubyFontId, cp, static_cast<uint8_t>(rubyStyle), &ink) && ink.width > 0) {
           // SUP draws the glyph at 50%, so its metrics halve too.
           rubyInkRight = std::max(rubyInkRight, (ink.left + ink.width + 1) / 2);
+          if (uprightInkTop < 0 && ink.height > 0 && !Kinsoku::needsVerticalRotation(cp)) {
+            uprightInkTop = ink.top;
+            uprightInkHeight = ink.height;
+          }
         }
         rubyCharCount++;
       }
@@ -215,7 +225,39 @@ void VerticalTextBlock::render(GfxRenderer& renderer, int fontId, int rubyFontId
       std::memcpy(buf, rubyText.data() + ri, charLen);
       buf[charLen] = '\0';
 
-      renderer.drawText(rubyFontId, rubyX, rubyY, buf, black, rubyStyle);
+      // Ruby runs down the column like the base text, so a chōonpu or bracket inside an
+      // annotation has to be turned on its side exactly as the main path turns it (see the
+      // RotatedPunct branch above). Drawing the annotation as plain text left ハート's ー
+      // lying horizontally across the column.
+      const auto* cursor = reinterpret_cast<const unsigned char*>(buf);
+      const uint32_t cp = utf8NextCodepoint(&cursor);
+      if (Kinsoku::needsVerticalRotation(cp)) {
+        // Put the mark on the line its upright neighbours sit on, so the stack stays evenly
+        // spaced. drawText() takes rubyY as a TOP and puts the baseline textBaselineOffset()
+        // below it; a SUP glyph's ink then spans [baseline - top/2, +height/2], its metrics
+        // halved by the 50% scale. Measuring a real upright neighbour above (rather than
+        // assuming a band from the ascender, which reaches well past where kana ink stops) gives
+        // that band, and its centre in THIS character's slot is the target.
+        //
+        // The cell must hold the ROTATED glyph in both axes: drawCharVerticalRotatedInCell
+        // centres ink at cellTop + cellSize/2 but derives its clamps from the same cellSize, so
+        // too small a cell clamps the y centring to the cell top -- which silently parked the
+        // mark low -- and can leave maxX below minX, which is UB in std::clamp. After CCW
+        // rotation the glyph's width becomes its height, and vice versa; both halve with SUP.
+        int cell = std::max(1, rubyLineH);
+        GlyphInk rot;
+        if (measureGlyphInk(renderer, rubyFontId, cp, static_cast<uint8_t>(rubyStyle), &rot) && rot.width > 0) {
+          cell = std::max({cell, (rot.width + 1) / 2, (rot.height + 1) / 2});
+        }
+        const int baseline = rubyY + renderer.textBaselineOffset(rubyFontId, rubyText.c_str(), rubyStyle);
+        // No upright neighbour to measure (an all-dash annotation): fall back to the slot centre.
+        const int centre =
+            uprightInkTop >= 0 ? baseline - uprightInkTop / 2 + uprightInkHeight / 4 : rubyY + rubyLineH / 2;
+        renderer.drawCharVerticalRotatedInCell(rubyFontId, rubyX, centre - cell / 2, cell, cp,
+                                               Kinsoku::verticalShiftType(cp), black, rubyStyle);
+      } else {
+        renderer.drawText(rubyFontId, rubyX, rubyY, buf, black, rubyStyle);
+      }
       rubyY += rubyLineH;
       ri += charLen;
     }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -2096,7 +2096,16 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     // Flush if style will change OR if we're closing a block/structural element
     const bool isInlineTag = !headerOrBlockTag && !tableStructuralTag &&
                              !matches(name, IMAGE_TAGS, std::size(IMAGE_TAGS)) && self->depth != 1;
-    const bool shouldFlush = styleWillChange || headerOrBlockTag || matches(name, BOLD_TAGS, std::size(BOLD_TAGS)) ||
+    // A ruby base wrapped in a styleless inline element (Calibre writes
+    // <ruby><span class="xhtml_rb">心臓</span><rt>ハート</rt></ruby> for <rb>) would otherwise
+    // never be flushed: `span` is in none of the tag lists below, and with no CSS rule behind
+    // its class it pushes no style, so styleWillChange is false. The base then never becomes a
+    // word, and the </rt> handler sees baseWordCount == 0 and hangs the annotation on the
+    // PRECEDING word instead -- or drops it when the ruby opens a paragraph. Flushing here ends
+    // the base at its own closing tag, which is where it ends visually too.
+    const bool closingRubyBase = self->inRuby && !self->collectingRubyText;
+    const bool shouldFlush = closingRubyBase || styleWillChange || headerOrBlockTag ||
+                             matches(name, BOLD_TAGS, std::size(BOLD_TAGS)) ||
                              matches(name, ITALIC_TAGS, std::size(ITALIC_TAGS)) ||
                              matches(name, UNDERLINE_TAGS, std::size(UNDERLINE_TAGS)) ||
                              matches(name, LINETHROUGH_TAGS, std::size(LINETHROUGH_TAGS)) || tableStructuralTag ||

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -420,6 +420,11 @@ static AlignedMemRect screenRectToAlignedMemRect(GfxRenderer::Orientation orient
 //
 // The advance width is also halved in drawText() so layout reserves exactly the right
 // horizontal space for the scaled glyph.
+// Rotation mirrors renderCharImpl's Rotated90CCW mapping applied to the SCALED destination grid.
+// Without it a rotated SUP/SUB glyph has no renderer at all: drawCharVerticalRotatedInCell blits
+// through the UNSCALED path, so a half-size annotation glyph (vertical-text ruby containing a
+// chounpu or a bracket) came out at full size.
+template <TextRotation Rotation = TextRotation::None>
 static void renderCharScaled(const GfxRenderer& renderer, GfxRenderer::RenderMode renderMode,
                              const EpdFontFamily& fontFamily, const uint32_t cp, int cursorX, int cursorY,
                              const bool pixelState, const EpdFontFamily::Style style) {
@@ -438,6 +443,18 @@ static void renderCharScaled(const GfxRenderer& renderer, GfxRenderer::RenderMod
   // pixel offset from the (already-shifted) cursor position.
   const int baseX = cursorX + glyph->left / 2;
   const int baseY = cursorY - glyph->top / 2;
+
+  // dstX/dstY index the scaled glyph grid; map them to the screen for the requested rotation.
+  // The bearings are halved for the same reason baseX/baseY halve them: the grid is half-size.
+  const int outerBase = cursorX + glyph->top / 2;
+  const int innerBase = cursorY + glyph->left / 2;
+  const auto plot = [&](const int dstX, const int dstY) {
+    if constexpr (Rotation == TextRotation::Rotated90CCW) {
+      renderer.drawPixel(outerBase - dstY, innerBase + dstX, pixelState);
+    } else {
+      renderer.drawPixel(baseX + dstX, baseY + dstY, pixelState);
+    }
+  };
 
   if (fontData->is2Bit) {
     // 2-bit packed format: 4 pixels per byte, MSB first, 2 bits per pixel.
@@ -458,7 +475,7 @@ static void renderCharScaled(const GfxRenderer& renderer, GfxRenderer::RenderMod
           }
         }
         if (maxRaw >= 2 || coverage >= 2) {
-          renderer.drawPixel(baseX + dstX, baseY + dstY, pixelState);
+          plot(dstX, dstY);
         }
       }
     }
@@ -480,7 +497,7 @@ static void renderCharScaled(const GfxRenderer& renderer, GfxRenderer::RenderMod
           }
         }
         if (hasInk) {
-          renderer.drawPixel(baseX + dstX, baseY + dstY, pixelState);
+          plot(dstX, dstY);
         }
       }
     }
@@ -2524,6 +2541,16 @@ int GfxRenderer::getLineHeight(const int fontId, const float compression) const 
   return static_cast<int>(getLineHeight(fontId) * compression + 0.5f);
 }
 
+int GfxRenderer::textBaselineOffset(const int fontId, const char* text, const EpdFontFamily::Style style) const {
+  // Mirrors drawText()'s own yPos derivation; keep the two in step.
+  const int resolvedFontId = resolveTextFontId(fontId, text, style);
+  int offset = getFontAscenderSize(resolvedFontId);
+  if (resolvedFontId != fontId) {
+    offset += (getLineHeight(fontId) - getLineHeight(resolvedFontId)) / 2;
+  }
+  return offset;
+}
+
 int GfxRenderer::getTextHeight(const int fontId) const {
   const auto fontIt = fontMap.find(fontId);
   if (fontIt == fontMap.end()) {
@@ -2742,9 +2769,13 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   const EpdGlyph* glyph = font.getGlyph(cp, style);
   if (!glyph) return;
 
+  // SUP/SUB are rendered at 50% by the scaled path (see renderCharScaled); getGlyph returns the
+  // full-size glyph regardless, so the extents -- and the blit below -- have to halve to match
+  // or a ruby annotation's rotated glyph is drawn twice the size of the text around it.
+  const bool scaledStyle = (style & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0;
   // After CCW rotation, glyph height maps to X extent and glyph width maps to Y extent.
-  const int rotatedW = glyph->height;
-  const int rotatedH = glyph->width;
+  const int rotatedW = scaledStyle ? (glyph->height + 1) / 2 : glyph->height;
+  const int rotatedH = scaledStyle ? (glyph->width + 1) / 2 : glyph->width;
 
   // Centre the rotated ink box in the cell -- the same rule the upright glyphs follow, so
   // punctuation lands on the column's axis by construction. Brackets override this below.
@@ -2794,6 +2825,14 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
   //   screenX in [cursorX + top - (height-1), cursorX + top]
   //   screenY in [cursorY + left, cursorY + left + (width-1)]
   // Solve for cursor so the rotated bbox starts at (drawX, drawY).
+  // Both renderers derive their origin from the glyph's own bearings, and the scaled one halves
+  // them -- so solve for the cursor with the same halving the chosen renderer will apply.
+  if (scaledStyle) {
+    const int cursorXs = (drawX + rotatedW - 1) - glyph->top / 2;
+    const int cursorYs = drawY - glyph->left / 2;
+    renderCharScaled<TextRotation::Rotated90CCW>(*this, renderMode, font, cp, cursorXs, cursorYs, black, style);
+    return;
+  }
   const int cursorX = (drawX + rotatedW - 1) - glyph->top;
   const int cursorY = drawY - glyph->left;
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -340,6 +340,12 @@ class GfxRenderer {
   bool getGlyphMetrics(int fontId, uint32_t cp, EpdFontFamily::Style style, int* left, int* width, int* top,
                        int* height) const;
   int getFontAscenderSize(int fontId) const;
+  // The y drawText() will put `text`'s baseline at, given the same `y`. Text containing CJK is
+  // routed to a registered SD fallback whose metrics differ from fontId's, and drawText adds a
+  // line-height correction on top -- so a caller that has to place something on the SAME line as
+  // drawn text (vertical-text ruby aligning a rotated mark with its upright neighbours) cannot
+  // get there from getFontAscenderSize(fontId) alone.
+  int textBaselineOffset(int fontId, const char* text, EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   int getLineHeight(int fontId) const;
   int getLineHeightScaled(int fontId, uint16_t scale) const;
   int getLineHeight(int fontId, float compression) const;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make furigana render correctly in two places it did not: ruby bases swallowed by the surrounding run in the horizontal parser, and rotated marks in vertical mode drawn upright and at double size.
* **What changes are included?** Two independent commits.

### `ea6be8f` — flush the ruby base when `</ruby>` closes inside an inline span

`ChapterHtmlSlimParser` flushed pending text on the inline-element boundaries it tracked, but not on the boundary where a `<ruby>` element closes while still inside a surrounding inline element. A base run ending at that point was merged into the following run, so the base text lost its association and rendered as ordinary body text.

The flush condition now also fires on a closing ruby whose base collection has ended (`inRuby && !collectingRubyText`).

`SECTION_FILE_VERSION` 79 → 80, since already-laid-out sections carry the old grouping.

**This commit affects the horizontal path only.** Vertical reading uses its own layout and was never wrong here; the bump invalidates its cache too, which is the intended cost of a single shared version.

### `d8f49f5` — rotate and size vertical ruby marks correctly

Two defects, both visible on U+30FC (`ー`) inside furigana:

* The ruby loop in `VerticalTextBlock` drew every ruby character upright. A prolonged sound mark, which `Kinsoku::needsVerticalRotation` correctly flags, therefore appeared as a horizontal dash beside the column.
* `drawCharVerticalRotatedInCell` accepts a style, but the 50% scaling for `EpdFontFamily::SUP` lives in `renderCharScaled`, which was reachable only from `drawText`. Routing ruby through the rotated path drew it at full body size.

`renderCharScaled` is now `template <TextRotation Rotation>` over a `plot(dstX, dstY)` lambda, so the scaled and the rotated-scaled cases are one implementation rather than two. `drawCharVerticalRotatedInCell` halves its rotated cell geometry when the style carries `SUP` and dispatches through it.

Placement of the rotated mark uses a new `GfxRenderer::textBaselineOffset(fontId, text, style)`, which mirrors the `yPos` derivation `drawText` performs internally, so the mark sits on the same baseline as the upright ruby characters above and below it instead of on the slot centre.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — these are rendering bugs in existing ruby support.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Verification.**

* `pio run -e overlay` builds; `./bin/clang-format-fix` leaves the tree unchanged.
* Flashed to an **X4** and read a Japanese EPUB with furigana in vertical mode. Rotated marks now render vertically and at ruby size, confirmed against the previous build on the same page.
* The horizontal parser fix is reasoned from the parser's flush conditions; the book on hand reads vertically, so that half was not exercised on device.

**Known limitation, deliberately shipped.** The rotated mark's vertical position is baseline-matched to the surrounding upright ruby, which is correct relative to them, but the upright ruby characters themselves sit slightly lower in their slots than ideal. That is the pre-existing `drawText` placement, untouched here — fixing it means changing where every upright ruby character lands, which is a larger change than this PR is for. Tracking it separately rather than folding a speculative shift into a rendering fix.

**No new allocations.** The rotation template adds instantiations, not runtime cost; `textBaselineOffset` reuses the metrics `drawText` already queries.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
