### PR TITLE
fix: preserve image aspect ratio when CSS sets both width and height

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1576,26 +1576,31 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 }
 
                 if (hasCssHeight && hasCssWidth && dims.width > 0 && dims.height > 0) {
-                  // Both CSS height and width set: resolve both, then clamp to viewport preserving requested ratio
-                  displayHeight = static_cast<int>(
+                  // Both CSS height and width set: treat them as a bounding box and fit the
+                  // image within it preserving its own aspect ratio, the same as the
+                  // width-only/height-only branches below, rather than stretching to the
+                  // requested box. A stylesheet rule reused across images with different
+                  // intrinsic ratios (e.g. a template sized for a wide banner applied to a
+                  // roughly-square chapter-heading sketch) would otherwise visibly distort
+                  // the artwork.
+                  int boxHeight = static_cast<int>(
                       imgStyle.imageHeight.toPixels(emSize, static_cast<float>(self->viewportHeight)) + 0.5f);
-                  displayWidth =
+                  int boxWidth =
                       static_cast<int>(imgStyle.imageWidth.toPixels(emSize, static_cast<float>(containerWidth)) + 0.5f);
-                  if (displayHeight < 1) displayHeight = 1;
+                  if (boxHeight < 1) boxHeight = 1;
+                  if (boxWidth < 1) boxWidth = 1;
+                  if (boxWidth > containerWidth) boxWidth = containerWidth;
+                  if (boxHeight > self->viewportHeight) boxHeight = self->viewportHeight;
+
+                  const float scaleX = static_cast<float>(boxWidth) / dims.width;
+                  const float scaleY = static_cast<float>(boxHeight) / dims.height;
+                  const float scale = (scaleX < scaleY) ? scaleX : scaleY;
+                  displayWidth = static_cast<int>(dims.width * scale + 0.5f);
+                  displayHeight = static_cast<int>(dims.height * scale + 0.5f);
                   if (displayWidth < 1) displayWidth = 1;
-                  if (displayWidth > containerWidth || displayHeight > self->viewportHeight) {
-                    float scaleX =
-                        (displayWidth > containerWidth) ? static_cast<float>(containerWidth) / displayWidth : 1.0f;
-                    float scaleY = (displayHeight > self->viewportHeight)
-                                       ? static_cast<float>(self->viewportHeight) / displayHeight
-                                       : 1.0f;
-                    float scale = (scaleX < scaleY) ? scaleX : scaleY;
-                    displayWidth = static_cast<int>(displayWidth * scale + 0.5f);
-                    displayHeight = static_cast<int>(displayHeight * scale + 0.5f);
-                    if (displayWidth < 1) displayWidth = 1;
-                    if (displayHeight < 1) displayHeight = 1;
-                  }
-                  LOG_DBG("EHP", "Display size from CSS height+width: %dx%d", displayWidth, displayHeight);
+                  if (displayHeight < 1) displayHeight = 1;
+                  LOG_DBG("EHP", "Display size from CSS height+width (aspect preserved): %dx%d", displayWidth,
+                          displayHeight);
                 } else if (hasCssHeight && !hasCssWidth && dims.width > 0 && dims.height > 0) {
                   // Use CSS height (resolve % against viewport height) and derive width from aspect ratio
                   displayHeight = static_cast<int>(

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1599,6 +1599,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   displayHeight = static_cast<int>(dims.height * scale + 0.5f);
                   if (displayWidth < 1) displayWidth = 1;
                   if (displayHeight < 1) displayHeight = 1;
+                  // Rounding can push the result a pixel past the box; clamp to honor
+                  // the "fit within the box" contract exactly.
+                  if (displayWidth > boxWidth) displayWidth = boxWidth;
+                  if (displayHeight > boxHeight) displayHeight = boxHeight;
                   LOG_DBG("EHP", "Display size from CSS height+width (aspect preserved): %dx%d", displayWidth,
                           displayHeight);
                 } else if (hasCssHeight && !hasCssWidth && dims.width > 0 && dims.height > 0) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a decorative chapter-heading image rendering stretched/squished on-device when the EPUB's CSS sets both `width` and `height`.
* **What changes are included?**
  * `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp`: in the "both CSS height and width set" branch of the image-sizing logic, the code resolved each dimension independently from CSS and only clamped the pair to the viewport preserving the *requested* (CSS) ratio — it never checked that ratio against the image's own intrinsic aspect ratio. A stylesheet rule reused across images with different proportions (e.g. a template sized for a wide banner applied to a roughly-square sketch) visibly stretches the artwork. The three sibling branches (height-only, width-only, no CSS size at all) already derive the missing dimension from the image's real aspect ratio; this was the one un-guarded case.
  * Now treats the resolved width+height as a bounding box and fits the image within it preserving its own ratio (`object-fit: contain` semantics), matching the sibling branches. When the stylesheet's declared ratio already matches the image, the computed size is unchanged — this only affects the mismatched case.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a rendering bug fix for existing EPUB image display; not a new feature.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No new heap allocation — this only changes how a few existing `int`/`float` locals are computed.
* No dedicated automated test added: this file has no existing test coverage for `<img>` sizing (it requires a live `Epub` instance serving in-memory image bytes via `readItemContentsToStream`, which no current test fixture provides), and the three sibling branches this change now matches are themselves untested by the same gap. Verified by hand-checking the arithmetic against several width/height/aspect-ratio combinations (matching ratio → unchanged size; mismatched ratio → no longer stretched) plus the full existing suite.
* Verified: full host test suite (231/231 `ctest`, including all `ChapterHtmlSlimParserTest` cases), `pio run -e default` firmware build succeeds, `pio check` (cppcheck) reports no new defects, `./bin/clang-format-fix -g` made no further changes.
* Please verify visually on-device with the EPUB that surfaced this (a chapter-heading illustration whose stylesheet sets both `width` and `height`) — this was diagnosed from a device photo, not reproduced locally against the specific book.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkQxgTKNXGTMJwdWQh94p7)_