### PR TITLE
chore: bump version to 1.6.0-nightly-2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.5.1
+version = 1.6.0-nightly-2
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Label the next nightly build `1.6.0-nightly-2`.
* **What changes are included?** One line: `[crosspoint] version` in `platformio.ini`, `1.5.1` → `1.6.0-nightly-2`.

That value is the single source for the version string on every target. How it renders:

| Target | Version reported |
|---|---|
| `default`, `sticky` | `matcha-reader-1.6.0-nightly-2-debug` |
| `x4pro` | `1.6.0-nightly-2-x4pro` |
| `papermono` | `1.6.0-nightly-2-papermono` |

The `matcha-reader-` prefix and `-debug` suffix come from `scripts/git_branch.py`, which wraps the base version for the two dev environments; the board environments append their own suffix in `platformio.ini`. So the value here is the bare version, without a `matcha` prefix of its own.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — n/a, this is a version bump, not a feature.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact:** the version string is a compile-time `-DCROSSPOINT_VERSION` literal in flash. `1.6.0-nightly-2` is seven bytes longer than `1.5.1`.

Verified by running `scripts/git_branch.py` standalone, which exercises its version logic against `platformio.ini` and prints the string it would inject: `matcha-reader-1.6.0-nightly-2-debug`. The value contains no quote or backslash characters, so it cannot break the C string literal it is substituted into. No local firmware build was run for a one-line string change — CI builds all four targets on this PR, which is the real check.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7)_