### PR TITLE
fix(reader): reload vertical chapters after overlay jumps

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4377,6 +4377,7 @@ void EpubReaderActivity::handleOverlayInput() {
       nextPageNumber = 0;
       currentSpineIndex = target;
       section.reset();
+      verticalSection.reset();
     }
     requestUpdate();
   };
@@ -4499,6 +4500,7 @@ void EpubReaderActivity::handleOverlayInput() {
         pendingAnchor = item.anchor;
         nextPageNumber = 0;
         section.reset();
+        verticalSection.reset();
       }
       overlay = Overlay::None;
       discardOverlayPage();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Keep the rendered text synchronized with chapter changes made through the reader overlay.
* **What changes are included?** Reset the vertical section cache alongside the horizontal cache for toolbar chapter arrows, scrubbing, and Contents-panel jumps.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable.

## Additional Context

* Root cause: overlay navigation changed the spine index but retained the previous `verticalSection`, so the footer showed the new chapter while the old text remained visible.
* Verified on device with a private build.
* `clang-format`, `git diff --check`, `pio check`, and the full default firmware build pass.
* No HAL, `freeink-sdk/`, memory, or flash impact.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
