### PR TITLE
fix: guard clamp bounds for oversized rotated glyphs

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2813,8 +2813,11 @@ void GfxRenderer::drawCharVerticalRotatedInCell(const int fontId, const int cell
     if (!isSymmetricBracket(cp)) drawX = cellLeftX + cellSize - rotatedW;
   }
 
-  int minX = cellLeftX;
-  int maxX = cellLeftX + cellSize - rotatedW;
+  const int minX = cellLeftX;
+  // A rotated glyph wider than its cell leaves no room to slide in: without the max() the
+  // upper bound drops below the lower one, which is UB in std::clamp. Pin it flush left and
+  // let it overhang instead.
+  const int maxX = std::max(minX, cellLeftX + cellSize - rotatedW);
   const int minY = cellTopY;
   // An opening bracket is placed into the following cell on purpose, so the box spans two.
   const int maxY = cellTopY + cellSize * 2;

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -3,10 +3,10 @@
 #include <vector>
 
 #include "./FileBrowserActivity.h"
+#include "RecentBook.h"
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
-struct RecentBook;
 struct Rect;
 
 class HomeActivity final : public Activity {


### PR DESCRIPTION
Two latent bugs that the ESP32 toolchain accepts and a strict one rejects. Both surfaced while building the firmware for the iOS simulator fork, where libc++ replaces libstdc++.

## Reversed `std::clamp` bounds

`drawCharVerticalRotatedInCell` computed its upper x bound as `cellLeftX + cellSize - rotatedW`. When a CCW-rotated glyph is wider than the cell it goes in, that bound drops below `minX`, and `std::clamp` with reversed bounds is undefined behaviour.

On device this returns an unspecified value and mispositions the glyph with no diagnostic, so it is a real rendering bug rather than an iOS-only concern. libc++ hardening turns it into a trap:

```
libc++ Hardening assertion !__comp(__hi, __lo) failed: Bad bounds passed to std::clamp
```

Five of the six callers had no guard: the body-text path at `VerticalTextBlock.cpp:72`, and the three `verticalPunctInkBox` sites in `VerticalParsedText.cpp` (826, 856, 2073), which share the same code. Only the ruby path guarded, by sizing the cell to fit the rotated glyph, and the comment there already described this exact hazard. Fixing the shared function covers every caller and is a smaller diff than repeating the workaround.

An oversized glyph now pins flush to the cell's left edge and overhangs, consistent with what `minX` already intends and with the `std::max` guard the sibling function at line 2707 uses.

## Incomplete type in a vector member

`HomeActivity` holds `std::vector<RecentBook>` while only forward-declaring `RecentBook`. libc++ instantiates the vector's destructor at class scope and requires the complete type; GCC defers it. `HomeActivity.cpp` already included the definition transitively via `RecentBooksStore.h`, so the device build does not change.

## Verification

`GfxRenderer.cpp` and `HomeActivity.cpp` both compile under `pio run`, and the whole firmware compiles for arm64 against the iOS 26 SDK. `./bin/clang-format-fix -g` is clean.

Not verified: the assertion no longer firing at runtime on hardware. `pio run` does not currently reach a full link on `develop` for an unrelated reason — `src/overlay/{ContentAccess,ContentProtection,WebExtra}.cpp` cannot find `ContentProtection.h`, `ByteSource.h`, and `Crypto.h`, which exist under `freeink-sdk/libs/book/ContentProtection/include/` but are not on the include path. That predates this branch and is untouched here.