### PR TITLE
fix: two heap-tight vertical-layout failures on low-memory devices

### DIFF
--- a/lib/Epub/Epub/VerticalParsedText.cpp
+++ b/lib/Epub/Epub/VerticalParsedText.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 #include "GfxRenderer.h"
 #include "Kinsoku.h"
@@ -30,6 +31,51 @@ constexpr uint32_t SMALL_ALLOC_MARGIN = 8 * 1024;
 // -fno-exceptions, so nothing may be requested without first checking it fits. `margin` is what
 // the request must leave behind for everything else.
 inline bool heapCanAfford(const size_t bytes, const uint32_t margin) { return ESP.getMaxAllocHeap() >= bytes + margin; }
+
+// Cushion for the per-run reserves in addAnnotatedParagraph, which are a few hundred bytes each --
+// far below MIN_FREE_HEAP_FOR_RESERVE, sized for the multi-KB page and stream reserves. Charging
+// those a 4 KB margin refuses requests that fit with room to spare, and the doubling growth that
+// follows costs more allocations than the one it withheld: exactly what MIN_FREE_HEAP_FOR_RESERVE's
+// own comment warns against. This has only to cover what another task may take between the check
+// and the reserve; the fit itself is already guaranteed by getMaxAllocHeap().
+constexpr uint32_t PER_RUN_RESERVE_MARGIN = 1024;
+
+// Bulk reserve obeying that rule: skipped when the request would not fit, leaving the vector to
+// grow incrementally rather than aborting the process.
+template <typename T>
+void reserveIfAffordable(std::vector<T>& vec, const size_t count) {
+  if (count <= vec.capacity()) return;  // reserve() would not allocate; skip the heap query
+  // A count big enough to wrap the byte figure -- either in the multiply here or in
+  // heapCanAfford's margin add -- would compare as a SMALL request, pass the check, and abort in
+  // reserve(): the very failure this helper exists to prevent. Refuse it instead; the vector then
+  // grows incrementally, which is the same fallback an unaffordable request already takes.
+  if (count > (SIZE_MAX - PER_RUN_RESERVE_MARGIN) / sizeof(T)) return;
+  if (heapCanAfford(count * sizeof(T), PER_RUN_RESERVE_MARGIN)) vec.reserve(count);
+}
+
+// Upper bound on the entries a UTF-8 decode of `text` can append: one per decode step (one per
+// codepoint for well-formed UTF-8; malformed/truncated bytes still count as one step). One pass,
+// no allocation. Japanese sits at ~3 bytes per codepoint, where reserving by byte count instead
+// asks for ~3x the heap.
+size_t countUtf8Codepoints(const std::string& text) {
+  size_t count = 0;
+  for (size_t i = 0; i < text.size();) {
+    const unsigned char c0 = static_cast<unsigned char>(text[i]);
+    size_t consumed = 1;
+    if (c0 < 0x80) {
+      consumed = 1;
+    } else if ((c0 & 0xE0) == 0xC0 && i + 1 < text.size()) {
+      consumed = 2;
+    } else if ((c0 & 0xF0) == 0xE0 && i + 2 < text.size()) {
+      consumed = 3;
+    } else if ((c0 & 0xF8) == 0xF0 && i + 3 < text.size()) {
+      consumed = 4;
+    }
+    i += consumed;
+    count++;
+  }
+  return count;
+}
 
 // Make room for one more push_back. Tries a doubling first (amortised growth), then a small
 // linear step at each margin in turn, most protective first -- so a heap too tight for the
