### PR TITLE
fix: repaint the word-lookup page when the build clobbered the frame

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -166,6 +166,7 @@ void GfxRenderer::releaseFrameBufferForBuild() {
   uint32_t size = 0;
   uint8_t* scratch = display.lendFrameBufferStorage(&size);
   frameBuffer = nullptr;
+  frameBufferContentsStale_ = true;  // the borrower writes over these bytes
   if (scratch) {
     buildscratch::lend(scratch, size);
   }
@@ -1946,6 +1947,7 @@ static bool frameTimed = false;
 void GfxRenderer::clearScreen(const uint8_t color) const {
   start_ms = millis();
   frameTimed = true;
+  if (!_stripActive) frameBufferContentsStale_ = false;  // whatever draws next owns the frame
   if (_stripActive) {
     // Clear only the active band's scratch, not the shared framebuffer.
     memset(_stripBuf, color, static_cast<size_t>(panelWidthBytes) * _stripRows);

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -85,6 +85,11 @@ class GfxRenderer {
   // baseline. panelResidue_ cannot answer this: any FAST refresh sets it, so it is true almost
   // always and would force a scrub on every image page.
   mutable bool grayPlanesResident_ = false;
+  // True while the framebuffer's bytes do not hold what the panel is showing. A build lends those
+  // bytes out as inflate scratch (releaseFrameBufferForBuild), so after the loan the e-ink still
+  // displays the last page while the buffer behind it holds whatever the inflate left. Anything
+  // that composites onto the current frame instead of repainting it has to check this first.
+  mutable bool frameBufferContentsStale_ = false;
 
   // Tiled grayscale strip target. When active, drawPixel()/clearScreen()
   // operate on a caller-owned scratch holding one horizontal band of physical
@@ -435,6 +440,9 @@ class GfxRenderer {
   void releaseFrameBufferForBuild();
   bool restoreFrameBufferAfterBuild();
   bool hasFrameBuffer() const { return frameBuffer != nullptr; }
+  // Whether the framebuffer's CONTENTS can be trusted -- hasFrameBuffer() only answers for the
+  // pointer, which comes back intact after a build loan even though the pixels did not.
+  bool frameBufferContentsStale() const { return frameBufferContentsStale_; }
 
   // RAII form of the loan above, for blocking build regions with early-return
   // error paths: restores on scope exit (or explicitly via end()). Display the

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3866,7 +3866,11 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
     selectCtx.cellPx = verticalCellPx(renderer, effectiveReaderFontId());
     selectCtx.repaintPage = &EpubReaderActivity::repaintVerticalPageForPanelThunk;
     selectCtx.repaintCtx = this;
-    selectCtx.pageOnScreen = pageOnScreen;
+    // Only when the framebuffer really holds what the panel shows. It does not after a chapter
+    // build: the early render put the page on the e-ink, then the build borrowed the buffer's
+    // bytes as inflate scratch. Skipping the repaint there composites the cursor onto whatever
+    // the inflate left and flushes a blank page.
+    selectCtx.pageOnScreen = pageOnScreen && !renderer.frameBufferContentsStale();
 
     // Built under the render lock, started after it: the constructor's scan copies every glyph
     // out of *page, and the pointer is only valid while nothing else re-faults the section's


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop word lookup showing a blank screen the first time it is opened on a freshly
  built chapter.
* **What changes are included?** A staleness flag on `GfxRenderer`, and one condition in `openWordLookupPanel`.

The page was visible, then went blank the instant the selector appeared.

`renderSelect()` skips `clearScreen()` and the page repaint when `pageOnScreen` is set, and XORs the cursor onto the
frame already in the buffer. Correct when the reader has just drawn the page. Wrong after a chapter build: the
early-render hook put the page on the e-ink, and the build then borrowed the framebuffer's bytes as inflate scratch
(`GfxRenderer::releaseFrameBufferForBuild`). The panel kept showing the page while the buffer behind it held whatever
the inflate left, so the cursor went onto that and got flushed.

`hasFrameBuffer()` cannot catch this. The loan returns the same allocation, so the pointer is valid again while the
pixels are not — a device probe read `fb=1` with the screen blank.

`GfxRenderer` now tracks the contents, because it is the thing that hands the bytes away: set on loan, cleared by
`clearScreen()`, read through `frameBufferContentsStale()`. `openWordLookupPanel` requires it before trusting
`pageOnScreen`. Ordinary opens keep the fast path and are unchanged.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Not applicable — this fixes an existing panel.
- [x] Does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**How it was found.** Two probes on device, because the first two explanations I had were wrong. The panel's own
state read `repaint=0 pageOnScreen=1 fb=1` with exactly one `renderSelect` call, which ruled out a failed repaint and
pointed at the frame itself.

**An attempt that is not in this PR.** I first put the flag on the reader and set it in `render()`, where it decides
to keep an early-rendered page. That raced: `openWordLookupPanel` runs on the loop task and captured `pageOnScreen`
35ms before `render()` reached the flag on the render task, so the panel still saw `pageOnScreen=1`. Holding the
state where the event happens removes the ordering question entirely.

**Verification.** `pio run -e overlay` builds; `./bin/clang-format-fix -g` leaves the tree unchanged. Reproduced on
an X4 with a cleared cache four times before the fix and confirmed fixed after: the page stays up when the selector
appears.

**Risk.** `clearScreen()` clearing the flag is the load-bearing part — a path that repaints without it would keep the
frame marked stale and cost one extra repaint, never a wrong frame. The strip-render path is excluded, since it
writes a band scratch rather than the framebuffer.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
