### PR TITLE
fix(reader): hide irrelevant Japanese text settings

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4093,16 +4093,24 @@ std::string EpubReaderActivity::currentChapterTitle() const {
   return tr(STR_UNNAMED);
 }
 
-// Vertical Text / Furigana only mean anything for Japanese content, so a Latin book
-// sees upstream's five rows and nothing dead.
-int EpubReaderActivity::textRowCount() const { return showVerticalToggle() ? kTextRowCount : kBaseTextRowCount; }
+// Japanese books omit Paragraph Alignment and Focus Reading; Vertical Text / Furigana
+// take their place. Latin books keep the upstream rows.
+int EpubReaderActivity::textRowCount() const {
+  return isJapaneseBook() ? kBaseTextRowCount : showVerticalToggle() ? kTextRowCount : kBaseTextRowCount;
+}
+
+int EpubReaderActivity::textRowAt(const int visibleIndex) const {
+  return isJapaneseBook() && visibleIndex >= 3 ? visibleIndex + 2 : visibleIndex;
+}
 
 std::string EpubReaderActivity::textRowName(int row) const {
-  return row >= 0 && row < textRowCount() ? I18N.get(kTextRowNames[row]) : "";
+  if (row < 0 || row >= textRowCount()) return "";
+  return I18N.get(kTextRowNames[textRowAt(row)]);
 }
 
 std::string EpubReaderActivity::textRowValue(int row) const {
   static constexpr StrId kFamily[] = {StrId::STR_NOTO_SERIF, StrId::STR_NOTO_SANS};
+  row = textRowAt(row);
   switch (row) {
     case 0:
       if (SETTINGS.sdFontFamilyName[0] != '\0') return SETTINGS.sdFontFamilyName;
@@ -4455,14 +4463,16 @@ void EpubReaderActivity::handleOverlayInput() {
   const auto activateRow = [this, count, &fastRedraw] {
     if (panelIndex < 0 || panelIndex >= count) return;
     if (overlay == Overlay::Text) {
-      if (panelIndex == 0) {
+      const int row = textRowAt(panelIndex);
+      if (row == 0) {
         // Full font picker (built-in + SD fonts, live preview) -- the same
         // screen Settings uses; a popup cannot scroll a long font list.
         overlay = Overlay::None;
         overlayPopup.dismiss();
         discardOverlayPage();
         startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                                      TextSettingsActivity::Tab::Family),
+                                                                      TextSettingsActivity::Tab::Family,
+                                                                      isJapaneseBook(), useVerticalText()),
                                [this](const ActivityResult&) {
                                  applyReaderTextSettings();
                                  overlay = Overlay::Text;  // back to the Text panel
@@ -4470,17 +4480,16 @@ void EpubReaderActivity::handleOverlayInput() {
                                  if (toolbarUi) toolbarUi->begin();  // the picker drew its own FUI screen
                                  requestUpdate();                    // re-render page + Text panel
                                });
-      } else if (panelIndex == 4) {
+      } else if (row == 4) {
         // Focus Reading is a genuine on/off: a tap toggles and applies live.
         SETTINGS.focusReadingEnabled = SETTINGS.focusReadingEnabled ? 0 : 1;
         applyTextSettingLive();
-      } else if (panelIndex == kRowVerticalText || panelIndex == kRowFurigana) {
+      } else if (row == kRowVerticalText || row == kRowFurigana) {
         // This fork's per-book overrides, toggled in place like Focus Reading. Pass the
         // other one's CURRENT state so applyVerticalFuriganaOverride() leaves it alone --
         // it acts only on a value that differs from what is in effect.
-        const int8_t vertical =
-            panelIndex == kRowVerticalText ? (useVerticalText() ? 0 : 1) : (useVerticalText() ? 1 : 0);
-        const int8_t furigana = panelIndex == kRowFurigana ? (useFurigana() ? 0 : 1) : (useFurigana() ? 1 : 0);
+        const int8_t vertical = row == kRowVerticalText ? (useVerticalText() ? 0 : 1) : (useVerticalText() ? 1 : 0);
+        const int8_t furigana = row == kRowFurigana ? (useFurigana() ? 0 : 1) : (useFurigana() ? 1 : 0);
         applyVerticalFuriganaOverride(vertical, furigana);
         // Toggling vertical drops the section; furigana is a section-cache layout
         // parameter, so the next render rebuilds on the mismatch. Either way the stored
@@ -4489,7 +4498,7 @@ void EpubReaderActivity::handleOverlayInput() {
         requestUpdate();
       } else {
         // Enum rows open the Settings-style option picker.
-        showTextRowPopup(panelIndex);
+        showTextRowPopup(row);
       }
     } else if (overlay == Overlay::Contents) {
       const auto item = epub->getTocItem(panelIndex);

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -427,6 +427,7 @@ class EpubReaderActivity final : public ReaderActivity {
   // Text panel rows (font, size, line spacing, alignment, focus reading, and for
   // Japanese content this fork's vertical text / furigana toggles).
   int textRowCount() const;
+  int textRowAt(int visibleIndex) const;
   std::string textRowName(int row) const;
   std::string textRowValue(int row) const;
   void showTextRowPopup(int row);

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -494,12 +494,13 @@ void SettingsActivity::toggleCurrentSetting() {
                                });
         break;
       case SettingAction::TextSettings:
-        startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
-                                                                      TextSettingsActivity::Tab::Family, japaneseBook),
-                               [this](const ActivityResult&) {
-                                 saveSettings();
-                                 rebuildSettingsLists();
-                               });
+        startActivityForResult(
+            std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
+                                                   TextSettingsActivity::Tab::Family, japaneseBook, verticalTextState),
+            [this](const ActivityResult&) {
+              saveSettings();
+              rebuildSettingsLists();
+            });
         break;
       case SettingAction::Language:
         // Row labels are translated once in rebuildRowItems() and don't

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -59,11 +59,13 @@ constexpr int MARGIN_STEP = CrossPointSettings::SCREEN_MARGIN_STEP;
 }  // namespace
 
 TextSettingsActivity::TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                           const SdCardFontRegistry* registry, Tab initialTab, const bool japaneseBook)
