### PR TITLE
fix: wrap the dictionary reading and grammar tags

### DIFF
--- a/src/activities/reader/DefinitionTextRenderer.cpp
+++ b/src/activities/reader/DefinitionTextRenderer.cpp
@@ -678,7 +678,7 @@ void prewarmStyledText(GfxRenderer& renderer, const int fontId, const std::strin
   }
 }
 
-int entryMetadataLineCount(GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
+int entryMetadataLineCount(const GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
                            const EntryMetadata& metadata) {
   int y = 0;
   int lines = layoutMetadataField(renderer, metadata.reading, fontId, scale, 0, y, body.width, 0, 0, false);
@@ -687,7 +687,7 @@ int entryMetadataLineCount(GfxRenderer& renderer, const Rect& body, const int fo
   return lines;
 }
 
-int drawEntryMetadata(GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
+int drawEntryMetadata(const GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
                       const EntryMetadata& metadata, const int scrollOffset, const int lineHeight) {
   if (metadata.reading.empty() && metadata.grammar.empty()) return body.y;
 

--- a/src/activities/reader/DefinitionTextRenderer.cpp
+++ b/src/activities/reader/DefinitionTextRenderer.cpp
@@ -377,7 +377,7 @@ size_t wrapMetadataLine(const GfxRenderer& renderer, const int fontId, const uin
 
 // Wrap one metadata field to `maxWidth`, drawing the lines inside [clipTop, clipBottom) when
 // `draw` is set. `y` advances past the field either way; the return value is its line count.
-int layoutMetadataField(GfxRenderer& renderer, const std::string& text, const int fontId, const uint16_t scale,
+int layoutMetadataField(const GfxRenderer& renderer, const std::string& text, const int fontId, const uint16_t scale,
                         const int x, int& y, const int maxWidth, const int clipTop, const int clipBottom,
                         const bool draw) {
   if (text.empty()) return 0;

--- a/src/activities/reader/DefinitionTextRenderer.cpp
+++ b/src/activities/reader/DefinitionTextRenderer.cpp
@@ -304,6 +304,98 @@ inline size_t utf8CharLen(const unsigned char c0) {
   if (c0 >= 0xC0) return 2;
   return 1;
 }
+
+// 75% of the selected lookup size: the grammar tags read as an annotation to the reading.
+constexpr uint16_t METADATA_COMPACT_SCALE = 192;
+
+// One wrapped metadata line is bounded by the panel width; 192 bytes covers a full line of kana
+// or of `·`-joined Latin tags, so the line buffer stays on the stack and costs no heap per render.
+constexpr size_t METADATA_LINE_CAP = 192;
+
+// Would breaking at `end` leave the tag separator alone at the start of the next line?
+bool orphansSeparator(const std::string& text, size_t end) {
+  static constexpr char kMiddot[] = "\xc2\xb7";
+  while (end < text.size() && text[end] == ' ') end++;
+  if (text.compare(end, sizeof(kMiddot) - 1, kMiddot) != 0) return false;
+  const size_t after = end + sizeof(kMiddot) - 1;
+  return after == text.size() || text[after] == ' ';
+}
+
+// Longest prefix of `text` from `start` that fits `maxWidth`, cut at the last fitting space so
+// the ` · `-joined tags stay whole. Text without a usable space break (a kana reading, or a tag
+// wider than the panel) breaks per character. `out` receives the drawable, null-terminated line;
+// the return value is where the next line starts.
+size_t wrapMetadataLine(const GfxRenderer& renderer, const int fontId, const uint16_t scale, const std::string& text,
+                        const size_t start, const int maxWidth, char* out, const size_t outCap) {
+  out[0] = '\0';
+  size_t bestEnd = std::string::npos;
+  size_t cleanEnd = std::string::npos;  // longest fitting break that keeps the separator at line end
+  size_t candidate = start;
+  while (candidate <= text.size()) {
+    const size_t space = text.find(' ', candidate);
+    const size_t end = space == std::string::npos ? text.size() : space;
+    if (end - start >= outCap) break;
+    if (end > start) {
+      memcpy(out, text.data() + start, end - start);
+      out[end - start] = '\0';
+      if (renderer.getTextWidthScaled(fontId, out, scale) > maxWidth) break;
+      bestEnd = end;
+      if (!orphansSeparator(text, end)) cleanEnd = end;
+    }
+    if (space == std::string::npos) break;
+    candidate = space + 1;
+  }
+  if (cleanEnd != std::string::npos) bestEnd = cleanEnd;
+
+  if (bestEnd != std::string::npos) {
+    memcpy(out, text.data() + start, bestEnd - start);
+    out[bestEnd - start] = '\0';
+    size_t next = bestEnd;
+    while (next < text.size() && text[next] == ' ') next++;
+    return next;
+  }
+
+  size_t len = 0;
+  size_t pos = start;
+  while (pos < text.size()) {
+    size_t charLen = utf8CharLen(static_cast<unsigned char>(text[pos]));
+    if (charLen > text.size() - pos) charLen = text.size() - pos;
+    if (len + charLen + 1 > outCap) break;
+    memcpy(out + len, text.data() + pos, charLen);
+    out[len + charLen] = '\0';
+    // The first character always goes on the line: a glyph wider than the panel would
+    // otherwise stall the caller's loop forever.
+    if (len > 0 && renderer.getTextWidthScaled(fontId, out, scale) > maxWidth) {
+      out[len] = '\0';
+      break;
+    }
+    len += charLen;
+    pos += charLen;
+  }
+  return pos;
+}
+
+// Wrap one metadata field to `maxWidth`, drawing the lines inside [clipTop, clipBottom) when
+// `draw` is set. `y` advances past the field either way; the return value is its line count.
+int layoutMetadataField(GfxRenderer& renderer, const std::string& text, const int fontId, const uint16_t scale,
+                        const int x, int& y, const int maxWidth, const int clipTop, const int clipBottom,
+                        const bool draw) {
+  if (text.empty()) return 0;
+  const int lineHeight = renderer.getLineHeightScaled(fontId, scale);
+  char line[METADATA_LINE_CAP];
+  int lines = 0;
+  size_t pos = 0;
+  while (pos < text.size()) {
+    const size_t next = wrapMetadataLine(renderer, fontId, scale, text, pos, maxWidth, line, sizeof(line));
+    if (next <= pos) break;
+    pos = next;
+    if (draw && line[0] != '\0' && y >= clipTop && y < clipBottom)
+      renderer.drawTextScaled(fontId, x, y, line, scale, true);
+    y += lineHeight;
+    lines++;
+  }
+  return lines;
+}
 }  // namespace
 
 void extractEntryMetadata(std::string& text, const std::string& fallbackHeadword, EntryMetadata& metadata) {
@@ -586,28 +678,33 @@ void prewarmStyledText(GfxRenderer& renderer, const int fontId, const std::strin
   }
 }
 
+int entryMetadataLineCount(GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
+                           const EntryMetadata& metadata) {
+  int y = 0;
+  int lines = layoutMetadataField(renderer, metadata.reading, fontId, scale, 0, y, body.width, 0, 0, false);
+  lines +=
+      layoutMetadataField(renderer, metadata.grammar, fontId, METADATA_COMPACT_SCALE, 0, y, body.width, 0, 0, false);
+  return lines;
+}
+
 int drawEntryMetadata(GfxRenderer& renderer, const Rect& body, const int fontId, const uint16_t scale,
                       const EntryMetadata& metadata, const int scrollOffset, const int lineHeight) {
-  constexpr uint16_t COMPACT_SCALE = 192;  // 75% of the selected lookup size.
-  const bool hasReading = !metadata.reading.empty();
-  const bool hasGrammar = !metadata.grammar.empty();
-  if (!hasReading && !hasGrammar) return body.y;
+  if (metadata.reading.empty() && metadata.grammar.empty()) return body.y;
 
   const int baseY = body.y;
-  int y = body.y - scrollOffset * lineHeight;
-  const auto drawVisible = [&body, &renderer](const int fontId, const int x, const int y, const char* text,
-                                              const uint16_t scale) {
-    if (y >= body.y && y < body.y + body.height) renderer.drawTextScaled(fontId, x, y, text, scale, true);
-  };
-  if (hasReading) {
-    drawVisible(fontId, body.x, y, metadata.reading.c_str(), scale);
-    y += renderer.getLineHeightScaled(fontId, scale) + 3;
+  const int startY = body.y - scrollOffset * lineHeight;
+  const int clipBottom = body.y + body.height;
+  int y = startY;
+  if (!metadata.reading.empty()) {
+    layoutMetadataField(renderer, metadata.reading, fontId, scale, body.x, y, body.width, body.y, clipBottom, true);
+    y += 3;
   }
-  if (hasGrammar) {
-    drawVisible(fontId, body.x, y, metadata.grammar.c_str(), COMPACT_SCALE);
-    y += renderer.getLineHeightScaled(fontId, COMPACT_SCALE) + 5;
+  if (!metadata.grammar.empty()) {
+    layoutMetadataField(renderer, metadata.grammar, fontId, METADATA_COMPACT_SCALE, body.x, y, body.width, body.y,
+                        clipBottom, true);
+    y += 5;
   }
-  return std::min(baseY + (y - (body.y - scrollOffset * lineHeight)), body.y + body.height);
+  return std::min(baseY + (y - startY), clipBottom);
 }
 
 WrapResult DrawWrappedImpl(GfxRenderer& renderer, const int fontId, const std::string& text, const int textX,

--- a/src/activities/reader/DefinitionTextRenderer.h
+++ b/src/activities/reader/DefinitionTextRenderer.h
@@ -46,9 +46,10 @@ void prewarmStyledText(GfxRenderer& renderer, int fontId, const std::string& tex
 int drawEntryMetadata(GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
                       const EntryMetadata& metadata, int scrollOffset = 0, int lineHeight = 0);
 
-inline int entryMetadataLineCount(const EntryMetadata& metadata) {
-  return (!metadata.reading.empty() ? 1 : 0) + (!metadata.grammar.empty() ? 1 : 0);
-}
+// Reading and grammar tags wrap to the panel width, so their line count -- which the callers
+// use for scroll bookkeeping -- depends on the renderer's measurements, not just on presence.
+int entryMetadataLineCount(GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
+                           const EntryMetadata& metadata);
 
 // Tiny keeps the compact, readable 8pt font. Larger options use native built-in fonts so their
 // glyphs stay sharp; CJK characters can be routed to a matching SD-card size by the activity.

--- a/src/activities/reader/DefinitionTextRenderer.h
+++ b/src/activities/reader/DefinitionTextRenderer.h
@@ -43,12 +43,12 @@ void prewarmStyledText(GfxRenderer& renderer, int fontId, const std::string& tex
 // Draw the reading at the selected lookup size and the grammar tags at a compact 75% scale.
 // Metadata participates in the same scroll offset as the definition; the return value is the
 // unscrolled first y-coordinate available for the definition body.
-int drawEntryMetadata(GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
+int drawEntryMetadata(const GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
                       const EntryMetadata& metadata, int scrollOffset = 0, int lineHeight = 0);
 
 // Reading and grammar tags wrap to the panel width, so their line count -- which the callers
 // use for scroll bookkeeping -- depends on the renderer's measurements, not just on presence.
-int entryMetadataLineCount(GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
+int entryMetadataLineCount(const GfxRenderer& renderer, const Rect& body, int fontId, uint16_t scale,
                            const EntryMetadata& metadata);
 
 // Tiny keeps the compact, readable 8pt font. Larger options use native built-in fonts so their

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -1472,7 +1472,7 @@ void EpubReaderWordLookupActivity::renderContentArea(const Rect& body) {
   } else {
     DefinitionText::EntryMetadata metadata{visibleReading(), visibleGrammar()};
     const int defLineH = renderer.getLineHeightScaled(defFont, defScale);
-    const int metadataLines = DefinitionText::entryMetadataLineCount(metadata);
+    const int metadataLines = DefinitionText::entryMetadataLineCount(renderer, body, defFont, defScale, metadata);
     const int definitionScroll = std::max(0, scrollOffset - metadataLines);
     Rect definitionBody = body;
     const int metadataEndY =

--- a/src/activities/reader/MangaWordLookupActivity.cpp
+++ b/src/activities/reader/MangaWordLookupActivity.cpp
@@ -407,7 +407,7 @@ void MangaWordLookupActivity::renderContentArea(const Rect& body) {
 
   DefinitionText::EntryMetadata metadata{resultReading, resultGrammar};
   const int defLineH = renderer.getLineHeightScaled(defFont, defScale);
-  const int metadataLines = DefinitionText::entryMetadataLineCount(metadata);
+  const int metadataLines = DefinitionText::entryMetadataLineCount(renderer, body, defFont, defScale, metadata);
   const int definitionScroll = std::max(0, scrollOffset - metadataLines);
   Rect definitionBody = body;
   const int metadataEndY =


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop the dictionary entry header from running off the panel. An entry whose grammar tags are longer than the panel is wide (e.g. `取材` → `NOUN · SURU VERB · TRANSITIVE · INTRANSITIVE`) drew that line straight through the frame and off the screen instead of wrapping.
* **What changes are included?**
  * `drawEntryMetadata()` in `src/activities/reader/DefinitionTextRenderer.cpp` emitted the reading and the grammar tags with one `drawTextScaled()` call each — no wrapping at all. Only the definition body below went through `drawWrapped()`. Both fields now wrap to the panel body width.
  * Latin tags break at the last fitting space; a break that would leave the `·` separator alone at the start of the next line is rejected in favour of the previous one, so a wrapped line ends `… TRANSITIVE ·` and the next begins with a tag. Kana readings contain no spaces and break per glyph.
  * `entryMetadataLineCount()` now measures the wrapped line count instead of returning "one per present field". Both call sites (`EpubReaderWordLookupActivity`, `MangaWordLookupActivity`) feed it into their scroll bookkeeping, so leaving it at 1-per-field would offset the definition body once the header wrapped.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. This is a rendering bug in this fork's own dictionary panel, not a new feature.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. *(Not applicable — the diff is confined to `src/activities/reader/`.)*

## Additional Context

**Memory / flash impact:** no new heap. The wrapped line is built in a 192-byte stack buffer (under the 256-byte local-variable guidance), and the two new helpers live in the file's anonymous namespace. `pio run -e default` reports RAM 16.8% (55,140 B) and Flash 89.8% (5,885,703 B); the flash delta against `develop` is the two small helpers.

**Cost per render:** the wrap measures a prefix per break candidate, i.e. per space, and the count pass repeats it. The metadata is at most a reading plus a handful of tags, so this is a fraction of what the definition body already costs in `drawWrapped()`.

**Areas to focus on in review:**
* The scroll step for the metadata block is still the *definition* line height, while the tag lines are drawn at 75% scale — a pre-existing approximation I left alone. With three or more wrapped tag lines a scroll step through the header may feel coarse.
* The degenerate case (a single tag wider than the panel) hard-breaks mid-word. The first character is always accepted onto the line, so the caller's loop always makes progress.

**Verification:**
* `pio run -e default` succeeds, no warnings in the changed files.
* Not tested on hardware. The wrapping helpers were exercised on the host against a stub renderer across widths from 420px down to 40px, plus a long space-free kana string and an empty field; at realistic panel widths the tag list wraps to `NOUN · SURU VERB ·` / `TRANSITIVE · INTRANSITIVE` and the separator never starts a line. Device testing and the four orientations still need a human.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV1jcmTE62gBPiMcMEijHR


---
_Generated by [Claude Code](https://claude.ai/code/session_01VV1jcmTE62gBPiMcMEijHR)_