### PR TITLE
fix: close the definition view without a full-screen flash

### DIFF
--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -753,9 +753,10 @@ void EpubReaderWordLookupActivity::renderSelect() {
   invertBoxes(drawnBoxes, drawnBoxCount);
 
   if (repaint) {
-    // A freshly painted page deserves a clean pass; the fast LUT would carry over the definition
-    // view's ghost.
-    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+    // Coming back from the definition view. A HALF here scrubs any ghost it left, but it is a
+    // 1.7s black flash on every close against the 0.5s FAST that opened it, which reads as the
+    // panel breaking rather than closing. Take the FAST and let the interval below scrub.
+    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
     fastRefreshCount = 0;
     return;
   }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the definition view close as quietly as it opens. It ended on a 1.7s
  black-and-white inversion that read as a crash rather than a dismissal.
* **What changes are included?** One line, plus the comment explaining the trade.

Returning from the definition view sets `repaint`, which forced `HALF_REFRESH` on the word-lookup panel's repaint.
Measured on device across three open/close cycles, back to back:

```
[441439]  Wait complete: refresh (502 ms)    <- open
[444900]  Wait complete: refresh (1690 ms)   <- close
[445595]  Wait complete: refresh (502 ms)    <- open
[449145]  Wait complete: refresh (1690 ms)   <- close
```

Deterministic, not the refresh cadence landing there by chance.

The HALF was deliberate: the definition view fills the screen, and a FAST diff back to the page can leave its text
faintly behind. That is a real effect, but paying 1.7s of flashing on every close to pre-empt it is the wrong side of
the trade. The panel already takes a HALF every `kFullRefreshInterval` repaints, so residue is still scrubbed, just
not on each dismissal.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — this tunes an existing panel.
- [x] Does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Verification.** `pio run -e overlay` builds; `./bin/clang-format-fix -g` leaves the tree unchanged. Flashed to an
X4 and exercised: opening and closing the definition view now both take ~500ms, and the page underneath is clean
afterwards.

**What to watch in review.** Whether ghosting comes back on a page the definition covered. It did not appear in
testing, but the ghost the old code guarded against is content-dependent, so a dense definition over a dense page is
the case to try. If it does show up, the smaller fix is lowering `kFullRefreshInterval` rather than restoring the
per-close HALF.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