@@ -575,9 +621,12 @@ void VerticalParsedText::addAnnotatedParagraph(const std::vector<RubyRun>& runs,
     // character. Parallel to baseCps/baseOffsets.
     std::vector<uint32_t> baseCpIndex;
     std::vector<size_t> breakBeforeBaseIndex;
-    baseOffsets.reserve(run.baseText.size());
-    baseCps.reserve(run.baseText.size());
-    baseCpIndex.reserve(run.baseText.size());
+    // One entry per codepoint bounds all three: the decode below only ever drops entries
+    // (newlines, the second half of a composed kana diacritic), never adds one.
+    const size_t maxEntries = countUtf8Codepoints(run.baseText);
+    reserveIfAffordable(baseOffsets, maxEntries);
+    reserveIfAffordable(baseCps, maxEntries);
+    reserveIfAffordable(baseCpIndex, maxEntries);
     {
       size_t i = 0;
       uint32_t cpIndex = 0;

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1156,18 +1156,32 @@ struct LayoutPageSink final : ParagraphSink {
   void writeOne(const VerticalPage& p) {
     if (failed) return;  // a cancel latched mid-batch: the rest of this batch is discarded too
     if (pageOffsets.size() == pageOffsets.capacity()) {
-      // std::vector's automatic doubling throws/aborts when the heap is fragmented. Grow by a
-      // bounded step only when that exact contiguous block still leaves working headroom.
-      constexpr size_t kGrowth = 256;
-      constexpr size_t kHeadroom = 4 * 1024;
-      const size_t nextCapacity = pageOffsets.capacity() + kGrowth;
-      const size_t requestBytes = nextCapacity * sizeof(uint32_t);
-      if (ESP.getMaxAllocHeap() < requestBytes + kHeadroom || ESP.getFreeHeap() < requestBytes + kHeadroom) {
-        LOG_ERR("VSC", "OOM: page offset index (%zu pages, maxAlloc=%u)", pageOffsets.size(), ESP.getMaxAllocHeap());
+      // std::vector's automatic doubling throws/aborts when the heap is fragmented, so grow by a
+      // bounded step that still leaves working headroom. Step down through smaller ones rather
+      // than giving up on the first refusal: a smaller step costs extra reallocations, while
+      // giving up costs the whole chapter -- every page after this one is lost and the reader
+      // shows a page-load error. A long chapter of early-broken pages reaches this with the
+      // generous step unaffordable and a modest one perfectly affordable.
+      static constexpr size_t kGrowthSteps[] = {256, 64, 16};
+      static constexpr uint32_t kHeadrooms[] = {4 * 1024, 1024, 512};
+      static constexpr size_t kStepCount = sizeof(kGrowthSteps) / sizeof(kGrowthSteps[0]);
+      bool grew = false;
+      for (size_t i = 0; i < kStepCount; i++) {
+        const size_t nextCapacity = pageOffsets.capacity() + kGrowthSteps[i];
+        const size_t requestBytes = nextCapacity * sizeof(uint32_t);
+        if (ESP.getMaxAllocHeap() >= requestBytes + kHeadrooms[i] &&
+            ESP.getFreeHeap() >= requestBytes + kHeadrooms[i]) {
+          pageOffsets.reserve(nextCapacity);
+          grew = true;
+          break;
+        }
+      }
+      if (!grew) {
+        LOG_ERR("VSC", "OOM: page offset index (%zu pages, maxAlloc=%u, free=%u)", pageOffsets.size(),
+                ESP.getMaxAllocHeap(), ESP.getFreeHeap());
         failed = true;
         return;
       }
-      pageOffsets.reserve(nextCapacity);
     }
     pageOffsets.push_back(static_cast<uint32_t>(out.position()));
     // TRANSIENT staging buffer: allocated for this one write, freed before layout resumes.
@@ -1409,10 +1423,17 @@ constexpr size_t HEADER_PAGECOUNT_OFFSET = sizeof(uint8_t)     // version
 
 }  // namespace
 
+// Largest block the styled-block table needs before it is attempted. The table is all-or-nothing
+// (a partial one silently drops whichever selectors sit late in the file), so it is skipped rather
+// than truncated. See the collect site: it logs what the table actually costs, because this figure
+// predates SD CJK fonts and a resident one can hold maxAlloc below it for a whole session.
+constexpr uint32_t MIN_MAX_ALLOC_FOR_STYLED_BLOCKS = 48 * 1024;
+
 bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const uint16_t viewportWidth,
                                            const uint16_t viewportHeight, const uint8_t lineSpacing,
                                            const bool furiganaEnabled) {
   lastBuildDroppedForHeap_ = false;
+  lastBuildUnstyledForHeap_ = false;
   // Diagnostic: the "sparse page" investigation found maxAlloc already down at the very first
   // paragraph flush, staying flat for the rest of the chapter -- logging both metrics here checks
   // whether that low contiguous budget is a fresh drop from THIS chapter's own parsing, or whether
@@ -1527,12 +1548,12 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
     // Binary decision, no partial cap: the collector fills in CACHE order, so a reduced cap
     // silently drops whichever selectors happen to sit late in the file (confirmed earlier:
     // .k-solid boxes vanishing at a 64-entry cap). Either the full table fits, or the build
-    // runs unstyled AND is stamped stale so a later, roomier open rebuilds it properly.
+    // runs unstyled -- text-complete and still cached, see lastBuildUnstyledForHeap_.
     const uint32_t maxAllocNow = ESP.getMaxAllocHeap();
-    if (maxAllocNow < 48 * 1024) {
-      LOG_ERR("VSC", "Heap too tight for styled blocks (maxAlloc=%u); building unstyled, marked for rebuild",
-              maxAllocNow);
-      lastBuildDroppedForHeap_ = true;  // reuse the stale-stamp path: version 0 -> rebuild next open
+    if (maxAllocNow < MIN_MAX_ALLOC_FOR_STYLED_BLOCKS) {
+      LOG_ERR("VSC", "Heap too tight for styled blocks (maxAlloc=%u, need %u); building unstyled", maxAllocNow,
+              static_cast<unsigned>(MIN_MAX_ALLOC_FOR_STYLED_BLOCKS));
+      lastBuildUnstyledForHeap_ = true;
     } else {
       epub->getCssParser()->collectVerticalStyles(blockStyles);
       if (!blockStyles.empty()) {
@@ -1704,6 +1725,14 @@ bool VerticalSection::createSectionFile(const int fontId, const uint16_t viewpor
   }
   serialization::writePod(file, pageCount);
   serialization::writePod(file, indexOffset);
+  // Styling was skipped but every character is present, so the file is correct as text and is
+  // kept valid. Restamping it stale would rebuild the chapter on every open for a cosmetic
+  // difference -- and while a large SD CJK font is resident the condition never clears, so the
+  // rebuild would never win. Reported apart from a content drop because the two are not alike.
+  if (lastBuildUnstyledForHeap_ && !lastBuildDroppedForHeap_) {
+    LOG_INF("VSC", "Chapter cached without block styling (text complete)");
+  }
+
   // A build that dropped content on low heap produced sparse pages. Keep the file usable for
   // THIS session (offsets are in RAM, pages read back fine) but stamp version 0 so the next
   // open hits the version-mismatch path in loadSectionFile and rebuilds the chapter -- with,

--- a/lib/Epub/Epub/VerticalSection.h
+++ b/lib/Epub/Epub/VerticalSection.h
@@ -57,6 +57,10 @@ class VerticalSection {
   // file with version 0 so the next open sees a version mismatch and rebuilds the chapter --
   // instead of the truncation living on disk as a permanently sparse chapter.
   bool lastBuildDroppedForHeap_ = false;
+  // Set when only the styled-block table was skipped. The chapter's TEXT is complete; the book's
+  // own block styling is not. Kept apart from lastBuildDroppedForHeap_ because the two differ in
+  // kind: this one is cosmetic and must not be reported, or cached, as lost content.
+  bool lastBuildUnstyledForHeap_ = false;
   // Set by loadSectionFile when the on-disk cache carried the version-0 stale stamp (a prior
   // build dropped glyphs). If THIS build drops again, createSectionFile keeps the best-effort
   // cache valid instead of re-stamping: the drop conditions are deterministic per book, so

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2668,7 +2668,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // otherwise the on-disk file (finalized section, or a partial from a previous session).
     auto p = section->loadPage(section->currentPage);
     if (!p) {
-      LOG_ERR("ERS", "Failed to load page from SD - clearing section cache");
+      LOG_ERR("ERS", "Failed to load page %d of %u from SD - clearing section cache", section->currentPage,
+              static_cast<unsigned>(section->pageCount));
       automaticPageTurnActive = false;
       // Retrying rebuilds a transiently corrupt section and usually recovers, but a page that keeps
       // failing would loop forever on a blank screen, so bound the retries before giving up.


### PR DESCRIPTION
## Summary

Two confirmed fixes, found while diagnosing a 20pt-CJK-font crash and a follow-on "page load error" on a heap-tight device. Both are general low-heap correctness fixes — neither is specific to that font or size, and neither requires the font's own memory footprint to change.

**1. `abort()` in vertical layout (`c3e0f91`).** `addAnnotatedParagraph` reserved three per-run vectors with bare `reserve()`. Under `-fno-exceptions`, a failed `operator new` cannot return null — it aborts the process. A furigana-dense chapter laid out with ~4.6 KB free and a 2.4 KB largest block hit exactly that: `abort()` via `bad_alloc`/`__terminate`. Every other reserve in the file already goes through a `heapCanAfford()` check; these three were the only ones bypassing it. They're now guarded the same way, sized to codepoint count instead of byte count (~3× smaller requests for Japanese text), and the guard itself is checked against integer overflow.

**2. "Page load error" from two compounding bugs (`efd383a`):**
- A skipped CSS style table was reported and cached as if content had been *dropped*, so a heap-tight chapter rebuilt itself on every single open for a condition (a resident large CJK font) that never clears. Given its own flag; the cache now stays valid since the text itself is complete.
- The page-offset index grew by a fixed step and demanded a fixed 4 KB headroom on top, so one refusal threw away the *entire remaining chapter*. Device log: 640 pages held, `maxAlloc` 5108 — the growth step needed only 3584 bytes, refused solely because `3584 + 4096 > 5108`. It now steps down through smaller growths with proportionate headroom (the same ladder `growForOnePush` already uses for glyphs) before genuinely giving up.

Both were diagnosed with temporary on-device heap instrumentation (sampling `getFreeHeap()`/`getMaxAllocHeap()` at key points, written to the SD card so logs were readable without a serial cable). That instrumentation is **not** in this PR — it did its job and is stripped. Follow-up work on the font's own memory cost continues on a separate `font-investigation` branch.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — both are low-heap correctness bugs in existing vertical-layout code; this fork's own instrumentation is what surfaced them on-device.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact:** no new resident data structures. `pio run -e default`: RAM 56,828 B (17.3%), Flash 5,685,733 B (86.8%) — identical to the pre-investigation baseline; the two fixes change control flow and sizing, not what's held in memory. `pio check` (cppcheck, `--fail-on-defect low/medium/high`): clean.

**Areas to focus on:**
- The growth-step ladder in the page-offset index (`efd383a`) — a heap that genuinely has nothing left still fails on every step, which is intentional; the change only rescues the case where a smaller, still-useful step would have fit.
- `lastBuildUnstyledForHeap_` vs `lastBuildDroppedForHeap_` — these are now separate flags with separate meanings (cosmetic vs. content loss); a future change to either should keep that distinction.

Tested on X4.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_