### PR TITLE
fix: make the first pages of a vertical book responsive

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -224,6 +224,7 @@ void SdCardFont::clearOverflow() {
   }
   overflowCount_ = 0;
   overflowNext_ = 0;
+  overflowBytes_ = 0;
 }
 
 // --- Per-style kern/ligature ---
@@ -1790,12 +1791,26 @@ const EpdGlyph* SdCardFont::onGlyphMiss(void* ctx, uint32_t codepoint) {
     }
   }
 
+  // Slot count alone does not bound the memory: a CJK bitmap is several times a Latin one, so a
+  // ring sized for a line of Latin text holds several times as many bytes in kanji. Over budget,
+  // drop the whole ring rather than evicting individual entries -- the lookup above scans the
+  // dense prefix 0..overflowCount_, so selective eviction would have to compact the array, and a
+  // full reset keeps that invariant free. Coarse, but it only triggers on large-glyph text, where
+  // the ring is refilling from a fresh working set anyway. Latin body text (~60 bytes a glyph)
+  // never reaches the budget.
+  if (self->overflowBytes_ + tempGlyph.dataLength > OVERFLOW_BYTE_BUDGET) {
+    self->clearOverflow();
+    slot = 0;
+    wasAtCapacity = false;
+  }
   // All reads succeeded — commit to slot and advance ring buffer
   if (wasAtCapacity) {
+    self->overflowBytes_ -= self->overflow_[slot].glyph.dataLength;
     delete[] self->overflow_[slot].bitmap;
   } else {
     self->overflowCount_++;
   }
+  self->overflowBytes_ += tempGlyph.dataLength;
   self->overflowNext_ = (slot + 1) % OVERFLOW_CAPACITY;
   self->overflow_[slot].glyph = tempGlyph;
   self->overflow_[slot].bitmap = tempBitmap;

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -278,17 +278,41 @@ class SdCardFont {
   };
   OverflowContext overflowCtx_[MAX_STYLES] = {};
 
-  // Shared on-demand overflow buffer (ring buffer of glyphs loaded via glyphMissHandler)
-  static constexpr uint32_t OVERFLOW_CAPACITY = 8;
+  // Shared on-demand overflow buffer (ring buffer of glyphs loaded via glyphMissHandler).
+  //
+  // Sized against the working set, not "a few spare slots". A chapter build runs with the mini
+  // font cache deliberately released (the layout needs that heap), so EVERY glyph measurement
+  // during layout comes through here. At 8 slots a single line of Latin text overflows the ring,
+  // so each re-measure of the same run reloads every character from SD: measured on device while
+  // laying out one page, 548 loads for 82 distinct codepoints -- U+0020 alone read 164 times --
+  // costing ~6s of the ~7s before the page appeared.
+  //
+  // The larger ring also CHURNS LESS heap, not more: a miss on a full ring frees the evicted
+  // bitmap and allocates a new one, so 8 slots meant ~550 alloc/free pairs of similar sizes per
+  // page, which is exactly the pattern that shreds the largest contiguous block. Steady-state
+  // cost is 48 entries x 28 bytes = 1.3KB per loaded font (one or two are loaded) plus the
+  // resident bitmaps, which for a body-text size are tens to a few hundred bytes each.
+  static constexpr uint32_t OVERFLOW_CAPACITY = 48;
   struct OverflowEntry {
     EpdGlyph glyph;
     uint8_t* bitmap = nullptr;
     uint32_t codepoint = 0;
     uint8_t styleIdx = 0;
   };
