### PR TITLE
fix: release font caches and gate heap before Manage Fonts' WiFi fetch

### DIFF
--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
@@ -24,14 +25,19 @@
 namespace fui = freeink::ui;
 
 namespace {
-// Entry gate for the families_ build, sized against the published manifest:
-// 21 families / 84 files in ~17KB of JSON, whose parsed document stays live
-// while families_ and its per-family strings and vectors are allocated beside
-// it. That peaks around 40KB, so require a little over it, plus a contiguous
-// block for the one big allocation (families_.reserve). Same shape and the same
-// reasoning as the styled-definition gate in DictHtmlPages.cpp.
-constexpr size_t MANIFEST_BUILD_MIN_FREE_HEAP = 48 * 1024;
-constexpr size_t MANIFEST_BUILD_MIN_MAX_ALLOC = 12 * 1024;
+// Entry gate for the whole manifest screen, sized against the published
+// manifest: 21 families / 84 files in ~17KB of JSON, whose parsed document
+// stays live while families_ and its per-family strings and vectors are
+// allocated beside it. That build peaks around 40KB, so require a little over
+// it, plus a contiguous block for the one big allocation (families_.reserve).
+// Same shape and the same reasoning as the styled-definition gate in
+// DictHtmlPages.cpp. Checked both before the fetch (issue #191: a book open on
+// a large SD-card font can leave too little heap for the WiFi/TLS connect
+// itself, which -- like the JSON build below -- runs std::string/std::vector
+// growth through the throwing operator new) and again before the build (the
+// TLS teardown in between fragments the heap further).
+constexpr size_t FONT_SCREEN_MIN_FREE_HEAP = 48 * 1024;
+constexpr size_t FONT_SCREEN_MIN_MAX_ALLOC = 12 * 1024;
 }  // namespace
 
 FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
@@ -108,6 +114,18 @@ void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdateAndWait();
 
+  // The reader that opened this screen keeps its EPUB, layout and SD-font caches
+  // resident underneath (activities are pushed on a stack, not replaced -- see
+  // ActivityManager), and the WiFi selection screen just shown may have rendered
+  // a CJK SSID and repopulated them further. That is exactly the setup
+  // CrossPointWebServerActivity and CalibreConnectActivity already release
+  // before their own WiFi-heavy work, for the same reason: reclaim what a
+  // Japanese book's SD font caches hold (tens of KB at a large size) before the
+  // TLS handshake and manifest build below, both of which run
+  // std::string/std::vector growth that aborts on OOM (issue #191). Fonts
+  // reload lazily once the reader resumes.
+  if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
+
   if (!fetchAndParseManifest()) {
     {
       RenderLock lock(*this);
@@ -134,6 +152,19 @@ void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
 // --- Manifest fetching ---
 
 bool FontDownloadActivity::fetchAndParseManifest() {
+  // Refuse before even opening the connection: the WiFi/TLS handshake and the
+  // manual HTTP client (SecureClient/SecureHttpClient) run their own
+  // std::string/std::vector growth with no heap gate of their own, on
+  // whatever the reader left behind -- entering this screen from inside a
+  // book on a large SD-card font can leave too little of it (issue #191).
+  // Failing fast here also skips a WiFi/TLS round trip that would only end in
+  // the same low-memory error once the build gate below is reached anyway.
+  if (ESP.getFreeHeap() < FONT_SCREEN_MIN_FREE_HEAP || ESP.getMaxAllocHeap() < FONT_SCREEN_MIN_MAX_ALLOC) {
+    LOG_ERR("FONT", "Low heap before manifest fetch (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+    errorMessage_ = tr(STR_LOW_MEMORY_RETRY);
+    return false;
+  }
+
   // Download manifest to a temp file on SD card to avoid holding both
   // TLS buffers and the full JSON string in RAM simultaneously.
   static constexpr const char* MANIFEST_TMP = "/fonts_manifest.tmp";
@@ -182,8 +213,8 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   // operator new, which under -fno-exceptions calls abort() instead of returning
   // null, so exhausting the heap here panics to the boot screen instead of
   // reporting a failure. Refuse up front, while refusing is still possible.
-  if (ESP.getFreeHeap() < MANIFEST_BUILD_MIN_FREE_HEAP || ESP.getMaxAllocHeap() < MANIFEST_BUILD_MIN_MAX_ALLOC) {
-    LOG_ERR("FONT", "Low heap for manifest (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+  if (ESP.getFreeHeap() < FONT_SCREEN_MIN_FREE_HEAP || ESP.getMaxAllocHeap() < FONT_SCREEN_MIN_MAX_ALLOC) {
+    LOG_ERR("FONT", "Low heap for manifest build (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
     errorMessage_ = tr(STR_LOW_MEMORY_RETRY);
     return false;
   }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix issue #191: Manage Fonts still panics to the boot screen on nightly-2, even with the low-heap gate `4e3bbec` already added around the post-download JSON build.
* **What changes are included?**
  * The reporter's new log (issue #191, second comment) shows the crash moved *earlier* than the code that gate covers: WiFi connects and the manifest GET starts, then the device resets before any of that gated code is ever reached. Two gaps, both upstream of the existing gate:
    1. **Release the reader's resident font caches before the network work.** Activities are pushed on a stack, not replaced (`ActivityManager`), so the book's EPUB, layout and SD-font caches stay fully resident under this screen — worse at a large SD font size (the reporter was on size 20). `CrossPointWebServerActivity` and `CalibreConnectActivity` already release them before their own WiFi-heavy work for exactly this reason (a prior field crash is documented in the former's comments); `FontDownloadActivity` was the one network activity missing it. Released once the WiFi picker (which can itself repopulate the caches with a CJK SSID) has completed; fonts reload lazily when the reader resumes.
    2. **Extend the existing heap gate to also cover the fetch, not just the post-parse build.** The WiFi/TLS layer (`SecureClient`/`SecureHttpClient`) has no heap gate of its own — it runs the same `std::string`/`std::vector` growth through the throwing `operator new` that aborts under `-fno-exceptions`. Reused the same vetted 48KB/12KB thresholds (renamed `FONT_SCREEN_MIN_*` since they now guard both sites) so a device still too tight gets the graceful low-memory message instead of a reboot, and skips a doomed WiFi/TLS round trip.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this is a crash fix in this fork's own Manage Fonts feature).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No new heap allocation: this only *releases* memory earlier and adds an early-exit heap check reusing existing constants (renamed, not duplicated).
* Verified: `pio run -e default` firmware build succeeds, `pio check` (cppcheck) reports no defects, `./bin/clang-format-fix -g` made no further changes.
* **Not hardware-verified.** The reporter isn't available for another debug round (no raw crash backtrace, only an app-level log that cuts off right as the WiFi fetch starts), so this is the best evidence-based fix given the two real gaps found by code inspection rather than a confirmed exact abort line. Flagging for human verification on an X3 with a large SD-card font mid-book, per the project's testing checklist.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7)_