### PR TITLE
feat: split French verb-pronoun inversions into selectable words

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Vocabulary, names and grammar each come from their own dictionary. If the book i
 
 Other languages get the same treatment from their StarDict dictionaries. A word at the start of a sentence keeps its accents and still resolves (`École` finds `école`), and French adds its own rules: `l'eau` looks up `eau`, `journaux` finds `journal`, `heureuse` finds `heureux`, and the regular conjugations resolve to the infinitive (`parlaient` → `parler`, `mangeons` → `manger`, `finissent` → `finir`). English and everything else fall back to plurals and verb endings. Irregular verbs that share no stem with their infinitive need a `.syn` file in the dictionary folder — see [docs/dictionary.md](docs/dictionary.md).
 
+In French books, a literary verb-subject inversion like `songeai-je` or `pense-t-il` splits into two selectable words (`songeai`/`je`, `pense`/`il`), so both the verb and the pronoun look up on their own. A genuine compound like `rendez-vous` or `grand-mère` still selects as one word.
+
 Reader Settings includes **Word Lookup Font Size** (Tiny, Small, Medium or Large) for adjusting dictionary entry text.
 
 <p align="center"><img src="docs/images/screenshots/word-lookup.png" width="260" alt="Word lookup with reading, part of speech, definitions and an example sentence"></p>

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,11 +90,19 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 83 (fork numbering)
+### Version 84 (fork numbering)
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Version 84 keeps the version 83 serialized layout unchanged. It was bumped
+because, in French books, a word ending in a hyphenated subject pronoun
+("songeai-je", "pense-t-il", "dit-elle") is now split into extra word tokens
+so the verb and the pronoun are each independently selectable for dictionary
+lookup, while a lexicalized compound like "rendez-vous" stays one token. This
+changes the token count and positions on any page cached under v83 that
+contains such a word.
 
 Version 83 merges upstream's v43 and v44 changes into the fork's format:
 paragraph base direction no longer follows a direction change on an inline

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -210,7 +210,11 @@ namespace {
 //      direction change on an inline element, and each page now stores the internal-link
 //      rectangles touch navigation taps. The first moves RTL lines, the second extends the
 //      serialized page body, so older caches neither match nor parse.
-constexpr uint8_t SECTION_FILE_VERSION = 83;
+// v84: keeps the v83 serialized layout unchanged. In French books, a word ending in a hyphenated
+//      subject pronoun ("songeai-je", "pense-t-il") is now split into extra word tokens so the
+//      verb and pronoun are independently selectable for dictionary lookup, changing the token
+//      count and positions on any cached page containing one.
+constexpr uint8_t SECTION_FILE_VERSION = 84;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -442,7 +442,7 @@ bool findFrenchInversionSplit(const char* word, const int wordLen, int& verbLen,
     // Euphonic "-t-", inserted only before il/elle/on to avoid a vowel hiatus: "pense-t-il".
     const bool takesEuphonicT =
         strcmp(pronoun, "il") == 0 || strcmp(pronoun, "elle") == 0 || strcmp(pronoun, "on") == 0;
-    if (takesEuphonicT && hyphenIndex >= 2 && word[hyphenIndex - 1] == 't' && word[hyphenIndex - 2] == '-' &&
+    if (takesEuphonicT && hyphenIndex >= 2 && (word[hyphenIndex - 1] | 0x20) == 't' && word[hyphenIndex - 2] == '-' &&
         hyphenIndex - 2 > 0) {
       verbLen = hyphenIndex - 2;
       connectorLen = 3;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -11,10 +11,12 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <iterator>
 #include <new>
 
 #include "../../../../src/fontIds.h"
+#include "../../../../src/util/InflectionRules.h"
 #include "Epub.h"
 #include "Epub/AsciiTextTransform.h"
 #include "Epub/Page.h"
@@ -398,6 +400,61 @@ void ChapterHtmlSlimParser::setCurrentPageVisibleOffset(const uint32_t offset) {
   currentPageVisibleOffsetSet = true;
 }
 
+// French verb-subject inversion (literary narration register): "songeai-je", "pense-t-il",
+// "dit-elle". The verb and the clitic subject pronoun are each meaningful dictionary headwords
+// on their own, unlike a genuine hyphenated compound (kFrenchInversionExceptions below), so
+// flushPartWordBuffer() below splits the buffered word into extra addWord() tokens glued
+// together with attachToPrevious -- the same "extra token, no gap" technique the U+00A0 handling
+// above uses to keep a non-breaking pair visually joined while giving each half its own token.
+constexpr const char* kFrenchInversionPronouns[] = {"je", "tu", "il", "elle", "on", "nous", "vous", "ils", "elles"};
+
+// Nouns that are historically verb-pronoun inversions but are lexicalized as a single headword
+// today ("un rendez-vous", "le qu'en-dira-t-on"), so the whole word must stay one token.
+constexpr const char* kFrenchInversionExceptions[] = {"rendez-vous", "qu'en-dira-t-on"};
+
+bool asciiEqualsCi(const char* a, const int aLen, const char* b) {
+  if (static_cast<size_t>(aLen) != strlen(b)) return false;
+  for (int i = 0; i < aLen; i++) {
+    if ((a[i] | 0x20) != (b[i] | 0x20)) return false;
+  }
+  return true;
+}
+
+bool asciiEndsWithCi(const char* word, const int wordLen, const char* suffix) {
+  const int suffixLen = static_cast<int>(strlen(suffix));
+  if (wordLen < suffixLen) return false;
+  return asciiEqualsCi(word + (wordLen - suffixLen), suffixLen, suffix);
+}
+
+// On a match, word[0, verbLen) is the verb and word[verbLen, verbLen + connectorLen) is the
+// literal "-" or "-t-" connector; the pronoun runs from there to the end. Returns false when
+// `word` does not end in a hyphenated subject pronoun, or is one of kFrenchInversionExceptions.
+bool findFrenchInversionSplit(const char* word, const int wordLen, int& verbLen, int& connectorLen) {
+  if (!memchr(word, '-', static_cast<size_t>(wordLen))) return false;
+  for (const char* exception : kFrenchInversionExceptions) {
+    if (asciiEqualsCi(word, wordLen, exception)) return false;
+  }
+  for (const char* pronoun : kFrenchInversionPronouns) {
+    if (!asciiEndsWithCi(word, wordLen, pronoun)) continue;
+    const int pronounLen = static_cast<int>(strlen(pronoun));
+    const int hyphenIndex = wordLen - pronounLen - 1;
+    if (hyphenIndex <= 0 || word[hyphenIndex] != '-') continue;
+    // Euphonic "-t-", inserted only before il/elle/on to avoid a vowel hiatus: "pense-t-il".
+    const bool takesEuphonicT =
+        strcmp(pronoun, "il") == 0 || strcmp(pronoun, "elle") == 0 || strcmp(pronoun, "on") == 0;
+    if (takesEuphonicT && hyphenIndex >= 2 && word[hyphenIndex - 1] == 't' && word[hyphenIndex - 2] == '-' &&
+        hyphenIndex - 2 > 0) {
+      verbLen = hyphenIndex - 2;
+      connectorLen = 3;
+      return true;
+    }
+    verbLen = hyphenIndex;
+    connectorLen = 1;
+    return true;
+  }
+  return false;
+}
+
 // flush the contents of partWordBuffer to currentTextBlock
 void ChapterHtmlSlimParser::flushPartWordBuffer() {
   if (!currentTextBlock) {
@@ -450,8 +507,46 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
     }
     linkId = currentFootnoteLinkId;
   }
-  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, wordFontId, partWordVisibleOffset,
-                            linkId);
+  if (frenchBookCache < 0) {
+    frenchBookCache =
+        (epub && InflectionRules::languageFromCode(epub->getLanguage().c_str()) == InflectionRules::Language::French)
+            ? 1
+            : 0;
+  }
+  int frenchVerbLen = 0;
+  int frenchConnectorLen = 0;
+  if (frenchBookCache &&
+      findFrenchInversionSplit(partWordBuffer, partWordBufferIndex, frenchVerbLen, frenchConnectorLen)) {
+    const int pronounStart = frenchVerbLen + frenchConnectorLen;
+
+    // The connector and pronoun are always plain ASCII, so only the verb needs counting.
+    uint32_t verbVisibleLen = 0;
+    const auto* verbPtr = reinterpret_cast<const unsigned char*>(partWordBuffer);
+    const unsigned char* const verbEnd = verbPtr + frenchVerbLen;
+    while (verbPtr < verbEnd) {
+      utf8NextCodepoint(&verbPtr);
+      verbVisibleLen++;
+    }
+
+    const char savedAtVerbEnd = partWordBuffer[frenchVerbLen];
+    partWordBuffer[frenchVerbLen] = '\0';
+    currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, wordFontId, partWordVisibleOffset,
+                              linkId);
+    partWordBuffer[frenchVerbLen] = savedAtVerbEnd;
+
+    const char savedAtPronounStart = partWordBuffer[pronounStart];
+    partWordBuffer[pronounStart] = '\0';
+    currentTextBlock->addWord(partWordBuffer + frenchVerbLen, fontStyle, false, true, wordFontId,
+                              partWordVisibleOffset + verbVisibleLen, linkId);
+    partWordBuffer[pronounStart] = savedAtPronounStart;
+
+    currentTextBlock->addWord(partWordBuffer + pronounStart, fontStyle, false, true, wordFontId,
+                              partWordVisibleOffset + verbVisibleLen + static_cast<uint32_t>(frenchConnectorLen),
+                              linkId);
+  } else {
+    currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, wordFontId, partWordVisibleOffset,
+                              linkId);
+  }
   if (insideTableCell && !tableRowStacked) {
     tableCellTextBytes += wordBytes;
     if (currentTextBlock->size() > MAX_GRID_TABLE_CELL_WORDS) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -412,7 +412,7 @@ constexpr const char* kFrenchInversionPronouns[] = {"je", "tu", "il", "elle", "o
 // today ("un rendez-vous", "le qu'en-dira-t-on"), so the whole word must stay one token.
 constexpr const char* kFrenchInversionExceptions[] = {"rendez-vous", "qu'en-dira-t-on"};
 
-bool asciiEqualsCi(const char* a, const int aLen, const char* b) {
+static bool asciiEqualsCi(const char* a, const int aLen, const char* b) {
   if (static_cast<size_t>(aLen) != strlen(b)) return false;
   for (int i = 0; i < aLen; i++) {
     if ((a[i] | 0x20) != (b[i] | 0x20)) return false;
@@ -420,7 +420,7 @@ bool asciiEqualsCi(const char* a, const int aLen, const char* b) {
   return true;
 }
 
-bool asciiEndsWithCi(const char* word, const int wordLen, const char* suffix) {
+static bool asciiEndsWithCi(const char* word, const int wordLen, const char* suffix) {
   const int suffixLen = static_cast<int>(strlen(suffix));
   if (wordLen < suffixLen) return false;
   return asciiEqualsCi(word + (wordLen - suffixLen), suffixLen, suffix);
@@ -429,7 +429,7 @@ bool asciiEndsWithCi(const char* word, const int wordLen, const char* suffix) {
 // On a match, word[0, verbLen) is the verb and word[verbLen, verbLen + connectorLen) is the
 // literal "-" or "-t-" connector; the pronoun runs from there to the end. Returns false when
 // `word` does not end in a hyphenated subject pronoun, or is one of kFrenchInversionExceptions.
-bool findFrenchInversionSplit(const char* word, const int wordLen, int& verbLen, int& connectorLen) {
+static bool findFrenchInversionSplit(const char* word, const int wordLen, int& verbLen, int& connectorLen) {
   if (!memchr(word, '-', static_cast<size_t>(wordLen))) return false;
   for (const char* exception : kFrenchInversionExceptions) {
     if (asciiEqualsCi(word, wordLen, exception)) return false;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstring>
 #include <iterator>
 #include <new>
@@ -426,18 +427,41 @@ static bool asciiEndsWithCi(const char* word, const int wordLen, const char* suf
   return asciiEqualsCi(word + (wordLen - suffixLen), suffixLen, suffix);
 }
 
+// Mirrors Dictionary::cleanWord()'s trailing trim (a byte is "word" if it's ASCII alnum or any
+// non-ASCII byte, with the 3-byte E2 80/81 xx General Punctuation sequences -- curly quotes,
+// dashes -- stripped as a unit) so "songeai-je," and "pense-t-il?" match the same as the bare
+// forms. Only shrinks the length used for matching: the buffer itself is untouched, so the
+// trimmed punctuation still renders as part of the pronoun's token in flushPartWordBuffer().
+static int trimmedLengthForFrenchInversionMatch(const char* word, int wordLen) {
+  const auto* bytes = reinterpret_cast<const unsigned char*>(word);
+  while (wordLen > 0) {
+    if (std::isalnum(bytes[wordLen - 1]) || bytes[wordLen - 1] >= 0x80) {
+      if (wordLen >= 3 && bytes[wordLen - 3] == 0xE2 && (bytes[wordLen - 2] == 0x80 || bytes[wordLen - 2] == 0x81)) {
+        wordLen -= 3;
+        continue;
+      }
+      break;
+    }
+    wordLen--;
+  }
+  return wordLen;
+}
+
 // On a match, word[0, verbLen) is the verb and word[verbLen, verbLen + connectorLen) is the
-// literal "-" or "-t-" connector; the pronoun runs from there to the end. Returns false when
-// `word` does not end in a hyphenated subject pronoun, or is one of kFrenchInversionExceptions.
+// literal "-" or "-t-" connector; the pronoun runs from there to the end of `word` (including
+// any trailing punctuation ignored for matching). Returns false when `word`, ignoring trailing
+// punctuation, does not end in a hyphenated subject pronoun, or is one of
+// kFrenchInversionExceptions.
 static bool findFrenchInversionSplit(const char* word, const int wordLen, int& verbLen, int& connectorLen) {
   if (!memchr(word, '-', static_cast<size_t>(wordLen))) return false;
+  const int matchLen = trimmedLengthForFrenchInversionMatch(word, wordLen);
   for (const char* exception : kFrenchInversionExceptions) {
-    if (asciiEqualsCi(word, wordLen, exception)) return false;
+    if (asciiEqualsCi(word, matchLen, exception)) return false;
   }
   for (const char* pronoun : kFrenchInversionPronouns) {
-    if (!asciiEndsWithCi(word, wordLen, pronoun)) continue;
+    if (!asciiEndsWithCi(word, matchLen, pronoun)) continue;
     const int pronounLen = static_cast<int>(strlen(pronoun));
-    const int hyphenIndex = wordLen - pronounLen - 1;
+    const int hyphenIndex = matchLen - pronounLen - 1;
     if (hyphenIndex <= 0 || word[hyphenIndex] != '-') continue;
     // Euphonic "-t-", inserted only before il/elle/on to avoid a vowel hiatus: "pense-t-il".
     const bool takesEuphonicT =

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -41,6 +41,10 @@ class ChapterHtmlSlimParser {
   char partWordBuffer[MAX_WORD_SIZE + 1] = {};
   int partWordBufferIndex = 0;
   bool nextWordContinues = false;  // true when next flushed word attaches to previous (inline element boundary)
+  // French verb-subject inversion splitting (flushPartWordBuffer): -1 = not yet computed,
+  // 0 = no, 1 = yes. Cached lazily so epub->getLanguage() is looked up once per chapter
+  // instead of once per flushed word.
+  int8_t frenchBookCache = -1;
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
   // Ruby text state
   bool inRuby = false;

--- a/test/chapter_html_slim_parser/CMakeLists.txt
+++ b/test/chapter_html_slim_parser/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(ChapterHtmlSlimParserTest
   ${REPO_ROOT}/lib/Epub/Epub/RubyGlossary.cpp
   ${REPO_ROOT}/lib/Epub/Epub/converters/ImageDimsProbe.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+  ${REPO_ROOT}/src/util/InflectionRules.cpp
 )
 
 target_include_directories(ChapterHtmlSlimParserTest PRIVATE

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -1,3 +1,4 @@
+#include <Epub.h>
 #include <Epub/Page.h>
 #include <GfxRenderer.h>
 #include <gtest/gtest.h>
@@ -6,6 +7,7 @@
 #include <array>
 #include <climits>
 #include <cstdint>
+#include <cstring>
 #include <deque>
 #include <filesystem>
 #include <functional>
@@ -92,5 +94,77 @@ TEST_P(ChapterHtmlSlimParserTest, KeepsCssVerticalAlignAndInternalLinkMetadata) 
 
 INSTANTIATE_TEST_SUITE_P(CssVerticalAlign, ChapterHtmlSlimParserTest,
                          ::testing::Values("vertical-align: super", "vertical-align: sub"));
+
+class ChapterHtmlSlimParserFrenchInversionTest : public ::testing::Test {
+ protected:
+  std::string filepath = "unused.xhtml";
+  GfxRenderer renderer;
+  CssParser cssParser{cssCacheDir()};
+  std::shared_ptr<Epub> epub = std::make_shared<Epub>();
+  std::unique_ptr<ChapterHtmlSlimParser> parser;
+
+  void makeParser(const char* language) {
+    epub->language = language;
+    parser = std::make_unique<ChapterHtmlSlimParser>(
+        epub, filepath, renderer, 0, 1.0f, false, 0, static_cast<uint16_t>(renderer.getScreenWidth()),
+        static_cast<uint16_t>(renderer.getScreenHeight()), false, false, false,
+        std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>{}, true, "", "", 0,
+        std::vector<std::string>{}, std::function<void()>{}, &cssParser);
+    parser->currentTextBlock = std::make_unique<ParsedText>(false);
+  }
+
+  // Feeds `text` and forces a flush, as if it were followed by whitespace.
+  void feedWord(const char* text) {
+    ChapterHtmlSlimParser::characterData(parser.get(), text, static_cast<int>(strlen(text)));
+    parser->flushPartWordBuffer();
+  }
+};
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsVerbAndPronoun) {
+  makeParser("fr");
+  feedWord("songeai-je");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 3u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "songeai");
+  EXPECT_EQ(parser->currentTextBlock->words[1], "-");
+  EXPECT_EQ(parser->currentTextBlock->words[2], "je");
+  // The connector and pronoun stay glued to the verb: no rendered gap, matching the source.
+  EXPECT_TRUE(parser->currentTextBlock->wordContinues[1]);
+  EXPECT_TRUE(parser->currentTextBlock->wordContinues[2]);
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsAroundEuphonicT) {
+  makeParser("fr");
+  feedWord("pense-t-il");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 3u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "pense");
+  EXPECT_EQ(parser->currentTextBlock->words[1], "-t-");
+  EXPECT_EQ(parser->currentTextBlock->words[2], "il");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsLexicalizedCompoundsWhole) {
+  makeParser("fr");
+  feedWord("rendez-vous");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 1u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "rendez-vous");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsOrdinaryCompoundsWhole) {
+  makeParser("fr");
+  feedWord("grand-mère");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 1u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "grand-mère");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, DoesNotSplitInNonFrenchBooks) {
+  makeParser("en");
+  feedWord("songeai-je");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 1u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "songeai-je");
+}
 
 }  // namespace

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -155,12 +155,42 @@ TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsAroundEuphonicTWhenUpperc
   EXPECT_EQ(parser->currentTextBlock->words[2], "IL");
 }
 
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsWithTrailingPunctuation) {
+  makeParser("fr");
+  // The tokenizer only splits on whitespace, so punctuation right after the inversion (a
+  // comma before a dialogue tag, a question mark) stays glued to the buffered word.
+  feedWord("songeai-je,");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 3u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "songeai");
+  EXPECT_EQ(parser->currentTextBlock->words[1], "-");
+  EXPECT_EQ(parser->currentTextBlock->words[2], "je,");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsAroundEuphonicTWithTrailingPunctuation) {
+  makeParser("fr");
+  feedWord("pense-t-il?");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 3u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "pense");
+  EXPECT_EQ(parser->currentTextBlock->words[1], "-t-");
+  EXPECT_EQ(parser->currentTextBlock->words[2], "il?");
+}
+
 TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsLexicalizedCompoundsWhole) {
   makeParser("fr");
   feedWord("rendez-vous");
 
   ASSERT_EQ(parser->currentTextBlock->size(), 1u);
   EXPECT_EQ(parser->currentTextBlock->words[0], "rendez-vous");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsLexicalizedCompoundsWholeWithTrailingPunctuation) {
+  makeParser("fr");
+  feedWord("rendez-vous.");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 1u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "rendez-vous.");
 }
 
 TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsSecondLexicalizedCompoundWhole) {

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -143,12 +143,33 @@ TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsAroundEuphonicT) {
   EXPECT_EQ(parser->currentTextBlock->words[2], "il");
 }
 
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, SplitsAroundEuphonicTWhenUppercased) {
+  makeParser("fr");
+  // Simulates the buffer after a CSS text-transform: uppercase run has already applied --
+  // the euphonic "-t-" check must fold case, not just match lowercase 't'.
+  feedWord("PENSE-T-IL");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 3u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "PENSE");
+  EXPECT_EQ(parser->currentTextBlock->words[1], "-T-");
+  EXPECT_EQ(parser->currentTextBlock->words[2], "IL");
+}
+
 TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsLexicalizedCompoundsWhole) {
   makeParser("fr");
   feedWord("rendez-vous");
 
   ASSERT_EQ(parser->currentTextBlock->size(), 1u);
   EXPECT_EQ(parser->currentTextBlock->words[0], "rendez-vous");
+}
+
+TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsSecondLexicalizedCompoundWhole) {
+  makeParser("fr");
+  // Would otherwise match the euphonic "-t-on" pattern (verb "dira" + pronoun "on").
+  feedWord("qu'en-dira-t-on");
+
+  ASSERT_EQ(parser->currentTextBlock->size(), 1u);
+  EXPECT_EQ(parser->currentTextBlock->words[0], "qu'en-dira-t-on");
 }
 
 TEST_F(ChapterHtmlSlimParserFrenchInversionTest, KeepsOrdinaryCompoundsWhole) {

--- a/test/chapter_html_slim_parser/stubs/Epub.h
+++ b/test/chapter_html_slim_parser/stubs/Epub.h
@@ -9,4 +9,8 @@ class Epub {
   bool readItemContentsToStream(const std::string&, Output&, size_t, bool = false) const {
     return false;
   }
+
+  // Settable directly by tests (there is no real EPUB metadata to parse here).
+  std::string language;
+  const std::string& getLanguage() const { return language; }
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Improve dictionary word-selection for French literary verb-subject inversions such as `songeai-je` and `pense-t-il`, so both the verb and the pronoun are independently tap-selectable, while genuine hyphenated compounds stay a single word.
* **What changes are included?**
  * `ChapterHtmlSlimParser::flushPartWordBuffer()` now detects a hyphenated subject-pronoun inversion (`je`, `tu`, `il`, `elle`, `on`, `nous`, `vous`, `ils`, `elles`, including the euphonic `-t-` form: `pense-t-il`) in French books and splits it into extra word tokens glued together with `attachToPrevious`, so the source still renders as one hyphenated run (`songeai-je`) but each half is its own selectable dictionary word.
  * A small exception list (`rendez-vous`, `qu'en-dira-t-on`) keeps lexicalized compounds that happen to end in a pronoun-lookalike whole. An ordinary compound like `grand-mère` never matches the pattern at all (it doesn't end in a subject pronoun) and stays one word, unaffected.
  * Gated to French books via `epub->getLanguage()` / `InflectionRules::languageFromCode()`, cached once per chapter parse rather than looked up per word.
  * `SECTION_FILE_VERSION` bumped 83 → 84 (see `docs/file-formats.md`) since a page cached under v83 containing such a word has the old single-token split.
  * README's dictionary section documents the new behavior.
  * New host tests in `test/chapter_html_slim_parser/` cover the split, the euphonic-t form, the exception list, an ordinary compound, and non-French books being unaffected.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this fork's own French dictionary rules are being extended here).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No new heap allocation: the split reuses the existing `partWordBuffer` in place (temporary null-terminator swaps), and the detection tables are `constexpr` (flash-resident).
* Verified: full host test suite (220/220 `ctest`), `pio run -e default` firmware build succeeds, `pio check` (cppcheck) reports no new high/medium findings, `./bin/clang-format-fix -g` made no changes.
* Not yet tested on hardware with a real French EPUB — flagging for human verification per the project's testing checklist.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7)_