### PR TITLE
fix(reader): use switches in toolbar menu

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4074,6 +4074,7 @@ constexpr StrId kAlignIds[] = {StrId::STR_JUSTIFY, StrId::STR_ALIGN_LEFT, StrId:
 constexpr int kTextRowCount = static_cast<int>(std::size(kTextRowNames));
 // Rows every book gets; the two beyond this are Japanese-only.
 constexpr int kBaseTextRowCount = 5;
+constexpr int kRowFocusReading = 4;
 constexpr int kRowVerticalText = 5;
 constexpr int kRowFurigana = 6;
 static_assert(std::size(kSpacingIds) == CrossPointSettings::LINE_COMPRESSION_COUNT, "line spacing labels");
@@ -4329,11 +4330,34 @@ void EpubReaderActivity::renderOverlay() {
     model.itemCount = textRowCount();
     model.rowText = [this](int i) { return textRowName(i); };
     model.rowValue = [this](int i) { return textRowValue(i); };
+    model.rowToggleState = [this](int i) {
+      switch (textRowAt(i)) {
+        case kRowFocusReading:
+          return SETTINGS.focusReadingEnabled ? 1 : 0;
+        case kRowVerticalText:
+          return useVerticalText() ? 1 : 0;
+        case kRowFurigana:
+          return useFurigana() ? 1 : 0;
+        default:
+          return -1;
+      }
+    };
   } else {
     model.panelTitle = tr(STR_TOOL_MORE);
     model.itemCount = static_cast<int>(moreItems.size());
     model.rowText = [this](int i) { return moreRowName(i); };
     model.rowValue = [this](int i) { return moreRowValue(i); };
+    model.rowToggleState = [this](int i) {
+      if (i < 0 || i >= static_cast<int>(moreItems.size())) return -1;
+      switch (moreItems[i].action) {
+        case EpubReaderMenuActivity::MenuAction::NIGHT_MODE:
+          return SETTINGS.screenInverted ? 1 : 0;
+        case EpubReaderMenuActivity::MenuAction::FRONTLIGHT:
+          return Frontlight.isOn() ? 1 : 0;
+        default:
+          return -1;
+      }
+    };
   }
   toolbarUi->setModel(model);
   toolbarUi->render();
@@ -4480,7 +4504,7 @@ void EpubReaderActivity::handleOverlayInput() {
                                  if (toolbarUi) toolbarUi->begin();  // the picker drew its own FUI screen
                                  requestUpdate();                    // re-render page + Text panel
                                });
-      } else if (row == 4) {
+      } else if (row == kRowFocusReading) {
         // Focus Reading is a genuine on/off: a tap toggles and applies live.
         SETTINGS.focusReadingEnabled = SETTINGS.focusReadingEnabled ? 0 : 1;
         applyTextSettingLive();

--- a/src/activities/reader/ReaderToolbarUi.cpp
+++ b/src/activities/reader/ReaderToolbarUi.cpp
@@ -10,6 +10,7 @@
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "components/icons/readerToolbarIcons.h"
 
 namespace fui = freeink::ui;
@@ -260,11 +261,14 @@ void ReaderToolbarUi::buildPanel(UiScreen& screen) {
   const int windowCount = std::min({nav_.visibleRows, count - nav_.top, kMaxWindow});
   for (int i = 0; i < windowCount; ++i) {
     const int index = nav_.top + i;
+    const int toggleState = model_.rowToggleState ? model_.rowToggleState(index) : -1;
     windowLabels_[i] = model_.rowText ? model_.rowText(index) : std::string();
-    windowValues_[i] = model_.rowValue ? model_.rowValue(index) : std::string();
+    windowValues_[i] = toggleState < 0 && model_.rowValue ? model_.rowValue(index) : std::string();
     fui::ListItem item;
     item.label = windowLabels_[i].c_str();
     item.value = windowValues_[i].empty() ? nullptr : windowValues_[i].c_str();
+    item.toggle = toggleState >= 0;
+    item.toggleChecked = toggleState > 0;
     item.actionValue = static_cast<int16_t>(index);
     windowItems_[i] = item;
   }
@@ -273,6 +277,7 @@ void ReaderToolbarUi::buildPanel(UiScreen& screen) {
   listProps_.itemsWindowCount = static_cast<uint16_t>(std::max(0, windowCount));
   listProps_.valueText = tokens.bodyText;
   listProps_.valueText.bold = true;
+  applySwitchStyle(listProps_);
   if (count > 0) {
     screen.list(listProps_);
   }

--- a/src/activities/reader/ReaderToolbarUi.h
+++ b/src/activities/reader/ReaderToolbarUi.h
@@ -39,6 +39,8 @@ class ReaderToolbarUi : public UiAppHost {
     int selectedIndex = -1;  // row the buttons' cursor sits on; -1 = none shown
     std::function<std::string(int)> rowText;
     std::function<std::string(int)> rowValue;
+    // -1 = regular value row, 0 = unchecked switch, 1 = checked switch.
+    std::function<int(int)> rowToggleState;
     // Tile row: the tool in focus (toolbar) / the open panel (panel). 0..2.
     int activeTool = 0;
     // Pixels kept free along the screen's bottom edge under the panel sheet


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Use the standard pill switches for binary settings in the floating reader menu.
* **What changes are included?**
  * Adds explicit switch-state metadata to floating-menu rows.
  * Renders Focus Reading, Vertical Text, Furigana, Night Mode, and Frontlight as switches instead of ON/OFF text.
  * Leaves enum and numeric rows unchanged.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Toggle state is explicit and does not depend on translated ON/OFF labels.
* Reuses the existing app-wide switch styling helper.
* No `freeink-sdk/`, HAL, bootloader, OTA, or recovery changes.
* Checks: clang-format, `git diff --check`, `pio check`, and `pio run`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
