### PR TITLE
fix: keep every page of a chapter-foldered archive, in reading order

### DIFF
--- a/tools/manga_convert/convert_manga.py
+++ b/tools/manga_convert/convert_manga.py
@@ -170,43 +170,101 @@ def _natural_sort_key(path: str):
         return [(-2, 0, '')]
     if 'copyright' in lower:
         return [(-1, 0, '')]
+    # Built from the WHOLE path given, not just the basename: archives that put each
+    # chapter in its own folder restart page numbering inside it, so "ch01/001.jpg" and
+    # "ch08/001.jpg" share a basename and sorting on that interleaves the chapters.
+    # Callers pass a path relative to the extraction root, which for a flat book is
+    # exactly the basename -- so nothing changes for those.
     parts: list[tuple] = []
     i = 0
-    while i < len(name):
-        if name[i].isdigit():
+    while i < len(path):
+        if path[i].isdigit():
             j = i
-            while j < len(name) and name[j].isdigit():
+            while j < len(path) and path[j].isdigit():
                 j += 1
-            num_str = name[i:j].lstrip("0") or ""
+            num_str = path[i:j].lstrip("0") or ""
             parts.append((0, len(num_str), num_str))
             i = j
         else:
-            parts.append((1, 0, name[i].lower()))
+            parts.append((1, 0, path[i].lower()))
             i += 1
     return parts
+
+
+def _safe_archive_path(name: str) -> str | None:
+    """An archive member's path as a relative POSIX path, or None if it escapes.
+
+    Preserving the archive's folder structure means the member name now reaches the
+    filesystem, so absolute paths and ".." components have to be rejected here (zip
+    slip). The old basename-only extraction was inherently safe and needed no check.
+    """
+    norm = name.replace("\\", "/")
+    if norm.startswith("/") or (len(norm) > 1 and norm[1] == ":"):
+        return None
+    parts = []
+    for seg in norm.split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            return None
+        parts.append(seg)
+    return "/".join(parts) if parts else None
+
+
+def _sort_path(img: str, root: str | None) -> str:
+    """The path to sort an image by: relative to its extraction root, POSIX separators.
+
+    For a flat book this is just the basename, so ordering is unchanged; for a
+    chapter-foldered one it keeps the folder in the key, which is what puts ch01's
+    pages before ch02's.
+    """
+    if root:
+        try:
+            rel = os.path.relpath(img, root)
+        except ValueError:
+            rel = os.path.basename(img)
+        if not rel.startswith(".."):
+            return rel.replace(os.sep, "/")
+    return os.path.basename(img)
 
 
 def collect_pages(input_path: str, work_dir: str, page_order_file: str | None) -> list[str]:
     """Return an ordered list of source page image paths."""
     p = Path(input_path)
 
+    sort_root: str | None = None
+
     if p.is_dir():
-        images = [str(f) for f in p.iterdir() if f.is_file() and is_image(str(f))]
+        # Recursive: a folder of chapter subfolders used to yield nothing at all.
+        images = [str(f) for f in p.rglob("*") if f.is_file() and is_image(str(f))]
+        sort_root = str(p)
     elif p.suffix.lower() in (".cbz", ".zip"):
         extract_dir = os.path.join(work_dir, "extracted")
         os.makedirs(extract_dir, exist_ok=True)
+        # The archive's folders are preserved. Extracting everything into one directory
+        # by basename silently dropped pages: a chapter-foldered book repeats 001.jpg in
+        # every chapter, so each one overwrote the last and only the final chapter's
+        # numbering survived, interleaved into what reads as jumbled chapters.
         with zipfile.ZipFile(str(p), "r") as zf:
             for info in zf.infolist():
                 if info.is_dir() or not is_image(info.filename):
                     continue
-                target = os.path.join(extract_dir, os.path.basename(info.filename))
+                rel = _safe_archive_path(info.filename)
+                if rel is None:
+                    print(f"Warning: skipping unsafe archive path {info.filename!r}", file=sys.stderr)
+                    continue
+                target = os.path.join(extract_dir, *rel.split("/"))
+                os.makedirs(os.path.dirname(target), exist_ok=True)
                 with zf.open(info) as src, open(target, "wb") as dst:
                     shutil.copyfileobj(src, dst)
-        images = [str(f) for f in Path(extract_dir).iterdir() if is_image(str(f))]
+        images = [str(f) for f in Path(extract_dir).rglob("*") if f.is_file() and is_image(str(f))]
+        sort_root = extract_dir
     elif p.suffix.lower() == ".epub":
         images = _extract_epub_pages(str(p), work_dir)
+        sort_root = os.path.join(work_dir, "epub_extracted")
     elif p.suffix.lower() == ".pdf":
         images = _extract_pdf_pages(str(p), work_dir)
+        sort_root = os.path.dirname(images[0]) if images else None
     else:
         print(f"Error: unsupported input: {p}", file=sys.stderr)
         sys.exit(1)