+                                           const SdCardFontRegistry* registry, Tab initialTab, const bool japaneseBook,
+                                           const bool verticalText)
     : UiTabListActivity("TextSettings", renderer, mappedInput),
       registry_(registry),
       tab_(initialTab),
-      japaneseBook_(japaneseBook) {}
+      japaneseBook_(japaneseBook),
+      verticalText_(verticalText) {}
 
 const char* TextSettingsActivity::tabLabel(const int index) const { return I18N.get(TAB_NAME_IDS[index]); }
 
@@ -142,7 +144,7 @@ void TextSettingsActivity::rebuildRowItems() {
         item.label = I18N.get(LAYOUT_ROW_NAME_IDS[static_cast<int>(layoutRowAt(i))]);
         break;
       case Tab::Style:
-        item.label = I18N.get(STYLE_ROW_NAME_IDS[i]);
+        item.label = I18N.get(STYLE_ROW_NAME_IDS[static_cast<int>(styleRowAt(i))]);
         break;
       default:
         break;
@@ -258,8 +260,8 @@ void TextSettingsActivity::buildScreen(UiScreen& screen) {
         break;
       }
       case Tab::Style:
-        // Every Style row is on/off, so this tab is all switches and has no value text.
-        rowItems_[i].toggle = styleRowIsSwitch(i, checked);
+        // Every visible Style row is on/off, so this tab is all switches and has no value text.
+        rowItems_[i].toggle = styleRowIsSwitch(static_cast<int>(styleRowAt(i)), checked);
         break;
       default:
         break;
@@ -395,7 +397,7 @@ void TextSettingsActivity::activateRow(int row) {
       confirmLayoutRow(static_cast<int>(layoutRowAt(row)));
       break;
     case Tab::Style:
-      confirmStyleRow(row);
+      confirmStyleRow(static_cast<int>(styleRowAt(row)));
       break;
     default:
       break;
@@ -525,13 +527,13 @@ void TextSettingsActivity::confirmStyleRow(int row) {
 // have no distinct preview.
 bool TextSettingsActivity::focusedRowHasNoPreview() const {
   if (ringPos() == 0 || tab_ != Tab::Style) return false;
-  const StyleRow row = static_cast<StyleRow>(ringPos() - 1);
+  const StyleRow row = styleRowAt(ringPos() - 1);
   return row == StyleRow::Hyphenation || row == StyleRow::EmbeddedStyle || row == StyleRow::AntiAliasing;
 }
 
 void TextSettingsActivity::switchTab(const int direction) {
   const bool onTabBar = ringPos() == 0;
-  const int count = tabCount();  // a Japanese book hides the Style tab
+  const int count = tabCount();
   tab_ = static_cast<Tab>((static_cast<int>(tab_) + direction + count) % count);
   rebuildRowItems();
   auto& n = activeNav();
@@ -551,17 +553,20 @@ int TextSettingsActivity::listCount() const {
       // layout inputs the vertical engine does not read.
       return static_cast<int>(LayoutRow::Count) - (japaneseBook_ ? 3 : 0);
     case Tab::Style:
-      return static_cast<int>(StyleRow::Count);
+      return japaneseBook_ ? (verticalText_ ? 1 : 2) : static_cast<int>(StyleRow::Count);
     default:
       return 0;
   }
 }
 
-int TextSettingsActivity::tabCount() const {
-  return japaneseBook_ ? static_cast<int>(Tab::Style) : static_cast<int>(Tab::Count);
-}
+int TextSettingsActivity::tabCount() const { return static_cast<int>(Tab::Count); }
 
 TextSettingsActivity::LayoutRow TextSettingsActivity::layoutRowAt(const int visibleIndex) const {
   if (japaneseBook_ && visibleIndex > 0) return LayoutRow::ScreenMargin;
   return static_cast<LayoutRow>(visibleIndex);
+}
+
+TextSettingsActivity::StyleRow TextSettingsActivity::styleRowAt(const int visibleIndex) const {
+  if (!japaneseBook_) return static_cast<StyleRow>(visibleIndex);
+  return visibleIndex == 0 ? StyleRow::EmbeddedStyle : StyleRow::AntiAliasing;
 }

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -30,7 +30,7 @@ class TextSettingsActivity final : public UiTabListActivity {
   };
 
   TextSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const SdCardFontRegistry* registry,
-                       Tab initialTab = Tab::Family, bool japaneseBook = false);
+                       Tab initialTab = Tab::Family, bool japaneseBook = false, bool verticalText = false);
 
   void onEnter() override;
   void render(RenderLock&&) override;
@@ -78,6 +78,8 @@ class TextSettingsActivity final : public UiTabListActivity {
   // Maps a visible list position to its LayoutRow: a Japanese book hides ParaSpacing,
   // Alignment and BookSideMargins, so position and enum value diverge.
   LayoutRow layoutRowAt(int visibleIndex) const;
+  // Japanese books hide FocusReading/Hyphenation; vertical Japanese also hides AntiAliasing.
+  StyleRow styleRowAt(int visibleIndex) const;
   // Sentinel settingIndex for the "Manage Fonts" row appended to the family list. It opens
   // FontDownloadActivity instead of selecting a font -- the shortcut the pre-1.5.0 font
   // picker had at the bottom of its list, so "the font I want isn't here" is one press away.
@@ -88,6 +90,7 @@ class TextSettingsActivity final : public UiTabListActivity {
   // Rebuilds fonts_ (families installed on the card can change while this screen is open).
   void rebuildFamilyList();
   const bool japaneseBook_ = false;
+  const bool verticalText_ = false;
 
   // Row storage for the active tab: rowItems_ (label/actionValue) is
   // rebuilt only when the tab or its backing data changes (rebuildRowItems(),


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Hide reader settings that do not apply to Japanese books.
* **What changes are included?**
  * Hides paragraph alignment, extra paragraph spacing, focus reading, and hyphenation for horizontal and vertical Japanese books.
  * Hides text anti-aliasing only for vertical Japanese books.
  * Applies the same visibility rules to the full settings screen and toolbar reader menu.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Embedded Style remains available for Japanese books; anti-aliasing remains available for horizontal Japanese text.
* No `freeink-sdk/`, HAL, bootloader, OTA, or recovery changes.
* Checks: clang-format, `git diff --check`, `pio check`, and `pio run`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
