### PR TITLE
fix: frontlight panel toggle and shared power-button short press

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -94,7 +94,8 @@ Alternatively, while reading a book, press the **Confirm** button to open the re
 
 The X4 Pro has a built-in frontlight with adjustable brightness and warmth. It is controlled from a swipe panel rather than the Settings menu:
 
-* **Open the frontlight panel:** Swipe down from the top edge of the screen, from almost any screen (Home, Browse Files, Reading Mode, etc.). Drag the brightness and warmth sliders to adjust the light live, or tap the sun icon to turn it on or off.
+* **Open or close the frontlight panel:** Swipe down from the top edge of the screen, from almost any screen (Home, Browse Files, Reading Mode, etc.). Drag the brightness and warmth sliders to adjust the light live, or tap the sun icon to turn it on or off. The same swipe (or a status-bar tap) closes the panel again, as does the **Back** button.
+* **Adjust brightness with the buttons:** While the panel is open, the **Up**/**Down** side buttons and the page-turn buttons step the brightness. Hold one to ramp continuously. On devices with edge-mounted side buttons the direction follows the physical layout, so the upper button always brightens.
 * **Quick toggle:** Double-click the **Power** button to turn the frontlight on or off instantly, without opening the panel.
 
 > [!NOTE]

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -111,7 +111,11 @@ void ActivityManager::loop() {
       int ty = 0;
       statusBarTap = mappedInput.wasScreenTapped(tx, ty) && ty < 44;
     }
-    if (currentActivity->name != "FrontlightPanel" && (statusBarTap || mappedInput.wasLightPanelGesture())) {
+    if (statusBarTap || mappedInput.wasLightPanelGesture()) {
+      if (currentActivity->name == "FrontlightPanel") {
+        popActivity();
+        return;
+      }
       pushActivity(std::make_unique<FrontlightPanelActivity>(renderer, mappedInput));
       return;
     }

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -255,7 +255,7 @@ void FrontlightPanelActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) || mappedInput.wasLightPanelGesture()) {
     close();
     return;
   }
@@ -268,6 +268,13 @@ void FrontlightPanelActivity::loop() {
                                        [this] { adjustBrightness(-BRIGHTNESS_STEP); });
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Right},
                                        [this] { adjustBrightness(BRIGHTNESS_STEP); });
+
+  const int upDelta = gpio.hasEdgeSideButtons() ? -BRIGHTNESS_STEP : BRIGHTNESS_STEP;
+  const int downDelta = gpio.hasEdgeSideButtons() ? BRIGHTNESS_STEP : -BRIGHTNESS_STEP;
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up, MappedInputManager::Button::PageBack},
+                                       [this, upDelta] { adjustBrightness(upDelta); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down, MappedInputManager::Button::PageForward},
+                                       [this, downDelta] { adjustBrightness(downDelta); });
 }
 
 int FrontlightPanelActivity::computePanelBottom() const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -650,7 +650,9 @@ void loop() {
   const unsigned long loopStartTime = millis();
   static unsigned long lastMemPrint = 0;
 
-  gpio.setSharedConfirmPowerShortPressEmitsPower(SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP);
+  gpio.setSharedConfirmPowerShortPressEmitsPower(SETTINGS.shortPwrBtn !=
+                                                     CrossPointSettings::SHORT_PWRBTN::PWR_CONFIRM &&
+                                                 SETTINGS.shortPwrBtn != CrossPointSettings::SHORT_PWRBTN::IGNORE);
   mappedInputManager.update();
 
   if (activityManager.requiresExclusiveStorageLoop()) {


### PR DESCRIPTION
Two independent fixes that were sitting uncommitted in the working tree, rebuilt on top of the #165 upstream merge. The `HalGPIO.cpp` hunk that travelled with them was dropped — see below.

## `main.cpp` — short press never reached the shared-button actions

Boards such as Sticky wire OK/confirm and power/wake to the same GPIO: a short click emits `CONFIRM` and a hold emits `POWER`, unless the app opts into `setSharedConfirmPowerShortPressEmitsPower`.

That opt-in was gated on `shortPwrBtn == SLEEP`, so **Page Turn**, **Force Refresh**, **Footnotes** and **Word Lookup** never saw the power event — on a shared-GPIO board those settings silently did nothing.

Now gated on the two values that genuinely want a non-power click: `PWR_CONFIRM` (wants `CONFIRM`) and `IGNORE` (wants nothing). No effect on boards with a separate power button.

## Frontlight panel — the gesture is now a toggle

The top-edge swipe / status-bar tap only opened the panel; while it was open a `name != "FrontlightPanel"` guard swallowed the gesture, so it could only be dismissed with **Back**. The same gesture now pops it.

Brightness is also bound to **Up**/**Down** and the page-turn buttons, with the direction inverted on `hasEdgeSideButtons()` boards (X3, X3-UC8279, X4 Pro) so the upper button always brightens.

`USER_GUIDE.md` updated to match, extending the frontlight section added in #3187.

## Dropped hunk

The WIP also swapped `isPowerButtonPhysicallyPressed()` → `isPowerButtonPressed()` in `HalGPIO::verifyPowerButtonWakeup()`. That was a local compile workaround for a submodule parked on an SDK commit predating `e4d3cc3` ("Add power button physical state query method"), not a behaviour change — and it is wrong on the current SDK. `heldAtFirstSample` is sampled *before* the first `inputMgr.update()`, so the debounced logical accessor has no state yet and reads false, defeating the ghost-wake debounce from #3191. Deliberately not reapplied.

## Still open

The two closing paths are implemented at both layers — `ActivityManager` pops on the gesture, and `FrontlightPanelActivity::loop()` also treats `wasLightPanelGesture()` as a close. Preserved as written rather than collapsed; worth deciding which layer should own it.

## Testing

- [x] `pio run` (default) — SUCCESS, RAM 17.3%, Flash 86.4%
- [x] `./bin/clang-format-fix -g` clean
- [ ] On-device: panel toggles via swipe and status-bar tap; Up/Down and page buttons step brightness in the right direction on X4 Pro
- [x] On-device: shared-button boards — Page Turn / Footnotes / Word Lookup respond to a short press