@@ -218,19 +276,30 @@ def collect_pages(input_path: str, work_dir: str, page_order_file: str | None) -
     if page_order_file:
         with open(page_order_file, "r", encoding="utf-8") as f:
             order_names = [line.strip() for line in f if line.strip()]
-        by_name = {os.path.basename(img): img for img in images}
+        # Listed by path relative to the archive root, so a chapter-foldered book can
+        # name "ch01/001.jpg". A bare basename still works when it is unambiguous.
+        by_rel = {_sort_path(img, sort_root): img for img in images}
+        base_counts: dict[str, int] = {}
+        for img in images:
+            base_counts[os.path.basename(img)] = base_counts.get(os.path.basename(img), 0) + 1
+        by_base = {os.path.basename(img): img for img in images
+                   if base_counts[os.path.basename(img)] == 1}
         ordered = []
+        used = set()
         for name in order_names:
-            if name not in by_name:
+            key = name.replace(os.sep, "/")
+            img = by_rel.get(key) or by_base.get(key)
+            if img is None:
                 print(f"Warning: {name} from --page-order-file not found among extracted images", file=sys.stderr)
                 continue
-            ordered.append(by_name[name])
-        missing = [img for img in images if os.path.basename(img) not in order_names]
+            ordered.append(img)
+            used.add(img)
+        missing = [img for img in images if img not in used]
         if missing:
             print(f"Warning: {len(missing)} images not listed in --page-order-file are dropped", file=sys.stderr)
         return ordered
 
-    images.sort(key=_natural_sort_key)
+    images.sort(key=lambda img: _natural_sort_key(_sort_path(img, sort_root)))
     return images
 
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop silently losing most of a CBZ that puts each chapter in its own folder, and stop the survivors coming out in a jumbled order.

  A chapter-foldered archive restarts page numbering inside each folder, so `ch01/001.jpg` and `ch08/001.jpg` share a basename. Every member was extracted into one flat directory named by that basename, so each chapter's page 1 overwrote the last and only the final chapter's numbering survived — with nothing in the output to say pages had been dropped. A nine-image test archive across three folders converted to **three** pages:

  ```
  BEFORE                    AFTER
  Found 3 pages             Found 9 pages
  [1/3] 001.png             [1/9] ch01/001.png
  [2/3] 002.png             [2/9] ch01/002.png
  [3/3] 003.png             [3/9] ch01/003.png
                            [4/9] ch02/001.png  ...
  ```

* **What changes are included?**
  * The archive's folder structure is preserved on extraction, and the sort key is built from the path **relative to the extraction root** instead of the basename — so `ch01`'s pages precede `ch02`'s and chapter numbers still compare numerically (`ch2` before `ch10`).
  * `_safe_archive_path()` rejects absolute paths and `..` components. Preserving folders means a member name reaches the filesystem for the first time, so this is a **zip-slip guard**; the old basename-only extraction was inherently safe and needed no check.
  * A directory input is walked **recursively** — a folder of chapter subfolders previously yielded no images at all.
  * `--page-order-file` entries may now be paths relative to the archive root, the only way to name a page unambiguously in a foldered book. A bare basename still resolves when unique, so existing order files keep working.

### How this was found

A user reported the XTCH export from [matcha-reader-tools](https://github.com/eszter007/matcha-reader-tools) coming out with jumbled pages and panels. Decoding the actual `.xtch` showed a structurally perfect container — 365 pages, uniform 528×792, consistent offsets — with each page correctly followed by its own panels, but "CHAPTER 8: NAMI" at position 2 and "CHAPTER 1: ROMANCE DAWN" at position 30, front matter interleaved among story pages. That is what last-writer-wins basename collapse looks like. The JS port had the identical bug for the identical reason.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. This is a correctness fix to this repo's own conversion tool, not a new capability.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code — it is confined to `tools/manga_convert/convert_manga.py`.

## Additional Context

* **No firmware impact.** Host-side conversion tool only: no memory or flash cost, no device code changes. Output filenames on the device are unchanged (`page_NNNN.ext`), so device-side sorting is untouched.
* **Flat books are unaffected.** With no directory component the relative path *is* the basename, so the key is identical. Verified by regenerating the matcha-reader-tools reference fixtures with this build — `ref_manga`, `ref_manga_epub` and `ref_manga_pdf` all byte-identical — and its two suites still pass against them.
* **EPUB and PDF paths are unchanged.** Both already extract into a flat directory (`spine_NNNN_` prefixes preserve spine order), so their relative paths equal their basenames.
* **Cross-checked against the JS port.** The matching fix is already on matcha-reader-tools `main`; both tools were run against the same foldered archive and produce exactly the same page order.
* **Worth a reviewer's eye:** `_safe_archive_path`. It rejects `/etc/passwd.png`, `../../evil.png`, `ch01/../../evil.png` and `C:\x.png`, and normalises `./a/./b.png` → `a/b.png` and `ch01//002.png` → `ch01/002.png`.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — diagnosed from the user's decoded `.xtch`, then written and verified by Claude Code, including the before/after conversion, the reference-fixture regeneration, and the cross-check against the JS port.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czv7mJXXXujZLNgDgrPpgx)_