+  // Hard ceiling on the bitmap bytes the ring may hold, independent of slot count: 48 slots of
+  // large CJK glyphs are several times 48 slots of Latin, and this cache fills during a chapter
+  // build, the tightest heap moment on the device.
+  //
+  // Set from what the measurement justified, not from what the slots could hold. The thrash this
+  // ring fixes was a Latin working set of ~48 glyphs totalling roughly 3KB, so 4KB keeps the
+  // whole win while capping growth over the old 8-slot ring at about 3KB per loaded font. A
+  // larger budget bought nothing measurable and cost headroom that an OOM abort was already
+  // using up elsewhere (freeink-sdk Credential.cpp allocates with bare `new`).
+  static constexpr uint32_t OVERFLOW_BYTE_BUDGET = 4 * 1024;
   OverflowEntry overflow_[OVERFLOW_CAPACITY] = {};
   uint32_t overflowCount_ = 0;
   uint32_t overflowNext_ = 0;
+  uint32_t overflowBytes_ = 0;  // sum of dataLength over the occupied slots
 
   // Compact advance-only table for layout measurement (per-style).
   // Built by buildAdvanceTable(), queried by getAdvance().

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -978,6 +978,12 @@ struct LayoutPageSink final : ParagraphSink {
   std::atomic<bool>* backTurnFlag = nullptr;
   void (*buildNoticeFn)(void*) = nullptr;
   void* buildNoticeCtx = nullptr;
+  // Speculative-build cancellation; see VerticalSection::setBuildCancelHook(). Polled in
+  // writeOne, so once per laid-out page. `cancelled` rides alongside `failed` -- both stop the
+  // build, but only `failed` means something went wrong.
+  bool (*cancelFn)(const void*) = nullptr;
+  const void* cancelCtx = nullptr;
+  bool cancelled = false;
   uint64_t lastRefusedAttemptKey = 0;  // see servePageRequest()
   int fontReleasedForReq_ = -1;        // one font-cache release per starved request; see servePageRequest()
 
@@ -1118,8 +1124,20 @@ struct LayoutPageSink final : ParagraphSink {
   // BATCH_CHARS trigger below, onImage()'s pre-image flush) must pass false so a batch boundary
   // that lands mid-page continues that page on the next call instead of finalizing it early. See
   // VerticalParsedText::layoutPages()'s isFinalFlush doc comment for the full rationale.
+  // True once the cancel hook has fired; latches `cancelled`/`failed` so every guarded path
+  // (flushText, onImage, the parse loop) stops. Polled here as well as in writeOne because a
+  // page can take seconds to lay out, and a cancel that only lands on page boundaries makes the
+  // reader wait out the whole of the current page.
+  bool checkCancelled() {
+    if (failed) return true;
+    if (!cancelFn || !cancelFn(cancelCtx)) return false;
+    cancelled = true;
+    failed = true;
+    return true;
+  }
+
   void flushText(bool isFinalFlush = false) {
-    if (failed) return;
+    if (checkCancelled()) return;
     if (!isFinalFlush && layout.pendingCount() == 0) return;
     // Streaming pages out via callback as they're finalized keeps at most ~2 pages' worth of
     // glyph buffers resident at once instead of the whole batch's -- see PageReadyCallback in
@@ -1136,6 +1154,7 @@ struct LayoutPageSink final : ParagraphSink {
   static constexpr size_t kPageBufCap = 12 * 1024;
 
   void writeOne(const VerticalPage& p) {
+    if (failed) return;  // a cancel latched mid-batch: the rest of this batch is discarded too
     pageOffsets.push_back(static_cast<uint32_t>(out.position()));
     // TRANSIENT staging buffer: allocated for this one write, freed before layout resumes.
     // Holding it resident across the whole build deepened the layout's low-heap dips by
@@ -1161,7 +1180,10 @@ struct LayoutPageSink final : ParagraphSink {
       failed = true;
     }
 
-    if (ok) servePageRequest(p, static_cast<int>(pageOffsets.size()) - 1);
+    if (!ok) return;
+    // Poll BEFORE serving: a cancelled speculative build has no reader waiting on its pages.
+    if (checkCancelled()) return;
+    servePageRequest(p, static_cast<int>(pageOffsets.size()) - 1);
   }
 
   // Show-the-page-during-the-build engine, shared by the initial early first render (the
@@ -1471,6 +1493,8 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   sink.backTurnFlag = &backTurnDuringBuild_;
   sink.buildNoticeFn = buildNoticeFn_;
   sink.buildNoticeCtx = buildNoticeCtx_;
+  sink.cancelFn = cancelFn_;
+  sink.cancelCtx = cancelCtx_;
 
   // Styled blocks (borders, start offsets, hanging indents, centering, gaps): collect the
   // vertical-relevant selectors. Streams the on-disk CSS cache -- does NOT materialize the
@@ -1561,6 +1585,9 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
       parseOk = false;
       break;
     }
+    // A cancelled or failed sink drops every page the rest of this file would produce, so
+    // parsing on is pure waste -- and for a cancel the whole point is to hand the task back.
+    if (sink.failed) break;
   } while (!done);
 
   htmlFile.close();
@@ -1572,6 +1599,11 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
   extractor.flushParagraph();
   sink.flushText(/*isFinalFlush=*/true);
 
+  if (sink.cancelled) {
+    lastBuildCancelled_ = true;
+    LOG_INF("VSC", "Speculative build cancelled after %zu pages (spine=%d)", pageOffsets_.size(), spineIndex);
+    return false;
+  }
   if (sink.failed) return false;
 
   // OR, don't assign: the styled-block collect above may already have flagged this build
@@ -1606,6 +1638,7 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   pageOffsets_.clear();
   loadedPageIndex_ = -1;
   pageCount = 0;
+  lastBuildCancelled_ = false;
 
   HalFile file;
   if (!Storage.openFileForWrite("VSC", filePath, file)) {

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -75,6 +75,10 @@ class VerticalSection {
   std::atomic<bool> backTurnDuringBuild_{false};
   void (*buildNoticeFn_)(void*) = nullptr;
   void* buildNoticeCtx_ = nullptr;
+  // See setBuildCancelHook().
+  bool (*cancelFn_)(const void*) = nullptr;
+  const void* cancelCtx_ = nullptr;
+  bool lastBuildCancelled_ = false;
 
  public:
   uint16_t pageCount = 0;
@@ -120,6 +124,18 @@ class VerticalSection {
     buildNoticeCtx_ = ctx;
     buildNoticeFn_ = fn;
   }
+
+  // Cooperative cancellation, polled once per laid-out page (~60ms apart). For SPECULATIVE
+  // builds only -- a build the reader is waiting on must never be cancelled, so the foreground
+  // path leaves this unset. A cancelled build writes no cache file at all: the partial layout is
+  // discarded rather than persisted, so the next attempt starts clean.
+  void setBuildCancelHook(const void* ctx, bool (*fn)(const void*)) {
+    cancelCtx_ = ctx;
+    cancelFn_ = fn;
+  }
+  // True when the last createSectionFile() returned false because the cancel hook fired, as
+  // opposed to a real failure. Lets a speculative caller back off quietly instead of logging.
+  bool lastBuildCancelled() const { return lastBuildCancelled_; }
 
   // furiganaEnabled is part of the cache key: the column gap only has to clear ruby when ruby is
   // drawn, so turning furigana off tightens the columns and the chapter must be re-laid out.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -817,7 +817,15 @@ void EpubReaderActivity::readerLoop() {
   // press itself shouldn't be lost: it's latched into pendingManualTurn and
   // executed here, on the first idle tick after the guard clears.
   constexpr unsigned long kMinManualTurnGapMs = 200;
-  const bool turnGuardActive = RenderLock::peek() || (millis() - lastPageTurnTime) < kMinManualTurnGapMs;
+  // A vertical chapter build holds the RenderLock for its whole duration (seconds), so the guard
+  // below would latch every press for that entire window and replay it only once the build ends.
+  // That shadowed the build's own mid-build page-request path -- reachable in principle from
+  // pageTurn(), but unreachable in practice for a button press, which is the only way a reader
+  // turns a page. Let presses through while a build runs; pageTurn() routes them to the build,
+  // which serves each page as it is laid out.
+  const bool buildServingTurns = verticalBuildInProgress_.load(std::memory_order_relaxed);
+  const bool turnGuardActive =
+      !buildServingTurns && (RenderLock::peek() || (millis() - lastPageTurnTime) < kMinManualTurnGapMs);
   if (pendingManualTurn != 0 && !turnGuardActive) {
     if (!section && !verticalSection) {
       // The section was dropped after the latch (re-layout, build failure,
@@ -1561,17 +1569,6 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
-  // A page turn is authoritative: do not let a resume/reflow position captured
-  // at session start snap the reader back after the incremental build completes.
-  {
-    RenderLock lock(*this);
-    clearDeferredReposition();
-  }
-  // Tilt- and auto-page-turn calls reach here without a button press, so the loop()-side stamp
-  // bump didn't fire -- cancel a running image warm before the chapter-boundary branches below
-  // block on the RenderLock it holds.
-  imageWarmInputStamp_.fetch_add(1, std::memory_order_relaxed);
-  pendingHorizontalImageRefine_.store(NO_IMAGE_REFINE, std::memory_order_relaxed);
   lastTurnForward_.store(isForwardTurn, std::memory_order_relaxed);
 
   // A vertical chapter is still building on the render task: pageCount is 0 until the build
@@ -1579,6 +1576,11 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   // on the RenderLock for the rest of the build, and then jump to the NEXT SPINE (observed on
   // device: one press during the build teleported the reader to the end of the book). Route
   // the turn to the build's page-request hook instead -- the page shows as soon as it exists.
+  //
+  // FIRST, ahead of the RenderLock below: the render task holds that lock for the whole build,
+  // so taking it here would freeze the loop task until the chapter finishes -- exactly the wait
+  // this branch exists to avoid. Nothing here needs it. The branch only writes atomics the build
+  // polls, and the section cannot be destroyed while its own build is running on it.
   if (verticalBuildInProgress_.load(std::memory_order_relaxed)) {
     const int shown = earlyDisplayedPage_.load(std::memory_order_relaxed);
     if (shown >= 0 && verticalSection) {
@@ -1595,6 +1597,18 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
     lastPageTurnTime = millis();
     return;
   }
+
+  // A page turn is authoritative: do not let a resume/reflow position captured
+  // at session start snap the reader back after the incremental build completes.
+  {
+    RenderLock lock(*this);
+    clearDeferredReposition();
+  }
+  // Tilt- and auto-page-turn calls reach here without a button press, so the loop()-side stamp
+  // bump didn't fire -- cancel a running image warm before the chapter-boundary branches below
+  // block on the RenderLock it holds.
+  imageWarmInputStamp_.fetch_add(1, std::memory_order_relaxed);
+  pendingHorizontalImageRefine_.store(NO_IMAGE_REFINE, std::memory_order_relaxed);
 
   const int curPage = verticalSection ? verticalSection->currentPage : (section ? section->currentPage : 0);
   const int pgCount = verticalSection ? verticalSection->pageCount : (section ? section->pageCount : 0);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2723,8 +2723,23 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     silentIndexBackoffUntilMs_ = 0;
 
     LOG_DBG("ERS", "Silently indexing next vertical chapter: %d (maxAlloc=%u)", nextSpineIndex, ESP.getMaxAllocHeap());
+    // This build owns the render task for as long as it runs -- up to 18s on a 282-page chapter,
+    // measured. Every OTHER tail task already yields the task back on a button press; without the
+    // same courtesy here a turn pressed during the build sat frozen for the whole of it, and the
+    // window fires on every chapter shorter than SILENT_INDEX_WINDOW_PAGES, which in a Japanese
+    // book is every one-page illustration spine at the front. Cancelling costs the partial layout
+    // (nothing is persisted), but the foreground build that then runs carries the early-render
+    // hook, so the reader sees the page in seconds instead of waiting out the whole chapter.
+    imageWarmStampSnapshot_ = imageWarmInputStamp_.load(std::memory_order_relaxed);
+    nextVSection.setBuildCancelHook(this, &EpubReaderActivity::imageWarmShouldCancel);
     if (!nextVSection.createSectionFile(fontId, viewportWidth, viewportHeight, SETTINGS.lineSpacing, useFurigana())) {
-      LOG_ERR("ERS", "Failed silent indexing for vertical chapter: %d", nextSpineIndex);
+      if (nextVSection.lastBuildCancelled()) {
+        // Back off exactly as a heap skip does: without it a reader paging through a chapter's
+        // closing pages restarts the build on every turn and it never reaches the end.
+        silentIndexBackoffUntilMs_ = millis() + 1500;
+      } else {
+        LOG_ERR("ERS", "Failed silent indexing for vertical chapter: %d", nextSpineIndex);
+      }
     }
     return;
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -819,9 +819,12 @@ void EpubReaderActivity::readerLoop() {
   constexpr unsigned long kMinManualTurnGapMs = 200;
   const bool turnGuardActive = RenderLock::peek() || (millis() - lastPageTurnTime) < kMinManualTurnGapMs;
   if (pendingManualTurn != 0 && !turnGuardActive) {
-    if (!section) {
+    if (!section && !verticalSection) {
       // The section was dropped after the latch (re-layout, build failure,
-      // bookmark jump): the queued turn no longer names a page.
+      // bookmark jump): the queued turn no longer names a page. Both kinds must be
+      // tested -- a vertical book leaves `section` null always, so testing it alone
+      // discarded EVERY latched turn in vertical mode, which is every turn pressed
+      // while a render (or the chapter index that runs in its tail) was in flight.
       pendingManualTurn = 0;
       return;
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the first pages of a vertical (Japanese) book usable. Opening a book and pressing next did nothing for ~18s, and after the first page finally appeared, further presses were ignored until the chapter finished indexing.
* **What changes are included?** Two input bugs, one responsiveness change, one cache sizing fix. They are independent and land as four commits.

Measured on an X4 with a real Japanese EPUB (cover spine + a 282-page chapter), cache deleted before each run:

| | before | after |
|---|---|---|
| press on cover → first text page | ~18s of nothing | ~2s |
| pages served while the chapter indexes | none | 0, 1, 2, 6, 9, 10 at ~0.85s each |
| speculative build cancel latency | never cancels | 588 ms |
| SD glyph loads to lay out one page | 548 (82 distinct) | 66 (48 distinct) |
| chapter index | 18.4s | 6.3s |
| minimum free heap | 7992 B | 8052 B |

### `fc9dff7c` — latched page turns discarded in vertical books

A turn pressed while a render is in flight is latched into `pendingManualTurn` rather than executed, then replayed on the first idle tick. The replay guarded on `!section` — the **horizontal** section, which a vertical book leaves null for its entire life. Every latched turn in vertical mode was therefore thrown away.

That is every press made during any render. It is invisible during normal reading (renders are short) and total on a chapter's opening pages, where an index build occupies the render task for seconds. One line: test both section kinds.

### `db99effb` — page turns could not reach a running chapter build

`VerticalSection` can already serve the reader's page mid-build (`requestPageDuringBuild`, `setEarlyRenderHook`), and `pageTurn()` has a branch for it. A button press could never get there.

Two blockers:

* The turn guard latches any press made while the render task holds the `RenderLock`, and a build holds it for its whole duration. Presses were parked until the build ended, making that branch dead code for the only input a reader actually uses. Presses now pass the guard while a build runs.
* `pageTurn()` took the `RenderLock` as its first statement, *before* testing for a build. Acquiring it there blocks the loop task until the chapter finishes — precisely the wait the branch exists to avoid. The branch now runs first. It only writes atomics the build polls, and the section cannot be destroyed while its own build is running on it.

### `0352430c` — the speculative chapter index is now interruptible

`silentIndexNextChapterIfNeeded()` builds the next chapter on the render task and, alone among the tasks in the render tail, could not be interrupted. Every other one honours a button press; this one held the task for the full build.

The trigger window is `currentPage >= pageCount - SILENT_INDEX_WINDOW_PAGES`, so it fires on **any** chapter shorter than 5 pages — which in a Japanese book is every one-page illustration spine at the front. It runs immediately after the cover renders, at the moment the reader is most certain to press next.

`VerticalSection` gains a cancel hook, polled per text batch rather than per page: a chapter's first page can take seconds to lay out, and a cancel landing only on page boundaries makes the reader wait out that page (observed: 6.7s at page granularity, 588ms per batch).

Per `CLAUDE.md`'s rule about not persisting transient failures, a cancelled build persists **nothing** — `streamParseAndLayout` returns false and `createSectionFile`'s existing failure path removes the partial file, so the next attempt starts clean instead of inheriting a truncated chapter. Only speculative builds set the hook; a build the reader is waiting on is never cancelled. A cancel arms the same 1500ms backoff a heap skip uses, so paging through a chapter's closing pages does not restart the build on every turn.

### `e2c58d01` — SD font overflow ring sized to the layout working set

A chapter build runs with the mini font cache deliberately released (the layout needs that heap), so every glyph measurement during layout falls through to the on-demand overflow ring. At 8 slots a single line of Latin text overflows it, and each re-measure of the same run reloads every character from SD. Device log, laying out one page: **548 loads for 82 distinct codepoints, U+0020 alone read 164 times** — about 6s of the ~7s before the page appeared.

48 slots under a **4KB byte ceiling**. The ceiling is the point: slot count alone does not bound memory, since 48 large CJK glyphs are several times 48 Latin ones, and this cache fills at the tightest heap moment on the device. 4KB is what the measurement justified — the thrashing working set was ~3KB of Latin glyphs — capping growth over the old ring at roughly 3KB per loaded font. Over budget the ring resets wholesale rather than evicting entries, because the lookup scans a dense prefix that selective eviction would have to compact.

The larger ring also **churns less** heap, not more: a miss on a full ring frees the evicted bitmap and allocates a new one, so 8 slots meant ~550 alloc/free pairs of similar sizes per page — exactly the pattern that shreds the largest contiguous block.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — these are bugs and costs in the existing vertical reading path.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Verification.**

* `pio run -e overlay` builds; `./bin/clang-format-fix -g` leaves the tree unchanged.
* Every number in the table above was read off an X4 serial log, one change at a time, cache deleted before each run.
* The horizontal path was exercised on an English EPUB after the change: **zero** SD glyph loads (it uses the built-in flash fonts, so the ring never engages), and page timings are unchanged at ~565-950ms, dominated by the anti-aliasing grayscale pass and the panel refresh.

**Heap.** The one change that costs memory is the ring. Minimum free heap measured 8052 bytes after, against 7992 before — unchanged within noise. An earlier iteration used a 12KB budget; it bought nothing measurable over 4KB and is not what shipped.

**An abort worth reporting upstream, not fixed here.** During a Home rescan at the heap floor the device aborted:

```
operator new(unsigned int)  -> __unexpected -> __assert_func -> panic_abort
  std::__cxx11::basic_string::substr
  freeink::content::parseCredential (freeink-sdk/libs/book/ContentProtection/src/Credential.cpp:53)
```

That is a bare `new` under `-fno-exceptions`, which terminates rather than returning null — the hazard `CLAUDE.md` names explicitly. It lives in `freeink-sdk/`, which this PR does not touch, so it is reported rather than patched. It reproduced only at the heap floor and did not recur with the 4KB budget.

**Not included.** Making the *horizontal* silent index cancellable the same way. The horizontal path has partial-build persistence (`suspendBuild`/`isPartial`) that the vertical one lacks, so the trade there is different and deserves its own measurement.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
