### PR TITLE
feat: widen a font row's sizes to every family that can render it

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ python3 tools/dict_convert/convert_jmdict.py \
   --output-dir /path/to/sd/dictionaries/jp/    # add --name names / --name grammar for the others
 ```
 
-**3. Install a Japanese font** (optional). The built-in Noto handles Japanese, but a dedicated font looks better. Convert any TTF or OTF with the [browser tool](https://eszter007.github.io/matcha-reader-tools/) and put the result in `.fonts/<Family>/regular.cpfont`. An SD card Japanese font also fills in rare kanji elsewhere, such as dictionary entries and book titles.
+**3. Install a Japanese font** (optional). The built-in Noto handles Japanese, but a dedicated font looks better. Convert any TTF or OTF with the [browser tool](https://eszter007.github.io/matcha-reader-tools/) and put the result in `.fonts/<Family>/<Family>_<size>.cpfont` — one file per point size, and the size in the filename is the size offered in Text Settings. An SD card Japanese font also fills in rare kanji elsewhere, such as dictionary entries and book titles.
+
+Name the folder `NotoSansJP` or `NotoSerifJP` and it pairs with the matching built-in font instead of appearing as its own entry. Its sizes are then offered under **Noto Sans** / **Noto Serif** alongside the built-in 12, 14, 16 and 18 pt, so a Japanese book can be read at any size you install — put `NotoSansJP_20.cpfont` on the card and 20 pt appears. A non-Japanese book renders at the nearest built-in size instead, since the built-in faces only exist at those four.
 
 **4. Set up translation** (optional). Get a key from [Google AI Studio](https://aistudio.google.com/apikey) and save it as `/system/gemini.key` on the card.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python3 tools/dict_convert/convert_jmdict.py \
 
 **3. Install a Japanese font** (optional). The built-in Noto handles Japanese, but a dedicated font looks better. Convert any TTF or OTF with the [browser tool](https://eszter007.github.io/matcha-reader-tools/) and put the result in `.fonts/<Family>/<Family>_<size>.cpfont` — one file per point size, and the size in the filename is the size offered in Text Settings. An SD card Japanese font also fills in rare kanji elsewhere, such as dictionary entries and book titles.
 
-Name the folder `NotoSansJP` or `NotoSerifJP` and it pairs with the matching built-in font instead of appearing as its own entry. Its sizes are then offered under **Noto Sans** / **Noto Serif** alongside the built-in 12, 14, 16 and 18 pt, so a Japanese book can be read at any size you install — put `NotoSansJP_20.cpfont` on the card and 20 pt appears. A non-Japanese book renders at the nearest built-in size instead, since the built-in faces only exist at those four.
+Some folder names pair a font with an entry that is already in the list instead of adding one of their own: `NotoSansJP` / `NotoSerifJP` become the Japanese half of **Noto Sans** / **Noto Serif**, and a `…Extended` name widens the font it is named after. A paired font's sizes are offered on the entry it pairs with, so a book that font carries can be read at any size you install — put `NotoSansJP_20.cpfont` on the card and 20 pt appears under Noto Sans. A book it does not carry (an English one, for a Japanese font) renders at the nearest size the main font ships instead.
 
 **4. Set up translation** (optional). Get a key from [Google AI Studio](https://aistudio.google.com/apikey) and save it as `/system/gemini.key` on the card.
 

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -351,8 +351,6 @@ int CrossPointSettings::getRefreshFrequency() const {
 
 void CrossPointSettings::clearSdFontFamily() {
   sdFontFamilyName[0] = '\0';
-  fontPointSize =
-      snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), fontPointSize);
   saveToFile();
 }
 

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -382,10 +382,11 @@ class CrossPointSettings : public PersistableStore<CrossPointSettings> {
   int getBuiltinReaderFontId() const;
   int getRubyFontId() const;
 
-  // Drop the SD font selection and fall back to the built-in family. The reader
-  // point size comes back into BUILTIN_READER_POINT_SIZES with it, since that is
-  // the only set a built-in family ships — otherwise the settings UI would keep
-  // offering a size nothing renders at. Both fields are persisted in one write.
+  // Drop the SD font selection and fall back to the built-in family, persisting the change.
+  // The reader point size is deliberately left alone: which sizes a built-in row offers depends
+  // on the JP companion installed on the card, which only SdCardFontSystem can see. It snaps the
+  // size into that set on the next ensureLoaded(); until then getBuiltinReaderFontId() renders at
+  // the nearest built-in size, so nothing draws at a size no face exists at.
   void clearSdFontFamily();
 
   // Resolved status-bar composition. Consumers read the spec; only settings

--- a/src/ReaderFontSizes.cpp
+++ b/src/ReaderFontSizes.cpp
@@ -26,11 +26,11 @@ std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, co
 
   for (size_t i = 0; i < standInCount; i++) {
     if (!standIns[i]) continue;
-    for (const auto& file : standIns[i]->files) {
-      if (std::find(sizes.begin(), sizes.end(), file.pointSize) == sizes.end()) sizes.push_back(file.pointSize);
-    }
+    for (const auto& file : standIns[i]->files) sizes.push_back(file.pointSize);
   }
+  // A family lists one file per (size, style), so its own sizes repeat before this runs.
   std::sort(sizes.begin(), sizes.end());
+  sizes.erase(std::unique(sizes.begin(), sizes.end()), sizes.end());
   return sizes;
 }
 

--- a/src/ReaderFontSizes.cpp
+++ b/src/ReaderFontSizes.cpp
@@ -1,15 +1,43 @@
 #include "ReaderFontSizes.h"
 
+#include <algorithm>
 #include <iterator>
 
-std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName) {
+std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName,
+                                          const SdCardFontFamilyInfo* companion) {
   if (registry && sdFamilyName && sdFamilyName[0] != '\0') {
     if (const auto* family = registry->findFamily(sdFamilyName)) {
       auto sizes = family->availableSizes();
       if (!sizes.empty()) return sizes;
     }
   }
-  return {std::begin(BUILTIN_READER_POINT_SIZES), std::end(BUILTIN_READER_POINT_SIZES)};
+
+  std::vector<uint8_t> sizes;
+  sizes.reserve(std::size(BUILTIN_READER_POINT_SIZES) + (companion ? companion->files.size() : 0));
+  sizes.assign(std::begin(BUILTIN_READER_POINT_SIZES), std::end(BUILTIN_READER_POINT_SIZES));
+  if (!companion) return sizes;
+
+  for (const auto& file : companion->files) {
+    if (std::find(sizes.begin(), sizes.end(), file.pointSize) == sizes.end()) sizes.push_back(file.pointSize);
+  }
+  std::sort(sizes.begin(), sizes.end());
+  return sizes;
+}
+
+uint8_t snapToBuiltinPointSize(const SdCardFontFamilyInfo* companion, const uint8_t pt) {
+  uint8_t best = snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), pt);
+  if (!companion) return best;
+
+  uint8_t bestDelta = best > pt ? best - pt : pt - best;
+  for (const auto& file : companion->files) {
+    const uint8_t delta = file.pointSize > pt ? file.pointSize - pt : pt - file.pointSize;
+    // Ties resolve to the smaller size, matching snapToNearestPointSize().
+    if (delta < bestDelta || (delta == bestDelta && file.pointSize < best)) {
+      best = file.pointSize;
+      bestDelta = delta;
+    }
+  }
+  return best;
 }
 
 uint8_t snapToNearestPointSize(const uint8_t* sizes, const size_t count, const uint8_t pt) {

--- a/src/ReaderFontSizes.cpp
+++ b/src/ReaderFontSizes.cpp
@@ -26,7 +26,9 @@ std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, co
 
   for (size_t i = 0; i < standInCount; i++) {
     if (!standIns[i]) continue;
-    for (const auto& file : standIns[i]->files) sizes.push_back(file.pointSize);
+    const auto& files = standIns[i]->files;
+    std::transform(files.begin(), files.end(), std::back_inserter(sizes),
+                   [](const SdCardFontFileInfo& file) { return file.pointSize; });
   }
   // A family lists one file per (size, style), so its own sizes repeat before this runs.
   std::sort(sizes.begin(), sizes.end());

--- a/src/ReaderFontSizes.cpp
+++ b/src/ReaderFontSizes.cpp
@@ -4,40 +4,34 @@
 #include <iterator>
 
 std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName,
-                                          const SdCardFontFamilyInfo* companion) {
-  if (registry && sdFamilyName && sdFamilyName[0] != '\0') {
-    if (const auto* family = registry->findFamily(sdFamilyName)) {
-      auto sizes = family->availableSizes();
-      if (!sizes.empty()) return sizes;
-    }
+                                          const SdCardFontFamilyInfo* const* standIns, const size_t standInCount) {
+  std::vector<uint8_t> sizes;
+  size_t extra = 0;
+  for (size_t i = 0; i < standInCount; i++) {
+    if (standIns[i]) extra += standIns[i]->files.size();
   }
 
-  std::vector<uint8_t> sizes;
-  sizes.reserve(std::size(BUILTIN_READER_POINT_SIZES) + (companion ? companion->files.size() : 0));
-  sizes.assign(std::begin(BUILTIN_READER_POINT_SIZES), std::end(BUILTIN_READER_POINT_SIZES));
-  if (!companion) return sizes;
+  const SdCardFontFamilyInfo* own = nullptr;
+  if (registry && sdFamilyName && sdFamilyName[0] != '\0') own = registry->findFamily(sdFamilyName);
+  if (own && !own->files.empty()) {
+    // Copied element-wise, not move-assigned: assigning the temporary would swap in its buffer
+    // and throw away the reservation the stand-in loop below depends on.
+    const std::vector<uint8_t> ownSizes = own->availableSizes();
+    sizes.reserve(ownSizes.size() + extra);
+    sizes.assign(ownSizes.begin(), ownSizes.end());
+  } else {
+    sizes.reserve(std::size(BUILTIN_READER_POINT_SIZES) + extra);
+    sizes.assign(std::begin(BUILTIN_READER_POINT_SIZES), std::end(BUILTIN_READER_POINT_SIZES));
+  }
 
-  for (const auto& file : companion->files) {
-    if (std::find(sizes.begin(), sizes.end(), file.pointSize) == sizes.end()) sizes.push_back(file.pointSize);
+  for (size_t i = 0; i < standInCount; i++) {
+    if (!standIns[i]) continue;
+    for (const auto& file : standIns[i]->files) {
+      if (std::find(sizes.begin(), sizes.end(), file.pointSize) == sizes.end()) sizes.push_back(file.pointSize);
+    }
   }
   std::sort(sizes.begin(), sizes.end());
   return sizes;
-}
-
-uint8_t snapToBuiltinPointSize(const SdCardFontFamilyInfo* companion, const uint8_t pt) {
-  uint8_t best = snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES), pt);
-  if (!companion) return best;
-
-  uint8_t bestDelta = best > pt ? best - pt : pt - best;
-  for (const auto& file : companion->files) {
-    const uint8_t delta = file.pointSize > pt ? file.pointSize - pt : pt - file.pointSize;
-    // Ties resolve to the smaller size, matching snapToNearestPointSize().
-    if (delta < bestDelta || (delta == bestDelta && file.pointSize < best)) {
-      best = file.pointSize;
-      bestDelta = delta;
-    }
-  }
-  return best;
 }
 
 uint8_t snapToNearestPointSize(const uint8_t* sizes, const size_t count, const uint8_t pt) {

--- a/src/ReaderFontSizes.h
+++ b/src/ReaderFontSizes.h
@@ -15,19 +15,18 @@
 // point sizes (see the global font objects in main.cpp).
 inline constexpr uint8_t BUILTIN_READER_POINT_SIZES[] = {12, 14, 16, 18};
 
-// Point sizes selectable for the active reader font, ascending and deduplicated.
-// Never returns empty.
+// Point sizes selectable for the active reader row, ascending and deduplicated. Never empty.
 //
-//  - `sdFamilyName` names a family the registry knows: exactly the sizes it ships.
-//  - otherwise a built-in family is active: BUILTIN_READER_POINT_SIZES widened by every
-//    size `companion` ships. `companion` is the JP extension paired with that built-in
-//    (SdCardFontSystem::builtinJpCompanion), null when the card has none installed.
+// The row's own sizes -- the SD family `sdFamilyName` names, or BUILTIN_READER_POINT_SIZES for
+// a built-in family -- widened by every size the `standIns` ship. Stand-ins are the families
+// hidden from the picker that can still end up rendering this row: its coverage variant and the
+// JP companion (SdCardFontSystem::readerStandInFamilies).
 //
-// A size only the companion ships is still selectable on a built-in row: a Japanese book
-// renders from the companion at exactly that size, and Latin text falls back to the nearest
-// size the built-in face exists at (CrossPointSettings::getBuiltinReaderFontId).
+// A size only a stand-in ships is selectable because a book that stand-in carries renders at
+// exactly that size. A book it does not carry falls back to the nearest size the row's own face
+// exists at (CrossPointSettings::getBuiltinReaderFontId, SdCardFontFamilyInfo::findNearestSize).
 std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName,
-                                          const SdCardFontFamilyInfo* companion);
+                                          const SdCardFontFamilyInfo* const* standIns, size_t standInCount);
 
 // Closest entry in `sizes` (ascending, `count` > 0) to `pt`; ties resolve to the
 // smaller size. Takes a raw range rather than a vector because getReaderFontId()
@@ -37,8 +36,3 @@ uint8_t snapToNearestPointSize(const uint8_t* sizes, size_t count, uint8_t pt);
 inline uint8_t snapToNearestPointSize(const std::vector<uint8_t>& sizes, const uint8_t pt) {
   return sizes.empty() ? pt : snapToNearestPointSize(sizes.data(), sizes.size(), pt);
 }
-
-// Nearest size a built-in family can be asked for, over the same set readerFontPointSizes()
-// offers for one: BUILTIN_READER_POINT_SIZES widened by `companion`'s installed sizes.
-// Allocation-free, so it can run on the settings-load and font-reload paths.
-uint8_t snapToBuiltinPointSize(const SdCardFontFamilyInfo* companion, uint8_t pt);

--- a/src/ReaderFontSizes.h
+++ b/src/ReaderFontSizes.h
@@ -15,10 +15,19 @@
 // point sizes (see the global font objects in main.cpp).
 inline constexpr uint8_t BUILTIN_READER_POINT_SIZES[] = {12, 14, 16, 18};
 
-// Point sizes selectable for the active reader font, ascending: the SD family's
-// installed sizes when `sdFamilyName` names one the registry knows, otherwise
-// the built-in set. Never returns empty.
-std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName);
+// Point sizes selectable for the active reader font, ascending and deduplicated.
+// Never returns empty.
+//
+//  - `sdFamilyName` names a family the registry knows: exactly the sizes it ships.
+//  - otherwise a built-in family is active: BUILTIN_READER_POINT_SIZES widened by every
+//    size `companion` ships. `companion` is the JP extension paired with that built-in
+//    (SdCardFontSystem::builtinJpCompanion), null when the card has none installed.
+//
+// A size only the companion ships is still selectable on a built-in row: a Japanese book
+// renders from the companion at exactly that size, and Latin text falls back to the nearest
+// size the built-in face exists at (CrossPointSettings::getBuiltinReaderFontId).
+std::vector<uint8_t> readerFontPointSizes(const SdCardFontRegistry* registry, const char* sdFamilyName,
+                                          const SdCardFontFamilyInfo* companion);
 
 // Closest entry in `sizes` (ascending, `count` > 0) to `pt`; ties resolve to the
 // smaller size. Takes a raw range rather than a vector because getReaderFontId()
@@ -28,3 +37,8 @@ uint8_t snapToNearestPointSize(const uint8_t* sizes, size_t count, uint8_t pt);
 inline uint8_t snapToNearestPointSize(const std::vector<uint8_t>& sizes, const uint8_t pt) {
   return sizes.empty() ? pt : snapToNearestPointSize(sizes.data(), sizes.size(), pt);
 }
+
+// Nearest size a built-in family can be asked for, over the same set readerFontPointSizes()
+// offers for one: BUILTIN_READER_POINT_SIZES widened by `companion`'s installed sizes.
+// Allocation-free, so it can run on the settings-load and font-reload paths.
+uint8_t snapToBuiltinPointSize(const SdCardFontFamilyInfo* companion, uint8_t pt);

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -156,10 +156,12 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
     if (!currentFamily.empty()) {
       manager_.unloadAll(renderer);
     }
-    // Back on a built-in family, which exists only at BUILTIN_READER_POINT_SIZES:
-    // a size inherited from an SD family has to come back into that set.
-    snapFontPointSizeTo(snapToNearestPointSize(BUILTIN_READER_POINT_SIZES, std::size(BUILTIN_READER_POINT_SIZES),
-                                               SETTINGS.fontPointSize));
+    // Back on a built-in family: a size inherited from an SD family has to come back into the
+    // set that row offers. That set is BUILTIN_READER_POINT_SIZES widened by the JP companion's
+    // sizes, not the built-in set alone -- snapping to the latter would undo, on every reload, a
+    // companion-only size the picker legitimately offers.
+    snapFontPointSizeTo(
+        snapToBuiltinPointSize(builtinJpCompanion(&registry_, SETTINGS.fontFamily), SETTINGS.fontPointSize));
     return;
   }
 
@@ -299,6 +301,18 @@ int SdCardFontSystem::resolveFontId(const char* familyName, uint8_t /*pointSize*
 bool SdCardFontSystem::isBuiltinJpExtension(const std::string& familyName) {
   const std::string key = normalizedFamilyKey(familyName);
   return key == "notosansjp" || key == "notoserifjp";
+}
+
+const SdCardFontFamilyInfo* SdCardFontSystem::builtinJpCompanion(const SdCardFontRegistry* registry,
+                                                                 const uint8_t fontFamily) {
+  if (!registry) return nullptr;
+  // Matched on the normalized key, like every other family comparison here, so a folder named
+  // "noto sans jp" or "NotoSansJP" is the same companion.
+  const char* wanted = fontFamily == CrossPointSettings::NOTOSANS ? "notosansjp" : "notoserifjp";
+  for (const auto& fam : registry->getFamilies()) {
+    if (normalizedFamilyKey(fam.name) == wanted) return &fam;
+  }
+  return nullptr;
 }
 
 std::string SdCardFontSystem::coverageVariantBase(const std::string& familyName) {

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -157,11 +157,9 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
       manager_.unloadAll(renderer);
     }
     // Back on a built-in family: a size inherited from an SD family has to come back into the
-    // set that row offers. That set is BUILTIN_READER_POINT_SIZES widened by the JP companion's
-    // sizes, not the built-in set alone -- snapping to the latter would undo, on every reload, a
-    // companion-only size the picker legitimately offers.
-    snapFontPointSizeTo(
-        snapToBuiltinPointSize(builtinJpCompanion(&registry_, SETTINGS.fontFamily), SETTINGS.fontPointSize));
+    // set that row offers -- BUILTIN_READER_POINT_SIZES widened by its stand-ins, not the
+    // built-in set alone, which would undo a stand-in size the picker legitimately offers.
+    snapFontPointSizeTo(snapToNearestPointSize(rowPointSizes(), SETTINGS.fontPointSize));
     return;
   }
 
@@ -181,8 +179,14 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
     const auto* selected = family->findNearestSize(SETTINGS.fontPointSize);
     const uint8_t wantedPt = selected ? selected->pointSize : 0;
     // Snap before the early return: the wanted size can already be loaded while
-    // the setting still names a size this family does not ship.
-    snapFontPointSizeTo(wantedPt);
+    // the setting still names a size this family does not ship. Only persist it when the ROW
+    // does not offer the size either -- `family` may be a stand-in that happens to lack a size
+    // another family for this row can render, and writing its nearest down would silently
+    // demote the user's choice the first time a book pulled the stand-in in.
+    const auto rowSizes = rowPointSizes();
+    if (std::find(rowSizes.begin(), rowSizes.end(), SETTINGS.fontPointSize) == rowSizes.end()) {
+      snapFontPointSizeTo(wantedPt);
+    }
     if (!registryWasDirty && wantedPt == manager_.currentPointSize()) return;
     LOG_DBG("SDFS", "Reloading %s: size %u -> %u%s", wantedFamily.c_str(), manager_.currentPointSize(), wantedPt,
             registryWasDirty ? " [registry dirty]" : "");
@@ -207,7 +211,12 @@ void SdCardFontSystem::ensureSelectedLoaded(GfxRenderer& renderer) {
   const auto* family = registry_.findFamily(wantedFamily);
   if (family) {
     if (manager_.loadFamily(*family, renderer, SETTINGS.fontPointSize)) {
-      snapFontPointSizeTo(manager_.currentPointSize());
+      // Persisted only when the row cannot offer the setting at all — see the matching guard on
+      // the already-resident path above.
+      const auto rowSizes = rowPointSizes();
+      if (std::find(rowSizes.begin(), rowSizes.end(), SETTINGS.fontPointSize) == rowSizes.end()) {
+        snapFontPointSizeTo(manager_.currentPointSize());
+      }
       setupUiFallbacks(renderer);
       LOG_DBG("SDFS", "Loaded SD font family: %s", wantedFamily.c_str());
     } else {
@@ -303,16 +312,32 @@ bool SdCardFontSystem::isBuiltinJpExtension(const std::string& familyName) {
   return key == "notosansjp" || key == "notoserifjp";
 }
 
-const SdCardFontFamilyInfo* SdCardFontSystem::builtinJpCompanion(const SdCardFontRegistry* registry,
-                                                                 const uint8_t fontFamily) {
-  if (!registry) return nullptr;
-  // Matched on the normalized key, like every other family comparison here, so a folder named
-  // "noto sans jp" or "NotoSansJP" is the same companion.
-  const char* wanted = fontFamily == CrossPointSettings::NOTOSANS ? "notosansjp" : "notoserifjp";
-  for (const auto& fam : registry->getFamilies()) {
-    if (normalizedFamilyKey(fam.name) == wanted) return &fam;
+uint8_t SdCardFontSystem::readerStandInFamilies(const SdCardFontRegistry* registry, const char* sdFamilyName,
+                                                const uint8_t fontFamily, const SdCardFontFamilyInfo** out,
+                                                const uint8_t cap) {
+  if (!registry || !out || cap == 0) return 0;
+  uint8_t count = 0;
+
+  const bool builtinRow = sdFamilyName == nullptr || sdFamilyName[0] == '\0';
+  const std::string base = builtinRow ? builtinFamilyDirName(fontFamily) : sdFamilyName;
+  if (const auto* variant = findCoverageVariant(registry, base)) out[count++] = variant;
+
+  // The JP companion renders a Japanese book whole whenever the row's own face has no CJK,
+  // which is every built-in row and every Latin-only SD family. Matched on the normalized key,
+  // like every other family comparison here, so a folder named "noto sans jp" also pairs.
+  if (count < cap) {
+    // Same first choice ensureJpFallback() ranks highest, so the size offered is the size that
+    // will actually load: the sans extension only for a built-in Noto Sans row.
+    const bool preferSans = builtinRow && fontFamily == CrossPointSettings::NOTOSANS;
+    const char* wanted = preferSans ? "notosansjp" : "notoserifjp";
+    for (const auto& fam : registry->getFamilies()) {
+      if (normalizedFamilyKey(fam.name) == wanted) {
+        out[count++] = &fam;
+        break;
+      }
+    }
   }
-  return nullptr;
+  return count;
 }
 
 std::string SdCardFontSystem::coverageVariantBase(const std::string& familyName) {
@@ -328,12 +353,14 @@ std::string SdCardFontSystem::coverageVariantBase(const std::string& familyName)
   return {};
 }
 
-const SdCardFontFamilyInfo* SdCardFontSystem::findCoverageVariant(const std::string& baseName) const {
+const SdCardFontFamilyInfo* SdCardFontSystem::findCoverageVariant(const SdCardFontRegistry* registry,
+                                                                  const std::string& baseName) {
+  if (!registry) return nullptr;
   const std::string baseKey = normalizedFamilyKey(baseName);
   if (baseKey.empty()) return nullptr;
   for (const char* suffix : kCoverageVariantSuffixes) {
     const std::string wanted = baseKey + normalizedFamilyKey(suffix);
-    for (const auto& fam : registry_.getFamilies()) {
+    for (const auto& fam : registry->getFamilies()) {
       if (normalizedFamilyKey(fam.name) == wanted) return &fam;
     }
   }
@@ -353,6 +380,13 @@ bool SdCardFontSystem::isCoverageVariant(const std::string& familyName, const Sd
   return false;
 }
 
+std::vector<uint8_t> SdCardFontSystem::rowPointSizes() const {
+  const SdCardFontFamilyInfo* standIns[MAX_STAND_INS];
+  const uint8_t count =
+      readerStandInFamilies(&registry_, SETTINGS.sdFontFamilyName, SETTINGS.fontFamily, standIns, MAX_STAND_INS);
+  return readerFontPointSizes(&registry_, SETTINGS.sdFontFamilyName, standIns, count);
+}
+
 std::string SdCardFontSystem::resolveSelectedFamily() const {
   const std::string selected = SETTINGS.sdFontFamilyName;
   // A book that needs Japanese keeps the base as-is. The companion ensureJpFallback() is about
@@ -361,7 +395,7 @@ std::string SdCardFontSystem::resolveSelectedFamily() const {
   // base built-in also keeps its `preferSans` ranking working, which reads an empty selection.
   if (jpFallbackNeeded_) return selected;
   const std::string base = selected.empty() ? builtinFamilyDirName(SETTINGS.fontFamily) : selected;
-  const auto* variant = findCoverageVariant(base);
+  const auto* variant = findCoverageVariant(&registry_, base);
   return variant ? variant->name : selected;
 }
 

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -322,14 +322,17 @@ uint8_t SdCardFontSystem::readerStandInFamilies(const SdCardFontRegistry* regist
   const std::string base = builtinRow ? builtinFamilyDirName(fontFamily) : sdFamilyName;
   if (const auto* variant = findCoverageVariant(registry, base)) out[count++] = variant;
 
-  // The JP companion renders a Japanese book whole whenever the row's own face has no CJK,
-  // which is every built-in row and every Latin-only SD family. Matched on the normalized key,
-  // like every other family comparison here, so a folder named "noto sans jp" also pairs.
-  if (count < cap) {
-    // Same first choice ensureJpFallback() ranks highest, so the size offered is the size that
-    // will actually load: the sans extension only for a built-in Noto Sans row.
-    const bool preferSans = builtinRow && fontFamily == CrossPointSettings::NOTOSANS;
-    const char* wanted = preferSans ? "notosansjp" : "notoserifjp";
+  // Built-in rows only. ensureJpFallback() loads the companion for a Japanese book just when the
+  // row's own face lacks CJK, which is true of the built-ins by definition (selectedFontCovers
+  // treats them as Latin-complete and CJK-less) but unknowable here for an SD family: coverage
+  // lives in its .cpfont interval table and is only readable once resident. An SD row would
+  // otherwise offer sizes that a self-sufficient CJK family never renders at.
+  //
+  // Matched on the normalized key, like every other family comparison here, so a folder named
+  // "noto sans jp" also pairs, and on the extension ensureJpFallback() ranks first, so the size
+  // offered is the size that loads.
+  if (builtinRow && count < cap) {
+    const char* wanted = fontFamily == CrossPointSettings::NOTOSANS ? "notosansjp" : "notoserifjp";
     for (const auto& fam : registry->getFamilies()) {
       if (normalizedFamilyKey(fam.name) == wanted) {
         out[count++] = &fam;

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -57,9 +57,9 @@ class SdCardFontSystem {
 
   /// Families hidden from the picker that can nonetheless end up rendering the row named by
   /// `sdFamilyName` (empty for the built-in family `fontFamily`): the coverage variant that
-  /// stands in for it (resolveSelectedFamily) and the JP companion that carries a Japanese book
-  /// (ensureJpFallback + EpubReaderActivity::effectiveReaderFontId). Their installed sizes are
-  /// therefore selectable on that row -- see readerFontPointSizes().
+  /// stands in for it (resolveSelectedFamily), and on a built-in row the JP companion that
+  /// carries a Japanese book (ensureJpFallback + EpubReaderActivity::effectiveReaderFontId).
+  /// Their installed sizes are therefore selectable on that row -- see readerFontPointSizes().
   ///
   /// Writes up to `cap` entries into `out` and returns how many. Static and registry-driven so
   /// the settings UI can ask without owning a font system.

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -55,6 +55,12 @@ class SdCardFontSystem {
   /// fallback instead of being selected directly.
   static bool isBuiltinJpExtension(const std::string& familyName);
 
+  /// The JP extension installed for a built-in reader family (NotoSansJP for Noto Sans,
+  /// NotoSerifJP for Noto Serif), or nullptr when the card carries neither. `fontFamily` is a
+  /// CrossPointSettings built-in index. Static and registry-driven so the settings UI can ask
+  /// which sizes a built-in row offers without owning a font system.
+  static const SdCardFontFamilyInfo* builtinJpCompanion(const SdCardFontRegistry* registry, uint8_t fontFamily);
+
   /// True for SD families that only widen the coverage of a family the device already offers
   /// (NotoSerifExtended over the built-in Noto Serif, PagellaIPA over an installed Pagella).
   /// The picker shows the base alone and resolveSelectedFamily() decides which of the two is

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -55,11 +55,17 @@ class SdCardFontSystem {
   /// fallback instead of being selected directly.
   static bool isBuiltinJpExtension(const std::string& familyName);
 
-  /// The JP extension installed for a built-in reader family (NotoSansJP for Noto Sans,
-  /// NotoSerifJP for Noto Serif), or nullptr when the card carries neither. `fontFamily` is a
-  /// CrossPointSettings built-in index. Static and registry-driven so the settings UI can ask
-  /// which sizes a built-in row offers without owning a font system.
-  static const SdCardFontFamilyInfo* builtinJpCompanion(const SdCardFontRegistry* registry, uint8_t fontFamily);
+  /// Families hidden from the picker that can nonetheless end up rendering the row named by
+  /// `sdFamilyName` (empty for the built-in family `fontFamily`): the coverage variant that
+  /// stands in for it (resolveSelectedFamily) and the JP companion that carries a Japanese book
+  /// (ensureJpFallback + EpubReaderActivity::effectiveReaderFontId). Their installed sizes are
+  /// therefore selectable on that row -- see readerFontPointSizes().
+  ///
+  /// Writes up to `cap` entries into `out` and returns how many. Static and registry-driven so
+  /// the settings UI can ask without owning a font system.
+  static constexpr uint8_t MAX_STAND_INS = 2;
+  static uint8_t readerStandInFamilies(const SdCardFontRegistry* registry, const char* sdFamilyName, uint8_t fontFamily,
+                                       const SdCardFontFamilyInfo** out, uint8_t cap);
 
   /// True for SD families that only widen the coverage of a family the device already offers
   /// (NotoSerifExtended over the built-in Noto Serif, PagellaIPA over an installed Pagella).
@@ -104,7 +110,13 @@ class SdCardFontSystem {
   static std::string coverageVariantBase(const std::string& familyName);
 
   /// Installed variant standing in for `baseName`, or nullptr when the card has none.
-  const SdCardFontFamilyInfo* findCoverageVariant(const std::string& baseName) const;
+  static const SdCardFontFamilyInfo* findCoverageVariant(const SdCardFontRegistry* registry,
+                                                         const std::string& baseName);
+
+  /// Point sizes the current reader row offers: its own family's sizes widened by its
+  /// stand-ins'. The same set the pickers show, so a size the user can select is never snapped
+  /// away by a load.
+  std::vector<uint8_t> rowPointSizes() const;
 
   /// Family that should be resident for the current selection and reading context. Empty means
   /// "the built-in reader font, nothing to load". This is a runtime substitution only —

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -105,7 +105,8 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
 inline SettingInfo buildFontSizeSetting(const SdCardFontRegistry* registry) {
   // Captured by copy: getSettingsList() returns by value and the lambdas outlive
   // this call, so they must not reference the registry.
-  const std::vector<uint8_t> sizes = readerFontPointSizes(registry, SETTINGS.sdFontFamilyName);
+  const std::vector<uint8_t> sizes = readerFontPointSizes(
+      registry, SETTINGS.sdFontFamilyName, SdCardFontSystem::builtinJpCompanion(registry, SETTINGS.fontFamily));
 
   // "pt" is deliberately not translated — see the matching note in
   // TextSettingsActivity::rebuildSizeList().

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -96,17 +96,19 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
   return s;
 }
 
-// Build the font size setting dynamically: the options are the point sizes the
-// active family actually ships, so an SD family built at 10/12/14 offers three
-// sizes and a family built at 8..18 offers six. The selected point size persists
-// in SETTINGS.fontPointSize (saved/loaded manually in CrossPointSettings::
-// toJson/fromJson — the generic loop skips dynamic entries), while the ENUM
-// contract shared with the web UI stays index-based.
+// Build the font size setting dynamically: the options are the point sizes this row can
+// actually be rendered at — the active family's, plus those of the hidden families that stand
+// in for it — so an SD family built at 10/12/14 offers three sizes and a family built at 8..18
+// offers six. The selected point size persists in SETTINGS.fontPointSize (saved/loaded manually
+// in CrossPointSettings::toJson/fromJson — the generic loop skips dynamic entries), while the
+// ENUM contract shared with the web UI stays index-based.
 inline SettingInfo buildFontSizeSetting(const SdCardFontRegistry* registry) {
-  // Captured by copy: getSettingsList() returns by value and the lambdas outlive
-  // this call, so they must not reference the registry.
-  const std::vector<uint8_t> sizes = readerFontPointSizes(
-      registry, SETTINGS.sdFontFamilyName, SdCardFontSystem::builtinJpCompanion(registry, SETTINGS.fontFamily));
+  // `sizes` is captured by copy below: getSettingsList() returns by value and the lambdas
+  // outlive this call, so they must not reference the registry.
+  const SdCardFontFamilyInfo* standIns[SdCardFontSystem::MAX_STAND_INS];
+  const uint8_t standInCount = SdCardFontSystem::readerStandInFamilies(
+      registry, SETTINGS.sdFontFamilyName, SETTINGS.fontFamily, standIns, SdCardFontSystem::MAX_STAND_INS);
+  const std::vector<uint8_t> sizes = readerFontPointSizes(registry, SETTINGS.sdFontFamilyName, standIns, standInCount);
 
   // "pt" is deliberately not translated — see the matching note in
   // TextSettingsActivity::rebuildSizeList().

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4187,10 +4187,13 @@ void EpubReaderActivity::applyTextSettingLive() {
 void EpubReaderActivity::showTextRowPopup(const int row) {
   switch (row) {
     case 1: {
-      // The point sizes the active family actually ships.
+      // The point sizes this row can render: the active family's, plus its stand-ins'.
+      const SdCardFontFamilyInfo* standIns[SdCardFontSystem::MAX_STAND_INS];
+      const uint8_t standInCount =
+          SdCardFontSystem::readerStandInFamilies(&sdFontSystem.registry(), SETTINGS.sdFontFamilyName,
+                                                  SETTINGS.fontFamily, standIns, SdCardFontSystem::MAX_STAND_INS);
       const auto sizes =
-          readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.sdFontFamilyName,
-                               SdCardFontSystem::builtinJpCompanion(&sdFontSystem.registry(), SETTINGS.fontFamily));
+          readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.sdFontFamilyName, standIns, standInCount);
       if (sizes.empty()) return;
       std::vector<std::string> labels;
       labels.reserve(sizes.size());

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4188,7 +4188,9 @@ void EpubReaderActivity::showTextRowPopup(const int row) {
   switch (row) {
     case 1: {
       // The point sizes the active family actually ships.
-      const auto sizes = readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.sdFontFamilyName);
+      const auto sizes =
+          readerFontPointSizes(&sdFontSystem.registry(), SETTINGS.sdFontFamilyName,
+                               SdCardFontSystem::builtinJpCompanion(&sdFontSystem.registry(), SETTINGS.fontFamily));
       if (sizes.empty()) return;
       std::vector<std::string> labels;
       labels.reserve(sizes.size());

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -159,7 +159,8 @@ void TextSettingsActivity::rebuildRowItems() {
 // which snaps SETTINGS.fontPointSize into the new family's set — but entry does
 // not, so the highlight is resolved by snapping rather than by exact match.
 void TextSettingsActivity::rebuildSizeList() {
-  const std::vector<uint8_t> points = readerFontPointSizes(registry_, SETTINGS.sdFontFamilyName);
+  const std::vector<uint8_t> points = readerFontPointSizes(
+      registry_, SETTINGS.sdFontFamilyName, SdCardFontSystem::builtinJpCompanion(registry_, SETTINGS.fontFamily));
 
   // The stored size can still sit outside this family's set — e.g. the family
   // was deleted while selected, or the card was swapped. Highlight the size the

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -159,8 +159,11 @@ void TextSettingsActivity::rebuildRowItems() {
 // which snaps SETTINGS.fontPointSize into the new family's set — but entry does
 // not, so the highlight is resolved by snapping rather than by exact match.
 void TextSettingsActivity::rebuildSizeList() {
-  const std::vector<uint8_t> points = readerFontPointSizes(
-      registry_, SETTINGS.sdFontFamilyName, SdCardFontSystem::builtinJpCompanion(registry_, SETTINGS.fontFamily));
+  const SdCardFontFamilyInfo* standIns[SdCardFontSystem::MAX_STAND_INS];
+  const uint8_t standInCount = SdCardFontSystem::readerStandInFamilies(
+      registry_, SETTINGS.sdFontFamilyName, SETTINGS.fontFamily, standIns, SdCardFontSystem::MAX_STAND_INS);
+  const std::vector<uint8_t> points =
+      readerFontPointSizes(registry_, SETTINGS.sdFontFamilyName, standIns, standInCount);
 
   // The stored size can still sit outside this family's set — e.g. the family
   // was deleted while selected, or the card was swapped. Highlight the size the


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the reader font size list reflect what is actually installed, so a book can be read at a size the row's main font does not ship — install one `.cpfont` and the size appears.
* **What changes are included?**

Two kinds of family are hidden from the font picker but can still end up rendering a row:

| Hidden family | How it becomes resident | Offered on |
|---|---|---|
| `NotoSansJP` / `NotoSerifJP` | carries a Japanese book whole (`ensureJpFallback` → `effectiveReaderFontId`) | built-in rows |
| `…Extended`, `…IPA` | stands in for its base (`resolveSelectedFamily`) | built-in and SD rows |

The size list asked about neither, so it was `BUILTIN_READER_POINT_SIZES` verbatim for a built-in row and the base family's sizes for an SD row. Installing `NotoSansJP_20.cpfont` changed nothing — the size was unreachable from the UI even though the font that would render it was right there.

`SdCardFontSystem::readerStandInFamilies()` now returns the families that can render a row, and `readerFontPointSizes()` unions their sizes into the row's own. Concretely, with `NotoSansJP` shipping 12/13/50 the Noto Sans row offers 12, 13, 14, 16, 18, 50. A family with no stand-in installed still offers exactly its own sizes.

The JP companion is offered on built-in rows only. `ensureJpFallback()` loads a companion just when the row's own face lacks CJK or Latin — guaranteed for the built-ins (`selectedFontCovers()` treats them as Latin-complete and CJK-less) but unknowable for an SD family, whose coverage lives in its `.cpfont` interval table and is readable only once resident. Offering it on SD rows would mean a self-sufficient CJK family advertising sizes nothing on that row ever renders at.

**A stand-in could also silently demote the setting.** `ensureSelectedLoaded()` snapped `fontPointSize` to the *resident* family's nearest size and persisted it. Once a row can offer a size only one of its families ships, that write is destructive: select 20 pt, open one Latin book, and the variant standing in — which has no 20 — writes the setting down to 18 permanently. Both snap sites now persist only when the **row** cannot offer the size at all; loading still uses each family's nearest.

**Fallback, when a chosen size exists in only one of a row's families:**

| Book | Renders at |
|---|---|
| One the stand-in carries (Japanese, for a JP companion) | the stand-in at exactly that size |
| One it does not | the nearest size the row's own face ships |

So 20 pt on Noto Sans gives a Japanese book 20 pt and leaves an English book at 18. Intended, but worth knowing before testing with a Latin book.

`findCoverageVariant()` became static over an explicit registry so the settings UI, which holds no font system, can ask the same question the loader does. `BUILTIN_READER_POINT_SIZES` is unchanged, so the `ReaderFontScale` CSS ladders stay correct and no built-in face is added to flash.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the SD font path is size-agnostic end to end (`parseFilename` accepts 1–255, `findNearestSize` snaps, `fontPointSize` is stored unclamped); the only thing pinning a row to a fixed set was the size list ignoring the families that can render it.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact:** no new built-in font faces, so no flash cost for the sizes themselves. `readerStandInFamilies()` walks the registry (≤ 128 families) comparing normalized keys; those keys are short enough for SSO, so the scan does not heap-allocate, and it writes into a caller-owned 2-element stack array rather than a vector. It runs on settings-screen entry and inside `ensureSelectedLoaded()` — never in the page render loop, which reaches the font only through `getReaderFontId()`. Built with `pio run -e default`: RAM 17.3% (56,828 B), flash 86.7%, no warnings in the changed files.

**Areas to focus on:**
- The two snap guards in `ensureSelectedLoaded()`. Persisting less often is the behavioural change most likely to surprise: `SETTINGS.fontPointSize` may now legitimately differ from `manager_.currentPointSize()` while a stand-in is resident.
- `clearSdFontFamily()` no longer normalises `fontPointSize` at all — which sizes a row offers depends on the card, and only `SdCardFontSystem` can see that. It is reached from `FontInstaller` as well as three sites in `SdCardFontSystem`.

**Not verified on hardware.** Needs a device check: install a JP companion at a non-standard size, confirm it appears under Noto Sans, confirm a Japanese book renders at it, and confirm opening a Latin book afterwards does not write the size back down.

README step 3 is updated — it also still documented the pre-v4 `regular.cpfont` filename, which is corrected here.

Both Copilot findings are addressed: the JP companion over-inclusion on SD rows (f5167e7) and the point-size deduplication (d27e73c).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7