### PR TITLE
fix: let the file browsers delete hidden files and full folders

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -135,7 +135,7 @@ See [Reading Mode](#4-reading-mode) below for more information.
 
 ### 3.3 Browse Files Screen
 
-The Browse Files screen acts as a file and folder browser. The full path to the current directory is shown at the top of the screen. File extensions are displayed alongside each filename, and directories are shown with brackets (e.g. `[folder-name]`). Hidden entries — those beginning with `.`, plus `System Volume Information` — appear only when **Settings → System → Show Hidden Files** is enabled. Turning it on is also what makes the folders macOS leaves behind on a card (`.Spotlight-V100`, `.Trashes`) selectable, so they can be deleted.
+The Browse Files screen acts as a file and folder browser. The full path to the current directory is shown at the top of the screen. File extensions are displayed alongside each filename, and directories are shown with brackets (e.g. `[folder-name]`). Hidden entries — those beginning with `.` — appear only when **Settings → System → Show Hidden Files** is enabled. Turning it on is also what makes the folders macOS leaves behind on a card (`.Spotlight-V100`, `.Trashes`) selectable, so they can be deleted. `System Volume Information` stays hidden either way.
 
 * **Navigate List:** Use **Left** (or **Volume Up**), or **Right** (or **Volume Down**) to move the selection cursor up and down through folders and books. You can also long-press these buttons to scroll a full page up or down.
 * **Open Selection:** Press **Confirm** to open a folder or start reading a selected book. Selecting a `.bmp` file will open the image viewer.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -135,11 +135,11 @@ See [Reading Mode](#4-reading-mode) below for more information.
 
 ### 3.3 Browse Files Screen
 
-The Browse Files screen acts as a file and folder browser. The full path to the current directory is shown at the top of the screen. File extensions are displayed alongside each filename, and directories are shown with brackets (e.g. `[folder-name]`). Hidden directories (those beginning with `.`) are also visible.
+The Browse Files screen acts as a file and folder browser. The full path to the current directory is shown at the top of the screen. File extensions are displayed alongside each filename, and directories are shown with brackets (e.g. `[folder-name]`). Hidden entries — those beginning with `.`, plus `System Volume Information` — appear only when **Settings → System → Show Hidden Files** is enabled. Turning it on is also what makes the folders macOS leaves behind on a card (`.Spotlight-V100`, `.Trashes`) selectable, so they can be deleted.
 
 * **Navigate List:** Use **Left** (or **Volume Up**), or **Right** (or **Volume Down**) to move the selection cursor up and down through folders and books. You can also long-press these buttons to scroll a full page up or down.
 * **Open Selection:** Press **Confirm** to open a folder or start reading a selected book. Selecting a `.bmp` file will open the image viewer.
-* **Delete Files or Folders:** Hold and release **Confirm** to delete the selected file or folder. You will be given an option to either confirm or cancel. Multiple files can be selected for deletion in a single operation.
+* **Delete Files or Folders:** Hold and release **Confirm** to delete the selected file or folder. You will be given an option to either confirm or cancel. Multiple files can be selected for deletion in a single operation. Deleting a folder removes everything inside it.
 * **Rename or Move:** Files can be renamed or moved to a different folder from within the browse screen.
 
 ### 3.4 Recent Books Screen

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -78,9 +78,9 @@ Response:
 ]
 ```
 
-Hidden dotfiles, `System Volume Information` and `XTCache` are all omitted
-unless the device setting `showHiddenFiles` is enabled. Everything the listing
-shows can be deleted.
+Hidden dotfiles are omitted unless the device setting `showHiddenFiles` is
+enabled. `System Volume Information` and `XTCache` are always hidden and
+protected. Everything else the listing shows can be deleted.
 
 ### `GET /download`
 
@@ -194,8 +194,8 @@ Form parameters:
 | `path` | Yes, unless `paths` is provided | Single path to delete |
 | `paths` | Yes, unless `path` is provided | JSON array of paths to delete |
 
-Only the card root is refused. EPUB cache data for deleted files is cleared as
-the folder is walked.
+The card root and protected items are refused; dotfiles are not. EPUB cache
+data for deleted files is cleared as the folder is walked.
 
 ## Settings API
 

--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -78,8 +78,9 @@ Response:
 ]
 ```
 
-Hidden dotfiles are omitted unless the device setting `showHiddenFiles` is
-enabled. `System Volume Information` and `XTCache` are always hidden/protected.
+Hidden dotfiles, `System Volume Information` and `XTCache` are all omitted
+unless the device setting `showHiddenFiles` is enabled. Everything the listing
+shows can be deleted.
 
 ### `GET /download`
 
@@ -178,7 +179,8 @@ cleared before the move.
 
 ### `POST /delete`
 
-Deletes one or more files or empty folders.
+Deletes one or more files or folders. A folder is removed with everything
+inside it.
 
 ```bash
 curl -X POST -d "path=/Books/mybook.epub" http://crosspoint.local/delete
@@ -192,8 +194,8 @@ Form parameters:
 | `path` | Yes, unless `paths` is provided | Single path to delete |
 | `paths` | Yes, unless `path` is provided | JSON array of paths to delete |
 
-Protected items cannot be deleted. Non-empty folders are rejected. EPUB cache
-data for deleted files is cleared.
+Only the card root is refused. EPUB cache data for deleted files is cleared as
+the folder is walked.
 
 ## Settings API
 

--- a/docs/webserver.md
+++ b/docs/webserver.md
@@ -94,7 +94,7 @@ The File Manager page can:
 - Download files
 - Rename files
 - Move files into existing folders
-- Delete one or more selected files or empty folders
+- Delete one or more selected files or folders, including their contents
 
 Existing files with the same name are overwritten by uploads. When EPUB files
 are overwritten, moved, renamed, or deleted through the web server, the matching

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -57,11 +57,11 @@ void FileBrowserActivity::loadFiles() {
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(fileNameBuffer.get(), NAME_BUFFER_SIZE);
     const bool isDirectory = file.isDirectory();
-    // "System Volume Information" is hidden alongside the dot entries rather
-    // than unconditionally: an item that never lists can never be deleted, and
-    // the filesystem leftovers are exactly what users want to clear off a card.
-    if (!SETTINGS.showHiddenFiles &&
-        (fileNameBuffer[0] == '.' || strcmp(fileNameBuffer.get(), "System Volume Information") == 0)) {
+    // Dot entries are a display preference and come back with Show Hidden
+    // Files; "System Volume Information" is the filesystem's own bookkeeping
+    // and stays out of the listing either way.
+    if ((!SETTINGS.showHiddenFiles && fileNameBuffer[0] == '.') ||
+        strcmp(fileNameBuffer.get(), "System Volume Information") == 0) {
       continue;
     }
 

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -18,6 +18,7 @@
 #include "components/UiAppHelpers.h"
 #include "fontIds.h"
 #include "util/BookCacheUtils.h"
+#include "util/DeleteUtils.h"
 
 namespace fui = freeink::ui;
 
@@ -56,8 +57,11 @@ void FileBrowserActivity::loadFiles() {
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
     file.getName(fileNameBuffer.get(), NAME_BUFFER_SIZE);
     const bool isDirectory = file.isDirectory();
-    if ((!SETTINGS.showHiddenFiles && fileNameBuffer[0] == '.') ||
-        strcmp(fileNameBuffer.get(), "System Volume Information") == 0) {
+    // "System Volume Information" is hidden alongside the dot entries rather
+    // than unconditionally: an item that never lists can never be deleted, and
+    // the filesystem leftovers are exactly what users want to clear off a card.
+    if (!SETTINGS.showHiddenFiles &&
+        (fileNameBuffer[0] == '.' || strcmp(fileNameBuffer.get(), "System Volume Information") == 0)) {
       continue;
     }
 
@@ -208,87 +212,6 @@ void FileBrowserActivity::onExit() {
   fileNameBuffer.reset();
 }
 
-// To avoid traversing directories twice (once for cache clearing, once for deletion),
-// we do both in one pass here, instead of using Storage.removeDir
-bool FileBrowserActivity::removeDirFile(const std::string& fullPath) {
-  auto file = Storage.open(fullPath.c_str());
-  if (!file) {
-    LOG_ERR("FileBrowser", "Failed to open for metadata clearing: %s", fullPath.c_str());
-    return false;
-  }
-
-  if (!file.isDirectory()) {
-    file.close();
-    clearBookCache(fullPath);
-    return Storage.remove(fullPath.c_str());
-  }
-  file.close();
-
-  if (!fileNameBuffer) {
-    LOG_ERR("FileBrowser", "fileNameBuffer not allocated");
-    return false;
-  }
-
-  // Stack of (dirPath, postOrder): postOrder=true means rmdir this path after children are processed.
-  std::vector<std::pair<std::string, bool>> stack;
-  stack.reserve(16);
-  stack.push_back({fullPath, false});
-
-  while (!stack.empty()) {
-    auto [currentPath, postOrder] = std::move(stack.back());
-    stack.pop_back();
-
-    if (postOrder) {
-      if (!Storage.rmdir(currentPath.c_str())) {
-        LOG_ERR("FileBrowser", "Failed to rmdir: %s", currentPath.c_str());
-        return false;
-      }
-      continue;
-    }
-
-    auto dir = Storage.open(currentPath.c_str());
-    if (!dir) {
-      LOG_ERR("FileBrowser", "Failed to open dir: %s", currentPath.c_str());
-      return false;
-    }
-    if (!dir.isDirectory()) {
-      LOG_ERR("FileBrowser", "Not a directory: %s", currentPath.c_str());
-      return false;
-    }
-
-    // Push this dir for post-order rmdir (after all children are processed).
-    stack.push_back({currentPath, true});
-
-    dir.rewindDirectory();
-    for (auto entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
-      entry.getName(fileNameBuffer.get(), NAME_BUFFER_SIZE);
-      if (strcmp(fileNameBuffer.get(), ".") == 0 || strcmp(fileNameBuffer.get(), "..") == 0) {
-        continue;
-      }
-      std::string entryPath = currentPath;
-      if (entryPath.back() != '/') {
-        entryPath += "/";
-      }
-      entryPath += fileNameBuffer.get();
-
-      const bool isDir = entry.isDirectory();
-      entry.close();
-
-      if (isDir) {
-        stack.push_back({std::move(entryPath), false});
-      } else {
-        clearBookCache(entryPath);
-        if (!Storage.remove(entryPath.c_str())) {
-          LOG_ERR("FileBrowser", "Failed to remove file: %s", entryPath.c_str());
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
-
 void FileBrowserActivity::activateIndex(const int index) {
   (void)index;  // base already synced nav.selected to the tapped row
   // Activation navigates or opens; a lingering flash would gray an unrelated
@@ -334,7 +257,7 @@ void FileBrowserActivity::activateSelected(const bool forceDelete) {
     auto handler = [this, fullPath](const ActivityResult& res) {
       if (!res.isCancelled) {
         LOG_DBG("FileBrowser", "Attempting to delete: %s", fullPath.c_str());
-        if (removeDirFile(fullPath)) {
+        if (deletePathRecursive(fullPath)) {
           LOG_DBG("FileBrowser", "Deleted successfully");
           {
             // buildScreen() reads the row caches on the render task; see loop().

--- a/src/activities/home/FileBrowserActivity.h
+++ b/src/activities/home/FileBrowserActivity.h
@@ -13,9 +13,6 @@ class FileBrowserActivity final : public UiListActivity {
   enum class Mode { Books, PickFirmware };
 
  private:
-  // Deletion
-  bool removeDirFile(const std::string& fullPath);
-
   Mode mode = Mode::Books;
 
   // Files state

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -471,11 +471,11 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
     file.getName(name, sizeof(name));
     auto fileName = String(name);
 
-    // Dot entries and the filesystem's own bookkeeping folders are both hidden
-    // by default and both revealed by "Show hidden files" -- listing an item is
-    // what makes it deletable, so nothing is permanently out of reach.
+    // Dot entries are a display preference and come back with "Show hidden
+    // files"; the filesystem's own bookkeeping folders stay out of the listing
+    // either way.
     bool shouldHide = !SETTINGS.showHiddenFiles && fileName.startsWith(".");
-    if (!shouldHide && !SETTINGS.showHiddenFiles) {
+    if (!shouldHide) {
       for (const auto* item : HIDDEN_ITEMS) {
         if (fileName.equals(item)) {
           shouldHide = true;
@@ -1119,10 +1119,17 @@ void CrossPointWebServer::handleDelete() const {
       itemPath = "/" + itemPath;
     }
 
-    // Anything the listing shows can be deleted. The card is the user's, and a
-    // name-based veto here is what stranded the folders macOS leaves behind
-    // (.Spotlight-V100, .Trashes) with no way to remove them from either
-    // browser. Only the root above is refused, since it is the mount point.
+    // Anything the listing shows can be deleted -- vetoing every dot entry is
+    // what stranded the folders macOS leaves behind (.Spotlight-V100,
+    // .Trashes). Only the filesystem's own bookkeeping is still refused, and it
+    // never lists in the first place; /delete is a public endpoint, so the
+    // check stays here rather than resting on the UI not offering it.
+    const String itemName = itemPath.substring(itemPath.lastIndexOf('/') + 1);
+    if (isProtectedItemName(itemName)) {
+      failedItems += itemPath + " (protected file); ";
+      allSuccess = false;
+      continue;
+    }
 
     // Check if item exists
     if (!Storage.exists(itemPath.c_str())) {

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -28,6 +28,7 @@
 #include "html/SettingsPageHtml.generated.h"
 #include "html/js/jszip_minJs.generated.h"
 #include "util/BookCacheUtils.h"
+#include "util/DeleteUtils.h"
 #include "util/TaskWatchdog.h"
 
 namespace {
@@ -72,10 +73,13 @@ String normalizeWebPath(const String& inputPath) {
   return result;
 }
 
+// Only the filesystem's own bookkeeping is off-limits. A dot prefix is not a
+// protection marker: macOS strews `.Spotlight-V100`, `.Trashes` and `.fseventsd`
+// over the card, the listing already shows them when "Show hidden files" is on,
+// and treating every dot entry as protected is what made them undeletable.
+// Matches the on-device browser, which only ever special-cases
+// "System Volume Information".
 bool isProtectedItemName(const String& name) {
-  if (name.startsWith(".")) {
-    return true;
-  }
   for (const auto* item : HIDDEN_ITEMS) {
     if (name.equals(item)) {
       return true;
@@ -467,11 +471,11 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
     file.getName(name, sizeof(name));
     auto fileName = String(name);
 
-    // Skip hidden items (starting with ".")
+    // Dot entries and the filesystem's own bookkeeping folders are both hidden
+    // by default and both revealed by "Show hidden files" -- listing an item is
+    // what makes it deletable, so nothing is permanently out of reach.
     bool shouldHide = !SETTINGS.showHiddenFiles && fileName.startsWith(".");
-
-    // Check against explicitly hidden items list
-    if (!shouldHide) {
+    if (!shouldHide && !SETTINGS.showHiddenFiles) {
       for (const auto* item : HIDDEN_ITEMS) {
         if (fileName.equals(item)) {
           shouldHide = true;
@@ -1115,29 +1119,10 @@ void CrossPointWebServer::handleDelete() const {
       itemPath = "/" + itemPath;
     }
 
-    // Security check: prevent deletion of protected items
-    const String itemName = itemPath.substring(itemPath.lastIndexOf('/') + 1);
-
-    // Hidden/system files are protected
-    if (itemName.startsWith(".")) {
-      failedItems += itemPath + " (hidden/system file); ";
-      allSuccess = false;
-      continue;
-    }
-
-    // Check against explicitly protected items
-    bool isProtected = false;
-    for (const auto* item : HIDDEN_ITEMS) {
-      if (itemName.equals(item)) {
-        isProtected = true;
-        break;
-      }
-    }
-    if (isProtected) {
-      failedItems += itemPath + " (protected file); ";
-      allSuccess = false;
-      continue;
-    }
+    // Anything the listing shows can be deleted. The card is the user's, and a
+    // name-based veto here is what stranded the folders macOS leaves behind
+    // (.Spotlight-V100, .Trashes) with no way to remove them from either
+    // browser. Only the root above is refused, since it is the mount point.
 
     // Check if item exists
     if (!Storage.exists(itemPath.c_str())) {
@@ -1146,27 +1131,9 @@ void CrossPointWebServer::handleDelete() const {
       continue;
     }
 
-    // Decide whether it's a directory or file by opening it
-    bool success = false;
-    HalFile f = Storage.open(itemPath.c_str());
-    if (f && f.isDirectory()) {
-      // For folders, ensure empty before removing
-      HalFile entry = f.openNextFile();
-      if (entry) {
-        entry.close();
-        f.close();
-        failedItems += itemPath + " (folder not empty); ";
-        allSuccess = false;
-        continue;
-      }
-      f.close();
-      success = Storage.rmdir(itemPath.c_str());
-    } else {
-      // It's a file (or couldn't open as dir) — remove file
-      if (f) f.close();
-      success = Storage.remove(itemPath.c_str());
-      clearBookCache(itemPath.c_str());
-    }
+    // Folders are removed with their contents, the same walk the on-device
+    // browser uses -- it clears each book's reading cache as it goes.
+    const bool success = deletePathRecursive(std::string(itemPath.c_str()));
 
     if (!success) {
       failedItems += itemPath + " (deletion failed); ";

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 
 #include "util/BookCacheUtils.h"
+#include "util/DeleteUtils.h"
 #include "util/TaskWatchdog.h"
 
 namespace {
@@ -418,16 +419,10 @@ void WebDAVHandler::handleDelete(WebServer& s) {
   }
 
   if (file.isDirectory()) {
-    // Check if directory is empty
-    HalFile entry = file.openNextFile();
-    if (entry) {
-      entry.close();
-      file.close();
-      s.send(409, "text/plain", "Directory not empty");
-      return;
-    }
+    // RFC 4918 §9.6.1: DELETE on a collection removes the whole tree. Refusing
+    // a non-empty one left clients unable to delete a folder at all.
     file.close();
-    if (Storage.rmdir(path.c_str())) {
+    if (deletePathRecursive(std::string(path.c_str()))) {
       s.send(204);
     } else {
       s.send(500, "text/plain", "Failed to remove directory");

--- a/src/util/DeleteUtils.cpp
+++ b/src/util/DeleteUtils.cpp
@@ -1,5 +1,6 @@
 #include "DeleteUtils.h"
 
+#include <Arduino.h>  // yield()
 #include <HalStorage.h>
 #include <Logging.h>
 #include <Memory.h>
@@ -45,8 +46,6 @@ bool deletePathRecursive(const std::string& path) {
   stack.push_back({path, false});
 
   while (!stack.empty()) {
-    // A deep tree (macOS Spotlight indexes hold thousands of entries) can run
-    // long enough to trip the watchdog on whichever task is deleting.
     resetTaskWatchdogIfSubscribed();
 
     auto [currentPath, postOrder] = std::move(stack.back());
@@ -96,6 +95,14 @@ bool deletePathRecursive(const std::string& path) {
           return false;
         }
       }
+
+      // Per entry, matching scanFiles(): a macOS Spotlight index holds
+      // thousands, and this walk runs on the web server task as well as the
+      // activity task. Without the yield a long delete starves Wi-Fi and the
+      // HTTP reply never lands; without the watchdog reset it trips the 5s
+      // task WDT and resets the device on a half-deleted tree.
+      yield();
+      resetTaskWatchdogIfSubscribed();
     }
   }
 

--- a/src/util/DeleteUtils.cpp
+++ b/src/util/DeleteUtils.cpp
@@ -1,0 +1,103 @@
+#include "DeleteUtils.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+#include <Memory.h>
+
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "BookCacheUtils.h"
+#include "TaskWatchdog.h"
+
+namespace {
+// Matches FileBrowserActivity's listing buffer: long UTF-8 names are enabled
+// (USE_UTF8_LONG_NAMES), so a name can far exceed the 256-byte stack budget --
+// hence the heap allocation rather than a local array.
+constexpr size_t NAME_BUFFER_SIZE = 500;
+}  // namespace
+
+bool deletePathRecursive(const std::string& path) {
+  auto file = Storage.open(path.c_str());
+  if (!file) {
+    LOG_ERR("DEL", "Failed to open: %s", path.c_str());
+    return false;
+  }
+
+  if (!file.isDirectory()) {
+    file.close();
+    clearBookCache(path);
+    return Storage.remove(path.c_str());
+  }
+  file.close();
+
+  const auto nameBuffer = makeUniqueNoThrow<char[]>(NAME_BUFFER_SIZE);
+  if (!nameBuffer) {
+    LOG_ERR("DEL", "OOM: %d bytes", static_cast<int>(NAME_BUFFER_SIZE));
+    return false;
+  }
+
+  // Stack of (dirPath, postOrder): postOrder=true means rmdir this path after
+  // its children are processed, since rmdir only succeeds on an empty dir.
+  std::vector<std::pair<std::string, bool>> stack;
+  stack.reserve(16);
+  stack.push_back({path, false});
+
+  while (!stack.empty()) {
+    // A deep tree (macOS Spotlight indexes hold thousands of entries) can run
+    // long enough to trip the watchdog on whichever task is deleting.
+    resetTaskWatchdogIfSubscribed();
+
+    auto [currentPath, postOrder] = std::move(stack.back());
+    stack.pop_back();
+
+    if (postOrder) {
+      if (!Storage.rmdir(currentPath.c_str())) {
+        LOG_ERR("DEL", "Failed to rmdir: %s", currentPath.c_str());
+        return false;
+      }
+      continue;
+    }
+
+    auto dir = Storage.open(currentPath.c_str());
+    if (!dir) {
+      LOG_ERR("DEL", "Failed to open dir: %s", currentPath.c_str());
+      return false;
+    }
+    if (!dir.isDirectory()) {
+      LOG_ERR("DEL", "Not a directory: %s", currentPath.c_str());
+      return false;
+    }
+
+    stack.push_back({currentPath, true});
+
+    dir.rewindDirectory();
+    for (auto entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
+      entry.getName(nameBuffer.get(), NAME_BUFFER_SIZE);
+      if (strcmp(nameBuffer.get(), ".") == 0 || strcmp(nameBuffer.get(), "..") == 0) {
+        continue;
+      }
+      std::string entryPath = currentPath;
+      if (entryPath.back() != '/') {
+        entryPath += "/";
+      }
+      entryPath += nameBuffer.get();
+
+      const bool isDir = entry.isDirectory();
+      entry.close();
+
+      if (isDir) {
+        stack.push_back({std::move(entryPath), false});
+      } else {
+        clearBookCache(entryPath);
+        if (!Storage.remove(entryPath.c_str())) {
+          LOG_ERR("DEL", "Failed to remove file: %s", entryPath.c_str());
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}

--- a/src/util/DeleteUtils.h
+++ b/src/util/DeleteUtils.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+// Delete a file, or a directory and everything inside it. Hidden and dot-
+// prefixed entries are removed like any other -- macOS leaves `.Spotlight-V100`
+// and `.Trashes` on the card, and refusing to delete them is what left them
+// stranded. Callers still decide what is off-limits before calling.
+//
+// The reading cache of every book file removed is cleared during the same walk,
+// so the tree is traversed once rather than twice. Returns false at the first
+// failure; whatever was already deleted stays deleted.
+bool deletePathRecursive(const std::string& path);


### PR DESCRIPTION
Closes #178.

## Summary

* **What is the goal of this PR?** Make the file browsers able to delete what they show. macOS leaves `.Spotlight-V100`, `.Trashes` and `.fseventsd` on any card it touches, and the web file manager listed them but refused every delete with *"hidden/system file"*. It also refused any non-empty folder with *"folder not empty"*, so a folder could only be emptied one file at a time.

* **What changes are included?**
  * **A dot prefix is a display hint, not a permission.** `isProtectedItemName()` no longer treats every dot entry as protected, and `/delete` no longer has its own separate dot-entry veto. Listing behaviour is unchanged — dot entries still appear only under **Show Hidden Files**.
  * **Folders delete with their contents.** The on-device browser already did this correctly. Its post-order stack walk moves to `src/util/DeleteUtils.cpp` so the web server and WebDAV share one implementation, including the per-file `clearBookCache()` that keeps it a single traversal.
  * **WebDAV `DELETE` on a non-empty collection** removes the tree instead of returning 409, as RFC 4918 §9.6.1 requires. Finder and Explorer can delete folders now.
  * `System Volume Information` and `XTCache` are unchanged: still hidden unconditionally in both browsers, still refused by `/delete`. The second commit walks back an earlier attempt to reveal them — they are the filesystem's own bookkeeping, not a leftover a user wants to clear.

| Entry | Listed | Deletable |
|---|---|---|
| `.Spotlight-V100`, `.Trashes`, `.crosspoint` | under Show Hidden Files | ✅ (was ❌) |
| Non-empty folder | always | ✅ with contents (was ❌) |
| `System Volume Information`, `XTCache` | never | ❌ (unchanged) |

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this is a fix to CrossPoint's own file manager.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact.** Net ~zero: the recursive walk is moved, not added — `FileBrowserActivity` loses 78 lines and gains a call. `DeleteUtils` allocates one 500-byte name buffer via `makeUniqueNoThrow` for the duration of a delete, matching the browser's existing listing buffer; a name under `USE_UTF8_LONG_NAMES` can far exceed the 256-byte stack budget, so it is heap rather than a local array. The traversal stack is a `std::vector` with `reserve(16)`.

**Watchdog.** The shared walk calls `resetTaskWatchdogIfSubscribed()` each iteration. This is new behaviour worth a look: a Spotlight index holds thousands of entries, and the traversal now runs on the web server task as well as the activity task, where a multi-second delete would otherwise trip the WDT. The helper no-ops when the calling task is not subscribed, so it is safe on both.

**Deliberately not changed:** WebDAV's `isProtectedPath()` still rejects any dot-prefixed path segment across PUT / MKCOL / MOVE / COPY. Loosening it would let Finder scatter `.DS_Store` and `._*` files over the card on every mount, which seems like the reason it is there. That does mean `.Spotlight-V100` still cannot be deleted *over WebDAV* — only from the two browsers this issue is about. Happy to open that up if you'd rather.

Renaming and moving keep the narrowed protection (`System Volume Information`, `XTCache`); only the dot-prefix veto is gone from them.

**Testing.** cppcheck and clang-format clean. **`pio run` has not been run** — no PlatformIO available in the environment I worked in, so CI is the first real compile, and this has had **no on-device testing**. Worth exercising on hardware: deleting a real `.Spotlight-V100` (the watchdog path), and confirming a folder delete still clears the reading cache of the books inside it.

Docs updated: USER_GUIDE §3.3, `docs/webserver.md`, `docs/webserver-endpoints.md`.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7)_