### PR TITLE
feat: render CSS drop caps with wrap-around text

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A wallpaper laid over the page you were reading, so the book shows through inste
 - A built-in CJK fallback font, so the odd kanji in a non-Japanese book still renders
 - **Optimize EPUB** on upload: splits single-file Japanese novels into real chapters with a working table of contents, and fits images to the screen as dithered 1-bit BMPs
 - More of the book's own CSS respected: headings sized as headings, line spacing, page breaks, boxed asides, and rules written as `.callout p`
+- Drop caps: a chapter opening styled with `::first-letter { font-size: … }` gets the enlarged initial the book asked for, with the first few lines wrapping around it
 - **Use Book Margins** (Text Settings > Layout, on by default) keeps the indents a book sets for itself, so epigraphs and long quotations stay inset. Turn it off and those blocks sit flush with the body text
 - Instant image page turns, since the next image decodes in the background
 - Next-book suggestions at the end of EPUB, TXT/Markdown, XTC and manga books

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,11 +90,19 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 84 (fork numbering)
+### Version 85 (fork numbering)
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Version 85 extends each text block's record with a drop cap trailer — the
+enlarged letter's codepoint (u32), its ink origin relative to the block (two
+i16) and its glyph magnification (u8), all zero on the lines that have none.
+The layout changes with it: a paragraph whose stylesheet declares
+`::first-letter { font-size: ... }` at 2x or more now takes that letter out of
+the text flow and reserves a column for it, so the opening lines are broken to
+a narrower width and their words sit at new x positions.
 
 Version 84 keeps the version 83 serialized layout unchanged. It was bumped
 because, in French books, a word ending in a hyphenated subject pronoun

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -98,7 +98,8 @@ current reader settings, the section is discarded and rebuilt.
 
 Version 85 extends each text block's record with a drop cap trailer — the
 enlarged letter's codepoint (u32), its ink origin relative to the block (two
-i16) and its glyph magnification (u8), all zero on the lines that have none.
+i16), its glyph magnification (u8) and the face it is drawn in (u8, bits 0-1),
+all zero on the lines that have none.
 The layout changes with it: a paragraph whose stylesheet declares
 `::first-letter { font-size: ... }` at 2x or more now takes that letter out of
 the text flow and reserves a column for it, so the opening lines are broken to

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,11 +90,46 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 85 (fork numbering)
+### Version 90 (fork numbering)
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
+
+Version 90 keeps the version 89 framing unchanged. An inline `font-size`
+that the built-in font ladder cannot serve — a single-size SD-card reader font
+has no 12/14/16/18pt siblings to snap to — is now honoured by scaling the
+glyph bitmap instead of being dropped, at a scale snapped to an eighth. The
+per-word font slot carries that scale as a negative tag rather than a font id.
+`<small>` runs that previously rendered at body size are now narrower, so any
+line containing one breaks and positions differently.
+
+Version 89 extends the drop cap trailer with the opening mark's codepoint
+(u32, zero when there is none), so the record is 4 bytes longer than version
+88's and the two framings are not interchangeable. Punctuation a paragraph
+opens with before its initial — the em dash of a French chapter opening —
+now leaves the text flow together with the letter and is drawn at body size
+immediately left of it. Left in the flow it appeared to the *right* of the
+initial, because the flow begins where the reserved column ends.
+
+Version 88 keeps the version 85 serialized layout unchanged. It was bumped
+because the initial no longer has to be the paragraph's first token: a French
+chapter opening (`—&#160;<span class="let">L</span>…`) tokenizes the em dash
+and the no-break space ahead of the lettrine, and those paragraphs now get the
+reserved column and reflowed opening lines as well.
+
+Version 87 keeps the version 85 serialized layout unchanged. It was bumped
+because a paragraph opened by an enlarged single-letter span
+(`<p><span class="lettrine">L</span>…`) is now treated as an initial as well,
+which is how many trade EPUBs mark a drop cap up instead of using a
+pseudo-element at all. Those paragraphs gain the reserved column and the
+reflowed opening lines a version 86 cache was built without.
+
+Version 86 keeps the version 85 serialized layout unchanged. It was bumped
+because the drop cap selector is now also recognised in its CSS 2.1 one-colon
+spelling (`p:first-letter`, alongside `p::first-letter`), so a book written
+that way gains drop caps — and with them the reserved column and the reflowed
+opening lines a version 85 cache was built without.
 
 Version 85 extends each text block's record with a drop cap trailer — the
 enlarged letter's codepoint (u32), its ink origin relative to the block (two

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -699,6 +699,146 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
   }
   return 0;
 }
+
+int ParsedText::resolveLineIndent(const size_t lineIndex, const GfxRenderer& renderer, const int fontId) const {
+  if (blockStyle.hasDropCap()) {
+    // The enlarged letter takes the place of the first-line indent -- applying both would push
+    // the opening words a further three spaces off a column that is already inset.
+    return lineIndex < blockStyle.dropCapLines ? blockStyle.dropCapIndent : 0;
+  }
+  return resolveFirstLineIndent(lineIndex == 0 && !dropCapLinesEmitted, renderer, fontId);
+}
+
+namespace {
+
+// A drop cap is only meaningful on a letter. Digits and punctuation are excluded because a
+// stylesheet applies `::first-letter` to whole classes of paragraph, and one that happens to
+// open with a quote mark or a numeral would otherwise blow that character up to four lines
+// tall. Non-ASCII is assumed to be a letter (accented capitals, Cyrillic, Greek).
+bool isDropCapLetter(const uint32_t cp) {
+  if (cp >= 0x80) return true;
+  return (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');
+}
+
+}  // namespace
+
+bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, const int pageWidth) {
+  if (words.empty() || words[0].empty()) return false;
+
+  const auto* ptr = reinterpret_cast<const unsigned char*>(words[0].c_str());
+  const auto* const start = ptr;
+  const uint32_t cp = utf8NextCodepoint(&ptr);
+  if (cp == 0 || !isDropCapLetter(cp)) return false;
+  const size_t letterBytes = static_cast<size_t>(ptr - start);
+
+  int glyphLeft = 0;
+  int glyphWidth = 0;
+  int glyphTop = 0;
+  int glyphHeight = 0;
+  if (!renderer.getGlyphMetrics(fontId, cp, EpdFontFamily::REGULAR, &glyphLeft, &glyphWidth, &glyphTop, &glyphHeight)) {
+    return false;
+  }
+  if (glyphWidth <= 0 || glyphHeight <= 0) return false;
+
+  // Magnify by whole pixels only (see GfxRenderer::drawCharUpscaled). Floor rather than round,
+  // so the letter never grows past the lines it is meant to sit beside; the small shortfall
+  // reads as the optical gap a drop cap normally keeps above the baseline it lands on.
+  const int lineHeight = renderer.getLineHeight(fontId);
+  const int targetHeight = lineHeight * blockStyle.dropCapLines;
+  int scale = targetHeight / glyphHeight;
+  if (scale > TextBlock::MAX_DROP_CAP_SCALE) scale = TextBlock::MAX_DROP_CAP_SCALE;
+  // Below 2x this is not a wrap-around drop cap, just a slightly bigger letter, and the
+  // narrowed lines would cost more than the effect is worth. Leave the letter in the text.
+  if (scale < 2) return false;
+
+  const int gap = renderer.getSpaceWidth(fontId, EpdFontFamily::REGULAR);
+  const int indent = glyphWidth * scale + gap;
+  // A column this wide leaves too little for the text beside it to break sensibly; the greedy
+  // fill would put one word per line and any long word would overhang the margin.
+  if (indent > pageWidth / 3) return false;
+
+  dropCap.cp = cp;
+  dropCap.scale = static_cast<uint8_t>(scale);
+  // Ink box origin relative to the block's, on the side the reserved column sits.
+  dropCap.inkLeft = blockStyle.isRtl ? static_cast<int16_t>(pageWidth - glyphWidth * scale) : 0;
+  // Align the enlarged letter's ink top with where the first line's own capitals start, so the
+  // two share a top edge instead of the drop cap floating above or sinking into the line.
+  dropCap.inkTop = static_cast<int16_t>(renderer.getFontAscenderSize(fontId) - glyphTop);
+  blockStyle.dropCapIndent = static_cast<int16_t>(indent);
+
+  // The letter now belongs to the drop cap, not to the text flow -- CSS ::first-letter styles
+  // it in place, and drawing it here as well would double it. Its visible-codepoint offset
+  // stays with the word so selection and progress positions do not shift.
+  words[0].erase(0, letterBytes);
+  if (words[0].empty()) {
+    // The whole first token was the letter (a one-character opening word). Drop the now-empty
+    // token, keeping every parallel array in lockstep exactly as layoutAndExtractLines does.
+    words.erase(words.begin());
+    wordStyles.erase(wordStyles.begin());
+    wordContinues.erase(wordContinues.begin());
+    wordNoSpaceBefore.erase(wordNoSpaceBefore.begin());
+    wordFocusBoundary.erase(wordFocusBoundary.begin());
+    if (!wordFonts.empty()) wordFonts.erase(wordFonts.begin());
+    wordLinkIds.erase(wordLinkIds.begin());
+    eraseVisibleOffsetPrefix(1);
+    if (!rubyTexts.empty()) rubyTexts.erase(rubyTexts.begin());
+  } else if (!wordFocusBoundary.empty() && wordFocusBoundary[0] != 0) {
+    // The focus-reading bold prefix is a BYTE count into the word that just got shorter.
+    wordFocusBoundary[0] =
+        static_cast<uint8_t>(wordFocusBoundary[0] > letterBytes ? wordFocusBoundary[0] - letterBytes : 0);
+  }
+  return true;
+}
+
+std::vector<size_t> ParsedText::computeDropCapLineBreaks(const GfxRenderer& renderer, const int fontId,
+                                                         const int pageWidth, const std::vector<uint16_t>& wordWidths,
+                                                         const std::vector<bool>& continuesVec,
+                                                         const std::vector<bool>& noSpaceBeforeVec) const {
+  // Greedy, not the optimal DP in computeLineBreaks: dp[i] is keyed by the word that STARTS a
+  // line, and of the lines beside a drop cap only line 0's start is known before the solution
+  // exists -- lines 1..N-1 begin wherever line 0 happened to break. Threading a line count
+  // through that DP would change the cost function every paragraph in every book goes through,
+  // to gain optimality on at most four lines of one paragraph per chapter whose width is FIXED
+  // (unlike the paragraph tail the DP exists to balance). The hyphenated path is greedy for the
+  // whole paragraph already, so this is the behaviour books ship with either way.
+  std::vector<size_t> breaks;
+  breaks.reserve(blockStyle.dropCapLines);
+
+  const size_t total = words.size();
+  size_t start = 0;
+  for (uint8_t line = 0; line < blockStyle.dropCapLines && start < total; ++line) {
+    const int avail = pageWidth - resolveLineIndent(line, renderer, fontId);
+    int used = 0;
+    size_t best = start;  // words committed at the last break the boundary flags allow
+
+    for (size_t j = start; j < total; ++j) {
+      int gap = 0;
+      if (j > start) {
+        if (continuesVec[j]) {
+          gap = renderer.getKerning(fontId, lastCodepoint(words[j - 1]), firstCodepoint(words[j]), wordStyles[j - 1]);
+        } else if (!noSpaceBeforeVec[j]) {
+          gap = renderer.getSpaceAdvance(fontId, lastCodepoint(words[j - 1]), firstCodepoint(words[j]),
+                                         wordStyles[j - 1], blockStyle.letterSpacing);
+        }
+      }
+      const int candidate = used + gap + wordWidths[j];
+      const bool overflows = candidate > avail;
+      if (overflows && best > start) break;  // this word does not fit; keep the last legal break
+      used = candidate;
+      if (j + 1 >= total || TokenBoundary::allowsBreak(continuesVec[j + 1], noSpaceBeforeVec[j + 1])) {
+        best = j + 1;
+        if (overflows) break;  // an unbreakable run had to overflow to reach a legal break
+      }
+    }
+
+    // No legal break anywhere ahead: give the line one word, the same concession the DP makes
+    // for a word wider than the column (dp[i] == MAX_COST).
+    if (best <= start) best = start + 1;
+    breaks.push_back(best);
+    start = best;
+  }
+  return breaks;
+}
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int baseFontId, const uint16_t viewportWidth,
                                        const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
@@ -754,7 +894,42 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int ba
   }
 
   const int pageWidth = viewportWidth;
+
+  // Drop cap: claim the first letter before the widths are measured, so the shortened opening
+  // word is measured as it will be drawn.
+  if (blockStyle.dropCapLines > 0 && !dropCapResolved) {
+    dropCapResolved = true;
+    if (!prepareDropCap(renderer, fontId, pageWidth)) {
+      blockStyle.dropCapLines = 0;  // letter stays in the text and renders inline
+    } else if (words.empty()) {
+      return;  // the paragraph was the single letter
+    }
+  }
+
   auto wordWidths = calculateWordWidths(renderer, fontId);
+
+  // The lines beside the enlarged letter, laid out against the reserved column, then removed
+  // from the pass so the rest of the paragraph flows at full width through the usual DP.
+  if (blockStyle.hasDropCap()) {
+    const std::vector<size_t> dropCapBreaks =
+        computeDropCapLineBreaks(renderer, fontId, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore);
+    for (size_t i = 0; i < dropCapBreaks.size(); ++i) {
+      extractLine(i, pageWidth, wordWidths, wordContinues, wordNoSpaceBefore, dropCapBreaks, processLine, renderer,
+                  fontId);
+    }
+    if (!dropCapBreaks.empty()) {
+      consumeWords(dropCapBreaks.back());
+      wordWidths.erase(wordWidths.begin(), wordWidths.begin() + std::min(dropCapBreaks.back(), wordWidths.size()));
+    }
+    // Cleared together: the column is behind us, so the remaining lines take the full width,
+    // and the paragraph tail's own first line -- which reaches extractLine with breakIndex 0
+    // like any other -- cannot pick the enlarged letter up and draw it a second time.
+    blockStyle.dropCapLines = 0;
+    blockStyle.dropCapIndent = 0;
+    dropCap = TextBlock::DropCap{};
+    dropCapLinesEmitted = true;
+    if (words.empty()) return;
+  }
 
   std::vector<size_t> lineBreakIndices;
   if (hyphenationActive) {
@@ -773,22 +948,26 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int ba
 
   // Remove consumed words so size() reflects only remaining words
   if (lineCount > 0) {
-    const size_t consumed = lineBreakIndices[lineCount - 1];
-    words.erase(words.begin(), words.begin() + consumed);
-    wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
-    wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
-    wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + consumed);
-    wordFocusBoundary.erase(wordFocusBoundary.begin(), wordFocusBoundary.begin() + consumed);
-    if (!wordFonts.empty()) {
-      const size_t wfConsumed = std::min(consumed, wordFonts.size());
-      wordFonts.erase(wordFonts.begin(), wordFonts.begin() + wfConsumed);
-    }
-    wordLinkIds.erase(wordLinkIds.begin(), wordLinkIds.begin() + consumed);
-    eraseVisibleOffsetPrefix(consumed);
-    if (!rubyTexts.empty()) {
-      const size_t rtConsumed = std::min(consumed, rubyTexts.size());
-      rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + rtConsumed);
-    }
+    consumeWords(lineBreakIndices[lineCount - 1]);
+  }
+}
+
+void ParsedText::consumeWords(const size_t consumed) {
+  if (consumed == 0) return;
+  words.erase(words.begin(), words.begin() + consumed);
+  wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
+  wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
+  wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + consumed);
+  wordFocusBoundary.erase(wordFocusBoundary.begin(), wordFocusBoundary.begin() + consumed);
+  if (!wordFonts.empty()) {
+    const size_t wfConsumed = std::min(consumed, wordFonts.size());
+    wordFonts.erase(wordFonts.begin(), wordFonts.begin() + wfConsumed);
+  }
+  wordLinkIds.erase(wordLinkIds.begin(), wordLinkIds.begin() + consumed);
+  eraseVisibleOffsetPrefix(consumed);
+  if (!rubyTexts.empty()) {
+    const size_t rtConsumed = std::min(consumed, rubyTexts.size());
+    rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + rtConsumed);
   }
 }
 
@@ -987,7 +1166,10 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
     return {};
   }
 
-  const int firstLineIndent = resolveFirstLineIndent(true, renderer, fontId);
+  // Line 0 of THIS pass, through the same resolver extractLine uses: after a drop cap's
+  // lines the paragraph tail re-enters here as line 0 with no first-line indent, and a
+  // width measured against one the drawing would not apply breaks the line short.
+  const int firstLineIndent = resolveLineIndent(0, renderer, fontId);
 
   // Ensure any word that would overflow even as the first entry on a line is split using fallback hyphenation.
   for (size_t i = 0; i < wordWidths.size(); ++i) {
@@ -1110,7 +1292,10 @@ std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& r
                                                             const int pageWidth, std::vector<uint16_t>& wordWidths,
                                                             std::vector<bool>& continuesVec,
                                                             std::vector<bool>& noSpaceBeforeVec) {
-  const int firstLineIndent = resolveFirstLineIndent(true, renderer, fontId);
+  // Line 0 of THIS pass, through the same resolver extractLine uses: after a drop cap's
+  // lines the paragraph tail re-enters here as line 0 with no first-line indent, and a
+  // width measured against one the drawing would not apply breaks the line short.
+  const int firstLineIndent = resolveLineIndent(0, renderer, fontId);
 
   std::vector<size_t> lineBreakIndices;
   size_t currentIndex = 0;
@@ -1305,7 +1490,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   const size_t lineWordCount = lineBreak - lastBreakAt;
   const uint32_t lineVisibleOffset = visibleOffsetAt(lastBreakAt);
 
-  const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0, renderer, fontId);
+  const int firstLineIndent = resolveLineIndent(breakIndex, renderer, fontId);
 
   std::vector<std::string> lineRubyTexts(lineWordCount);
   if (!rubyTexts.empty() && lastBreakAt < rubyTexts.size()) {
@@ -1683,6 +1868,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
       return;
     }
+    if (breakIndex == 0 && dropCap.present()) block->setDropCap(dropCap);
     processLine(std::move(block), lineVisibleOffset);
     return;
   }
@@ -1708,5 +1894,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
     return;
   }
+  if (breakIndex == 0 && dropCap.present()) block->setDropCap(dropCap);
   processLine(std::move(block), lineVisibleOffset);
 }

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -731,11 +731,16 @@ bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, c
   if (cp == 0 || !isDropCapLetter(cp)) return false;
   const size_t letterBytes = static_cast<size_t>(ptr - start);
 
+  // The face of the word the letter comes from -- an italic chapter opening keeps an italic
+  // initial. Read before the peel below, which can drop the token entirely.
+  const auto style = static_cast<EpdFontFamily::Style>(
+      wordStyles.empty() ? 0 : static_cast<uint8_t>(wordStyles[0]) & TextBlock::DROP_CAP_STYLE_MASK);
+
   int glyphLeft = 0;
   int glyphWidth = 0;
   int glyphTop = 0;
   int glyphHeight = 0;
-  if (!renderer.getGlyphMetrics(fontId, cp, EpdFontFamily::REGULAR, &glyphLeft, &glyphWidth, &glyphTop, &glyphHeight)) {
+  if (!renderer.getGlyphMetrics(fontId, cp, style, &glyphLeft, &glyphWidth, &glyphTop, &glyphHeight)) {
     return false;
   }
   if (glyphWidth <= 0 || glyphHeight <= 0) return false;
@@ -759,6 +764,7 @@ bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, c
 
   dropCap.cp = cp;
   dropCap.scale = static_cast<uint8_t>(scale);
+  dropCap.style = static_cast<uint8_t>(style);
   // Ink box origin relative to the block's, on the side the reserved column sits.
   dropCap.inkLeft = blockStyle.isRtl ? static_cast<int16_t>(pageWidth - glyphWidth * scale) : 0;
   // Align the enlarged letter's ink top with where the first line's own capitals start, so the

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -714,10 +714,25 @@ namespace {
 // A drop cap is only meaningful on a letter. Digits and punctuation are excluded because a
 // stylesheet applies `::first-letter` to whole classes of paragraph, and one that happens to
 // open with a quote mark or a numeral would otherwise blow that character up to four lines
-// tall. Non-ASCII is assumed to be a letter (accented capitals, Cyrillic, Greek).
+// tall. The punctuation that actually opens a paragraph is mostly NON-ASCII -- the curly
+// quotes and guillemets EPUBs set dialogue with -- so the ranges holding it are named here and
+// anything outside them is taken to be a letter (accented capitals, Cyrillic, Greek, kana).
+// Same ranges isWordCharacter() rejects, minus its allowance for the apostrophes U+2018/U+2019,
+// which open a quotation as often as they sit inside a word.
 bool isDropCapLetter(const uint32_t cp) {
-  if (cp >= 0x80) return true;
-  return (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');
+  if (cp < 0x80) return (cp >= 'A' && cp <= 'Z') || (cp >= 'a' && cp <= 'z');
+  // Latin-1 punctuation and symbols (« » ¡ ¿ §), keeping the three that are letters.
+  if (cp >= 0x00A0 && cp <= 0x00BF) return cp == 0x00AA || cp == 0x00B5 || cp == 0x00BA;
+  if (cp == 0x00D7 || cp == 0x00F7) return false;  // × ÷
+  // General punctuation through the symbol blocks: “ ” ‘ ’ — dashes, the zero-width format
+  // characters, arrows and maths.
+  if (cp >= 0x2000 && cp <= 0x2BFF) return false;
+  if (cp >= 0x2E00 && cp <= 0x2E7F) return false;  // supplemental punctuation
+  if (cp >= 0x3000 && cp <= 0x303F) return false;  // CJK punctuation 、。「」『』
+  if (cp >= 0xFF01 && cp <= 0xFF20) return false;  // fullwidth punctuation and digits
+  if (cp >= 0xFF3B && cp <= 0xFF40) return false;
+  if (cp >= 0xFF5B && cp <= 0xFF65) return false;
+  return true;
 }
 
 }  // namespace
@@ -1686,11 +1701,15 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
         xpos = (effectivePageWidth - contentWidth) / 2;
       }
     } else {
+      // effectivePageWidth is already reduced by the indent, so the aligned positions below are
+      // measured from the indented origin and must be shifted back onto it. That matters only
+      // for a drop cap: resolveLineIndent reserves its column whatever the alignment, while a
+      // first-line text-indent resolves to 0 unless the alignment is the natural one.
       xpos = firstLineIndent;
       if (effectiveAlignment == CssTextAlign::Right) {
-        xpos = effectivePageWidth - contentWidth;
+        xpos = firstLineIndent + effectivePageWidth - contentWidth;
       } else if (effectiveAlignment == CssTextAlign::Center) {
-        xpos = (effectivePageWidth - contentWidth) / 2;
+        xpos = firstLineIndent + (effectivePageWidth - contentWidth) / 2;
       }
     }
 
@@ -1777,11 +1796,13 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       }
     } else {
       // LTR: position words from left to right
+      // See the reordered branch above: effectivePageWidth is measured from the indented
+      // origin, so an aligned line has to be shifted back onto it to clear a drop cap column.
       int xpos = firstLineIndent + extraStartOffset;
       if (effectiveAlignment == CssTextAlign::Right) {
-        xpos = effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
+        xpos = firstLineIndent + effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
       } else if (effectiveAlignment == CssTextAlign::Center) {
-        xpos = (effectivePageWidth - lineWordWidthSum - totalNaturalGaps) / 2;
+        xpos = firstLineIndent + (effectivePageWidth - lineWordWidthSum - totalNaturalGaps) / 2;
       }
 
       for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -271,6 +271,13 @@ uint16_t measureFocusPrefixAdvance(const GfxRenderer& renderer, const int fontId
   return static_cast<uint16_t>(renderer.getTextAdvanceX(fontId, prefixBuf, boldStyle, letterSpacing) + kerning);
 }
 
+// Same rounding as GfxRenderer's own scalePositive, so a scaled word measures exactly as wide as
+// drawTextScaled draws it.
+uint16_t scaleWordWidth(const uint16_t width, const uint16_t scale) {
+  if (scale == TextBlock::WORD_SCALE_ONE) return width;
+  return static_cast<uint16_t>(std::max(0, (static_cast<int>(width) * scale + 128) / 256));
+}
+
 uint16_t measureFocusWordWidth(const GfxRenderer& renderer, const int fontId, const std::string& word,
                                const EpdFontFamily::Style style, const uint8_t focusBoundary,
                                const int8_t letterSpacing, const bool appendHyphen = false) {
@@ -372,6 +379,22 @@ void ParsedText::insertVisibleOffset(const size_t wordIndex, const uint32_t offs
   }
   wordVisibleOffsetDeltas.insert(wordVisibleOffsetDeltas.begin() + wordIndex,
                                  static_cast<uint16_t>(offset - insertionBase));
+}
+
+void ParsedText::eraseVisibleOffsetAt(const size_t wordIndex) {
+  if (wordIndex >= wordVisibleOffsetDeltas.size()) return;
+  if (wordIndex == 0) {
+    eraseVisibleOffsetPrefix(1);
+    return;
+  }
+  // Each entry carries its own base plus delta, so removing one leaves every other word's
+  // absolute offset intact; only the rebase indices after it shift down. A rebase sitting ON the
+  // erased index still applies to what slides into its place, so it stays where it is -- and
+  // baseAt() takes the LAST rebase at or before the target, so a duplicated index is harmless.
+  wordVisibleOffsetDeltas.erase(wordVisibleOffsetDeltas.begin() + static_cast<long>(wordIndex));
+  for (auto& rebase : visibleOffsetRebases) {
+    if (rebase.wordIndex > wordIndex) rebase.wordIndex--;
+  }
 }
 
 void ParsedText::eraseVisibleOffsetPrefix(const size_t count) {
@@ -738,18 +761,45 @@ bool isDropCapLetter(const uint32_t cp) {
 }  // namespace
 
 bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, const int pageWidth) {
-  if (words.empty() || words[0].empty()) return false;
+  const size_t idx = dropCapWordIndex;
+  if (idx >= words.size() || words[idx].empty()) {
+    return false;
+  }
 
-  const auto* ptr = reinterpret_cast<const unsigned char*>(words[0].c_str());
+  // Whatever precedes the initial must be punctuation -- the em dash and no-break space a French
+  // chapter opens dialogue with, a guillemet, a quote. A LETTER before it means this is an
+  // enlarged span in mid-sentence, which is emphasis and must not be blown up four lines tall.
+  // Exactly one visible mark is carried, and it JOINS the drop cap rather than staying in the
+  // text: the flow begins where the reserved column ends, so a dash left in it would be drawn to
+  // the RIGHT of the letter it is supposed to introduce.
+  uint32_t prefixCp = 0;
+  if (idx > 0) {
+    if (blockStyle.isRtl) {
+      return false;
+    }
+    for (size_t i = 0; i < idx; ++i) {
+      const auto* w = reinterpret_cast<const unsigned char*>(words[i].c_str());
+      uint32_t cp = utf8NextCodepoint(&w);
+      if (cp == 0 || cp == ' ') continue;  // the no-break space token a French opening carries
+      if (isDropCapLetter(cp) || *w != 0 || prefixCp != 0) {
+        return false;
+      }
+      prefixCp = cp;
+    }
+  }
+
+  const auto* ptr = reinterpret_cast<const unsigned char*>(words[idx].c_str());
   const auto* const start = ptr;
   const uint32_t cp = utf8NextCodepoint(&ptr);
-  if (cp == 0 || !isDropCapLetter(cp)) return false;
+  if (cp == 0 || !isDropCapLetter(cp)) {
+    return false;
+  }
   const size_t letterBytes = static_cast<size_t>(ptr - start);
 
   // The face of the word the letter comes from -- an italic chapter opening keeps an italic
   // initial. Read before the peel below, which can drop the token entirely.
   const auto style = static_cast<EpdFontFamily::Style>(
-      wordStyles.empty() ? 0 : static_cast<uint8_t>(wordStyles[0]) & TextBlock::DROP_CAP_STYLE_MASK);
+      idx >= wordStyles.size() ? 0 : static_cast<uint8_t>(wordStyles[idx]) & TextBlock::DROP_CAP_STYLE_MASK);
 
   int glyphLeft = 0;
   int glyphWidth = 0;
@@ -758,7 +808,9 @@ bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, c
   if (!renderer.getGlyphMetrics(fontId, cp, style, &glyphLeft, &glyphWidth, &glyphTop, &glyphHeight)) {
     return false;
   }
-  if (glyphWidth <= 0 || glyphHeight <= 0) return false;
+  if (glyphWidth <= 0 || glyphHeight <= 0) {
+    return false;
+  }
 
   // Magnify by whole pixels only (see GfxRenderer::drawCharUpscaled). Floor rather than round,
   // so the letter never grows past the lines it is meant to sit beside; the small shortfall
@@ -769,19 +821,34 @@ bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, c
   if (scale > TextBlock::MAX_DROP_CAP_SCALE) scale = TextBlock::MAX_DROP_CAP_SCALE;
   // Below 2x this is not a wrap-around drop cap, just a slightly bigger letter, and the
   // narrowed lines would cost more than the effect is worth. Leave the letter in the text.
-  if (scale < 2) return false;
+  if (scale < 2) {
+    return false;
+  }
 
   const int gap = renderer.getSpaceWidth(fontId, EpdFontFamily::REGULAR);
-  const int indent = glyphWidth * scale + gap;
+  // The opening mark sits at the block's left edge and the enlarged letter starts after it, so
+  // the column has to hold both.
+  int prefixAdvance = 0;
+  if (prefixCp != 0) {
+    char prefixBuf[5] = {};
+    utf8EncodeCodepoint(prefixCp, prefixBuf);
+    prefixAdvance = renderer.getTextAdvanceX(fontId, prefixBuf, style) + gap;
+  }
+  const int indent = prefixAdvance + glyphWidth * scale + gap;
   // A column this wide leaves too little for the text beside it to break sensibly; the greedy
   // fill would put one word per line and any long word would overhang the margin.
-  if (indent > pageWidth / 3) return false;
+  if (indent > pageWidth / 3) {
+    return false;
+  }
 
   dropCap.cp = cp;
+  dropCap.prefixCp = prefixCp;
   dropCap.scale = static_cast<uint8_t>(scale);
   dropCap.style = static_cast<uint8_t>(style);
-  // Ink box origin relative to the block's, on the side the reserved column sits.
-  dropCap.inkLeft = blockStyle.isRtl ? static_cast<int16_t>(pageWidth - glyphWidth * scale) : 0;
+  // Ink box origin relative to the block's, on the side the reserved column sits -- past the
+  // opening mark, which is drawn at the edge itself.
+  dropCap.inkLeft =
+      blockStyle.isRtl ? static_cast<int16_t>(pageWidth - glyphWidth * scale) : static_cast<int16_t>(prefixAdvance);
   // Align the enlarged letter's ink top with where the first line's own capitals start, so the
   // two share a top edge instead of the drop cap floating above or sinking into the line.
   dropCap.inkTop = static_cast<int16_t>(renderer.getFontAscenderSize(fontId) - glyphTop);
@@ -790,10 +857,27 @@ bool ParsedText::prepareDropCap(const GfxRenderer& renderer, const int fontId, c
   // The letter now belongs to the drop cap, not to the text flow -- CSS ::first-letter styles
   // it in place, and drawing it here as well would double it. Its visible-codepoint offset
   // stays with the word so selection and progress positions do not shift.
+  if (idx > 0) {
+    // The opening mark now belongs to the drop cap, so it leaves the flow with the letter. Done
+    // only here, past every gate: prepareDropCap must leave the paragraph untouched when it
+    // returns false. Erasing the prefix puts the letter at index 0.
+    const auto at = static_cast<long>(idx);
+    words.erase(words.begin(), words.begin() + at);
+    wordStyles.erase(wordStyles.begin(), wordStyles.begin() + at);
+    wordContinues.erase(wordContinues.begin(), wordContinues.begin() + at);
+    wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + at);
+    wordFocusBoundary.erase(wordFocusBoundary.begin(), wordFocusBoundary.begin() + at);
+    if (!wordFonts.empty()) wordFonts.erase(wordFonts.begin(), wordFonts.begin() + at);
+    wordLinkIds.erase(wordLinkIds.begin(), wordLinkIds.begin() + at);
+    eraseVisibleOffsetPrefix(idx);
+    if (!rubyTexts.empty()) rubyTexts.erase(rubyTexts.begin(), rubyTexts.begin() + at);
+  }
+
   words[0].erase(0, letterBytes);
   if (words[0].empty()) {
-    // The whole first token was the letter (a one-character opening word). Drop the now-empty
-    // token, keeping every parallel array in lockstep exactly as layoutAndExtractLines does.
+    // The whole token was the letter (a one-character word, which is what a drop cap span holds).
+    // Drop the now-empty token, keeping every parallel array in lockstep exactly as
+    // layoutAndExtractLines does.
     words.erase(words.begin());
     wordStyles.erase(wordStyles.begin());
     wordContinues.erase(wordContinues.begin());
@@ -1078,8 +1162,10 @@ std::vector<uint16_t> ParsedText::calculateWordWidths(const GfxRenderer& rendere
     // A word with an inline font-size measures with its own font -- the widths feed the line
     // breaker and the x positions, so measuring here with the block font while drawing with
     // the override is exactly the layout/draw disagreement resolveFontId() exists to prevent.
-    wordWidths.push_back(measureFocusWordWidth(renderer, effectiveWordFont(i, fontId), words[i], wordStyles[i],
-                                               wordFocusBoundary[i], blockStyle.letterSpacing));
+    wordWidths.push_back(
+        scaleWordWidth(measureFocusWordWidth(renderer, effectiveWordFont(i, fontId), words[i], wordStyles[i],
+                                             wordFocusBoundary[i], blockStyle.letterSpacing),
+                       effectiveWordScale(i)));
   }
 
   // Adjust widths for ruby groups to comply with JLReq standards
@@ -1399,8 +1485,9 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   const std::string& word = words[wordIndex];
   const auto style = wordStyles[wordIndex];
   const uint8_t focusBoundary = wordFocusBoundary[wordIndex];
-  // Prefix/remainder widths must use the same font the whole word was measured with.
+  // Prefix/remainder widths must use the same font AND scale the whole word was measured with.
   const int wordFont = effectiveWordFont(wordIndex, fontId);
+  const uint16_t wordScale = effectiveWordScale(wordIndex);
 
   // Collect candidate breakpoints (byte offsets and hyphen requirements).
   auto breakInfos = Hyphenator::breakOffsets(word, allowFallbackBreaks);
@@ -1420,9 +1507,10 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
     }
 
     const bool needsHyphen = info.requiresInsertedHyphen;
-    const int prefixWidth =
+    const int prefixWidth = scaleWordWidth(
         measureFocusWordWidth(renderer, wordFont, word.substr(0, offset), style,
-                              focusBoundaryBefore(focusBoundary, offset), blockStyle.letterSpacing, needsHyphen);
+                              focusBoundaryBefore(focusBoundary, offset), blockStyle.letterSpacing, needsHyphen),
+        wordScale);
     if (prefixWidth > availableWidth || prefixWidth <= chosenWidth) {
       continue;  // Skip if too wide or not an improvement
     }
@@ -1495,8 +1583,10 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 
   // Update cached widths to reflect the new prefix/remainder pairing.
   wordWidths[wordIndex] = static_cast<uint16_t>(chosenWidth);
-  const uint16_t remainderWidth = measureFocusWordWidth(renderer, wordFont, remainder, style,
-                                                        wordFocusBoundary[wordIndex + 1], blockStyle.letterSpacing);
+  const uint16_t remainderWidth =
+      scaleWordWidth(measureFocusWordWidth(renderer, wordFont, remainder, style, wordFocusBoundary[wordIndex + 1],
+                                           blockStyle.letterSpacing),
+                     wordScale);
   wordWidths.insert(wordWidths.begin() + wordIndex + 1, remainderWidth);
   return true;
 }
@@ -1908,11 +1998,17 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   for (size_t i = 0; i < lineWordCount; i++) {
     const uint8_t boundary = focusBoundaryAt(i);
-    const int wordFont = !lineWordFonts.empty() && lineWordFonts[i] != 0 ? lineWordFonts[i] : fontId;
+    const int32_t slot = !lineWordFonts.empty() ? lineWordFonts[i] : 0;
+    const int wordFont = (slot != 0 && !TextBlock::isWordScaleTag(slot)) ? slot : fontId;
+    // An x INSIDE the word, so it scales with the word it indexes into.
+    const uint16_t wordScale =
+        TextBlock::isWordScaleTag(slot) ? static_cast<uint16_t>(-slot) : TextBlock::WORD_SCALE_ONE;
     outBoundaries.push_back(boundary);
-    outSuffixX.push_back(boundary == 0 ? 0
-                                       : measureFocusPrefixAdvance(renderer, wordFont, lineWords[i], lineWordStyles[i],
-                                                                   boundary, blockStyle.letterSpacing));
+    outSuffixX.push_back(
+        boundary == 0 ? 0
+                      : scaleWordWidth(measureFocusPrefixAdvance(renderer, wordFont, lineWords[i], lineWordStyles[i],
+                                                                 boundary, blockStyle.letterSpacing),
+                                       wordScale));
   }
 
   auto block = std::make_shared<TextBlock>(lineWords, lineXPos, lineWordStyles, outBoundaries, outSuffixX, blockStyle,

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -61,6 +61,16 @@ class ParsedText {
   bool focusReadingEnabled;
   bool isNaturalAlign;
   bool hasRtlWord;
+  // The enlarged first letter, once prepareDropCap() has claimed it. Attached to the first
+  // line this ParsedText emits and cleared with blockStyle.dropCapLines once the lines beside
+  // it are out, so a soft flush mid-paragraph cannot start a second one.
+  TextBlock::DropCap dropCap;
+  bool dropCapResolved = false;
+  // Set once the lines beside the enlarged letter are out. The paragraph tail then re-enters
+  // line breaking as break index 0, which is otherwise how "this is the paragraph's first
+  // line" is spelled -- without this it would take the first-line text-indent a second time,
+  // several lines into the paragraph.
+  bool dropCapLinesEmitted = false;
   std::vector<std::string> reorderedWordsScratch;
   std::vector<EpdFontFamily::Style> reorderedStylesScratch;
   std::vector<int32_t> reorderedFontsScratch;
@@ -79,6 +89,21 @@ class ParsedText {
   int calculateRubyExtraEndOffset(size_t lineStartIdx, size_t lineBreakIdx, const GfxRenderer& renderer,
                                   int fontId) const;
   int resolveFirstLineIndent(bool isFirstLine, const GfxRenderer& renderer, int fontId) const;
+  // The leading-edge indent of line `lineIndex` of the CURRENT extraction pass. The single
+  // source of both the width the line is broken to and the x its words start at, so the two
+  // cannot disagree. Beside a drop cap this is the reserved column; otherwise it is the
+  // paragraph's first-line text-indent, exactly as before.
+  int resolveLineIndent(size_t lineIndex, const GfxRenderer& renderer, int fontId) const;
+  // Chooses the glyph, magnification and column width for a `::first-letter` drop cap and
+  // removes the letter from the text flow. Returns false (leaving the text untouched, so the
+  // letter simply renders inline) when the paragraph cannot carry one.
+  bool prepareDropCap(const GfxRenderer& renderer, int fontId, int pageWidth);
+  // Greedy line breaks for the lines beside the drop cap. See the implementation for why these
+  // do not go through computeLineBreaks' optimal DP.
+  std::vector<size_t> computeDropCapLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
+                                               const std::vector<uint16_t>& wordWidths,
+                                               const std::vector<bool>& continuesVec,
+                                               const std::vector<bool>& noSpaceBeforeVec) const;
   std::vector<size_t> computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
                                         std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec,
                                         std::vector<bool>& noSpaceBeforeVec);
@@ -93,6 +118,8 @@ class ParsedText {
                    const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
                    const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
+  // Drop the first `consumed` tokens, keeping every parallel per-word array in lockstep.
+  void consumeWords(size_t consumed);
 
  public:
   explicit ParsedText(const bool extraParagraphSpacing, const bool hyphenationEnabled = false,
@@ -102,7 +129,8 @@ class ParsedText {
         hyphenationEnabled(hyphenationEnabled),
         focusReadingEnabled(focusReadingEnabled),
         isNaturalAlign(false),
-        hasRtlWord(false) {}
+        hasRtlWord(false),
+        dropCapResolved(false) {}
   ~ParsedText() = default;
 
   // wordFontId: per-word font override from an inline font-size; 0 keeps the block's font.

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -85,6 +85,10 @@ class ParsedText {
   void pushVisibleOffset(uint32_t offset);
   void insertVisibleOffset(size_t wordIndex, uint32_t offset);
   void eraseVisibleOffsetPrefix(size_t count);
+  // Drop ONE word's offset entry, keeping every other word's absolute offset. Erasing the drop
+  // cap's token is not always a prefix erase: a paragraph can open with punctuation before the
+  // initial (`--<nbsp><span class="let">L</span>`, the French dialogue opening).
+  void eraseVisibleOffsetAt(size_t wordIndex);
   int calculateRubyExtraStartOffset(size_t wordIdx, size_t maxWordIdx, const GfxRenderer& renderer, int fontId) const;
   int calculateRubyExtraEndOffset(size_t lineStartIdx, size_t lineBreakIdx, const GfxRenderer& renderer,
                                   int fontId) const;
@@ -98,6 +102,10 @@ class ParsedText {
   // removes the letter from the text flow. Returns false (leaving the text untouched, so the
   // letter simply renders inline) when the paragraph cannot carry one.
   bool prepareDropCap(const GfxRenderer& renderer, int fontId, int pageWidth);
+  // Word holding the drop cap's letter. 0 for a `::first-letter` rule, which by definition
+  // styles the paragraph's first character; an enlarged span names its own word, because the
+  // punctuation a paragraph opens with is tokenized ahead of it.
+  uint8_t dropCapWordIndex = 0;
   // Greedy line breaks for the lines beside the drop cap. See the implementation for why these
   // do not go through computeLineBreaks' optimal DP.
   std::vector<size_t> computeDropCapLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
@@ -138,7 +146,15 @@ class ParsedText {
                int32_t wordFontId = 0, uint32_t visibleTextOffset = 0, uint8_t linkId = 0);
   // The font a word measures and draws with (block font unless an inline font-size overrode it).
   int effectiveWordFont(size_t index, int blockFontId) const {
-    return (index < wordFonts.size() && wordFonts[index] != 0) ? wordFonts[index] : blockFontId;
+    const int32_t slot = index < wordFonts.size() ? wordFonts[index] : 0;
+    return (slot != 0 && !TextBlock::isWordScaleTag(slot)) ? slot : blockFontId;
+  }
+  // Bitmap scale for a word whose size the font ladder could not serve; 256 = unscaled. Widths
+  // MUST be scaled by it wherever they are measured -- the drawn word is scaled, and a width
+  // measured unscaled would put the next word straight through it.
+  uint16_t effectiveWordScale(const size_t index) const {
+    const int32_t slot = index < wordFonts.size() ? wordFonts[index] : 0;
+    return TextBlock::isWordScaleTag(slot) ? static_cast<uint16_t>(-slot) : TextBlock::WORD_SCALE_ONE;
   }
   uint8_t addLinkTarget(const char* href);
   bool linkTargetMatches(uint8_t linkId, const char* href) const;
@@ -164,6 +180,7 @@ class ParsedText {
   std::string getRubyTextAt(size_t index) const { return index < rubyTexts.size() ? rubyTexts[index] : std::string(); }
   void ensureRubyCapacity();
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
+  void setDropCapWordIndex(const uint8_t wordIndex) { dropCapWordIndex = wordIndex; }
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }

--- a/lib/Epub/Epub/ReaderFontScale.cpp
+++ b/lib/Epub/Epub/ReaderFontScale.cpp
@@ -164,6 +164,18 @@ int8_t cssLetterSpacingPx(const CssStyle& style, const float emPx) {
       std::clamp(rounded, static_cast<int>(CSS_LETTER_SPACING_MIN_PX), static_cast<int>(CSS_LETTER_SPACING_MAX_PX)));
 }
 
+int32_t cssFontScaleTag(const CssStyle& style) {
+  const float scale = cssFontSizeScale(style);
+  if (scale <= 0.0f) return 0;
+
+  constexpr int SCALE_ONE = 256;
+  constexpr int SCALE_STEP = 32;  // 1/8 of the base size
+  int scaled = static_cast<int>(std::lround(scale * SCALE_ONE / SCALE_STEP)) * SCALE_STEP;
+  scaled = std::clamp(scaled, 32, 512);
+  if (scaled == SCALE_ONE) return 0;  // snapped back to the block's own size
+  return -scaled;
+}
+
 int cssBlockFontId(const CssStyle& style, const int baseFontId) {
   const float scale = cssFontSizeScale(style);
   if (scale <= 0.0f) return 0;

--- a/lib/Epub/Epub/ReaderFontScale.h
+++ b/lib/Epub/Epub/ReaderFontScale.h
@@ -30,6 +30,17 @@ float cssFontSizeScale(const CssStyle& style);
  */
 int cssBlockFontId(const CssStyle& style, int baseFontId);
 
+// Bitmap scale for an inline font-size the LADDER cannot serve -- a single-size reader font (an
+// SD-card font has no 12/14/16/18pt siblings), or an ask that snaps back to the base. Returns a
+// NEGATIVE tag for the per-word font slot (see TextBlock::wordFontScale) carrying a 256-based
+// scale, or 0 when the text should simply render at the block's own size.
+//
+// The scale is snapped to a multiple of 32/256 (1/8 steps: 50%, 62.5%, 75%, 87.5%, ...). A 1-bit
+// glyph is resampled by nearest neighbour, so a clean ratio drops or repeats whole pixels on a
+// short, regular period -- 3/4 keeps three of every four rows -- while an arbitrary factor like
+// 77% beats against the stem spacing and breaks strokes unevenly.
+int32_t cssFontScaleTag(const CssStyle& style);
+
 /**
  * CSS line-height -> a PERCENTAGE of the leading the reader would have used anyway.
  *

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -214,7 +214,11 @@ namespace {
 //      subject pronoun ("songeai-je", "pense-t-il") is now split into extra word tokens so the
 //      verb and pronoun are independently selectable for dictionary lookup, changing the token
 //      count and positions on any cached page containing one.
-constexpr uint8_t SECTION_FILE_VERSION = 84;
+// v85: each text block's record gains a drop cap trailer (codepoint, ink origin, glyph scale;
+//      zeroed on every line that has none), and a paragraph whose CSS declares
+//      `::first-letter { font-size: ... }` now reserves a column for the enlarged letter, so
+//      its opening lines are broken to a narrower width and their words sit at new positions.
+constexpr uint8_t SECTION_FILE_VERSION = 85;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -218,7 +218,28 @@ namespace {
 //      zeroed on every line that has none), and a paragraph whose CSS declares
 //      `::first-letter { font-size: ... }` now reserves a column for the enlarged letter, so
 //      its opening lines are broken to a narrower width and their words sit at new positions.
-constexpr uint8_t SECTION_FILE_VERSION = 85;
+// v86: `::first-letter` is now also recognised in its CSS 2.1 one-colon spelling, so a book that
+//      uses it gains drop caps -- and with them the reserved column and the reflowed opening
+//      lines a v85 cache was built without.
+// v90: an inline font-size the font ladder cannot serve (a single-size SD-card reader font has
+//      no 12/14/16/18pt siblings) is now honoured by scaling the glyph bitmap, snapped to an
+//      eighth. `<small>` runs that used to render at body size are narrower, so every line
+//      holding one breaks and positions differently. The per-word font slot carries the scale as
+//      a negative tag, so the framing is unchanged.
+// v89: the drop cap record gains the opening mark's codepoint (u32, 0 when there is none), so
+//      the record grew by 4 bytes and a v88 record cannot be read with the v89 framing. The mark
+//      a paragraph opens with (`--` before a lettrine) now leaves the text flow WITH the initial
+//      and is drawn at body size beside it, so those opening lines are broken differently too.
+// v88: the initial no longer has to be the paragraph's FIRST token -- a French chapter opening
+//      (`--<nbsp><span class="let">L</span>`) tokenizes the dash and the space ahead of it, and
+//      those paragraphs now get the reserved column and reflowed opening lines too.
+// v87: a paragraph opened by an enlarged single-letter span (`<p><span class="let">L</span>...`)
+//      is treated as an initial too, which is how many trade EPUBs mark one up instead of using
+//      a pseudo-element at all. Its own version rather than an amendment to v86: v86 was already
+//      built and run, so a v86 section on disk was laid out by a parser that did not know about
+//      the span form, and reusing it would leave those books looking exactly as unfixed as
+//      before -- with nothing to indicate why.
+constexpr uint8_t SECTION_FILE_VERSION = 90;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -221,24 +221,24 @@ namespace {
 // v86: `::first-letter` is now also recognised in its CSS 2.1 one-colon spelling, so a book that
 //      uses it gains drop caps -- and with them the reserved column and the reflowed opening
 //      lines a v85 cache was built without.
-// v90: an inline font-size the font ladder cannot serve (a single-size SD-card reader font has
-//      no 12/14/16/18pt siblings) is now honoured by scaling the glyph bitmap, snapped to an
-//      eighth. `<small>` runs that used to render at body size are narrower, so every line
-//      holding one breaks and positions differently. The per-word font slot carries the scale as
-//      a negative tag, so the framing is unchanged.
-// v89: the drop cap record gains the opening mark's codepoint (u32, 0 when there is none), so
-//      the record grew by 4 bytes and a v88 record cannot be read with the v89 framing. The mark
-//      a paragraph opens with (`--` before a lettrine) now leaves the text flow WITH the initial
-//      and is drawn at body size beside it, so those opening lines are broken differently too.
-// v88: the initial no longer has to be the paragraph's FIRST token -- a French chapter opening
-//      (`--<nbsp><span class="let">L</span>`) tokenizes the dash and the space ahead of it, and
-//      those paragraphs now get the reserved column and reflowed opening lines too.
 // v87: a paragraph opened by an enlarged single-letter span (`<p><span class="let">L</span>...`)
 //      is treated as an initial too, which is how many trade EPUBs mark one up instead of using
 //      a pseudo-element at all. Its own version rather than an amendment to v86: v86 was already
 //      built and run, so a v86 section on disk was laid out by a parser that did not know about
 //      the span form, and reusing it would leave those books looking exactly as unfixed as
 //      before -- with nothing to indicate why.
+// v88: the initial no longer has to be the paragraph's FIRST token -- a French chapter opening
+//      (`--<nbsp><span class="let">L</span>`) tokenizes the dash and the space ahead of it, and
+//      those paragraphs now get the reserved column and reflowed opening lines too.
+// v89: the drop cap record gains the opening mark's codepoint (u32, 0 when there is none), so
+//      the record grew by 4 bytes and a v88 record cannot be read with the v89 framing. The mark
+//      a paragraph opens with (`--` before a lettrine) now leaves the text flow WITH the initial
+//      and is drawn at body size beside it, so those opening lines are broken differently too.
+// v90: an inline font-size the font ladder cannot serve (a single-size SD-card reader font has
+//      no 12/14/16/18pt siblings) is now honoured by scaling the glyph bitmap, snapped to an
+//      eighth. `<small>` runs that used to render at body size are narrower, so every line
+//      holding one breaks and positions differently. The per-word font slot carries the scale as
+//      a negative tag, so the framing is unchanged.
 constexpr uint8_t SECTION_FILE_VERSION = 90;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /

--- a/lib/Epub/Epub/blocks/BlockStyle.h
+++ b/lib/Epub/Epub/blocks/BlockStyle.h
@@ -113,6 +113,21 @@ struct BlockStyle {
   // NOT propagated through getCombinedBlockStyle so it can't leak into sibling blocks.
   bool fromBrElement = false;
 
+  // Drop cap (CSS `::first-letter` with an enlarged font-size). The enlarged letter occupies a
+  // column on the leading edge of the block's first `dropCapLines` lines, and those lines are
+  // laid out `dropCapIndent` px narrower so the text wraps around it -- see
+  // ParsedText::resolveLineIndent, which is the single place both the reduced width and the
+  // shifted x origin come from, so measurement and drawing cannot disagree.
+  //
+  // Build-only, like lineHeightPct: the indent is baked into the cached word x positions, and
+  // the enlarged glyph itself travels on the first line's TextBlock. Never inherited -- a drop
+  // cap belongs to exactly one block, and getCombinedBlockStyle starts from the child, so an
+  // ancestor's never reaches a nested paragraph.
+  uint8_t dropCapLines = 0;
+  int16_t dropCapIndent = 0;
+
+  [[nodiscard]] bool hasDropCap() const { return dropCapLines > 0 && dropCapIndent > 0; }
+
   // The font this block is laid out AND drawn with. Single source of truth; see fontId.
   [[nodiscard]] int resolveFontId(const int baseFontId) const { return fontId != 0 ? fontId : baseFontId; }
 

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -172,7 +172,8 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
   // its column at layout time, so it only has to be drawn. Both offsets are relative to the
   // block's origin and were resolved against the same font metrics the layout used.
   if (dropCap.present()) {
-    renderer.drawCharUpscaled(fontId, dropCap.cp, dropCap.scale, x + dropCap.inkLeft, y + dropCap.inkTop, inkBlack);
+    renderer.drawCharUpscaled(fontId, dropCap.cp, dropCap.scale, x + dropCap.inkLeft, y + dropCap.inkTop, inkBlack,
+                              static_cast<EpdFontFamily::Style>(dropCap.style));
   }
 
   // Resolve ruby collisions left-to-right to prevent adjacent ruby texts from overlapping
@@ -457,6 +458,7 @@ bool TextBlock::serialize(HalFile& file) const {
   serialization::writePod(file, dropCap.inkLeft);
   serialization::writePod(file, dropCap.inkTop);
   serialization::writePod(file, dropCap.scale);
+  serialization::writePod(file, dropCap.style);
 
   return true;
 }
@@ -572,6 +574,8 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   serialization::readPod(file, block->dropCap.inkLeft);
   serialization::readPod(file, block->dropCap.inkTop);
   serialization::readPod(file, block->dropCap.scale);
+  serialization::readPod(file, block->dropCap.style);
+  block->dropCap.style &= DROP_CAP_STYLE_MASK;
   // Bound what a corrupt record can ask the glyph scaler for: an absurd scale would blow up
   // the block-replication loop (and paint over the page) rather than fail. The cap matches the
   // ceiling ParsedText applies when it chooses the scale.

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -168,6 +168,13 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
   const bool scanning = renderer.isFontCacheScanning();
   const int ascender = renderer.getFontAscenderSize(fontId);
 
+  // Drop cap: the words on this line and the ones beneath it were already positioned clear of
+  // its column at layout time, so it only has to be drawn. Both offsets are relative to the
+  // block's origin and were resolved against the same font metrics the layout used.
+  if (dropCap.present()) {
+    renderer.drawCharUpscaled(fontId, dropCap.cp, dropCap.scale, x + dropCap.inkLeft, y + dropCap.inkTop, inkBlack);
+  }
+
   // Resolve ruby collisions left-to-right to prevent adjacent ruby texts from overlapping
   struct RubyDrawInfo {
     int x;
@@ -444,6 +451,13 @@ bool TextBlock::serialize(HalFile& file) const {
   serialization::writePod(file, blockStyle.inkMode);
   serialization::writePod(file, blockStyle.inkModeDefined);
 
+  // Drop cap. Written on every line (cp 0 = none) rather than behind a flag byte: the record
+  // stays fixed-width, which is what lets deserialize() read it back without a framing branch.
+  serialization::writePod(file, dropCap.cp);
+  serialization::writePod(file, dropCap.inkLeft);
+  serialization::writePod(file, dropCap.inkTop);
+  serialization::writePod(file, dropCap.scale);
+
   return true;
 }
 
@@ -553,6 +567,15 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   // A corrupt byte must not commit the line to white-on-nothing: only the exact Inverted value
   // survives, anything else falls back to the always-legible Normal.
   if (blockStyle.inkMode != CssInkMode::Inverted) blockStyle.inkMode = CssInkMode::Normal;
+
+  serialization::readPod(file, block->dropCap.cp);
+  serialization::readPod(file, block->dropCap.inkLeft);
+  serialization::readPod(file, block->dropCap.inkTop);
+  serialization::readPod(file, block->dropCap.scale);
+  // Bound what a corrupt record can ask the glyph scaler for: an absurd scale would blow up
+  // the block-replication loop (and paint over the page) rather than fail. The cap matches the
+  // ceiling ParsedText applies when it chooses the scale.
+  if (block->dropCap.scale > MAX_DROP_CAP_SCALE) block->dropCap = DropCap{};
 
   return block;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 #include <Memory.h>
 #include <Serialization.h>
+#include <Utf8.h>
 
 #include <cstring>
 
@@ -172,6 +173,13 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
   // its column at layout time, so it only has to be drawn. Both offsets are relative to the
   // block's origin and were resolved against the same font metrics the layout used.
   if (dropCap.present()) {
+    if (dropCap.prefixCp != 0) {
+      // Body size, on the first line's own top edge -- it belongs to the text it opens, not to
+      // the magnified letter beside it.
+      char prefix[5] = {};
+      utf8EncodeCodepoint(dropCap.prefixCp, prefix);
+      renderer.drawText(fontId, x, y, prefix, inkBlack, static_cast<EpdFontFamily::Style>(dropCap.style));
+    }
     renderer.drawCharUpscaled(fontId, dropCap.cp, dropCap.scale, x + dropCap.inkLeft, y + dropCap.inkTop, inkBlack,
                               static_cast<EpdFontFamily::Style>(dropCap.style));
   }
@@ -309,7 +317,11 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
     const int wordX = xposArr[i] + x;
     // Inline font-size override: this word was MEASURED with its own font (see
     // ParsedText::calculateWordWidths), so it must draw with the same one.
-    const int wordFontId = (fontsPresent && wordFontArr[i] != 0) ? wordFontArr[i] : fontId;
+    const int32_t fontSlot = fontsPresent ? wordFontArr[i] : 0;
+    const bool wordScaled = isWordScaleTag(fontSlot);
+    // A scale tag means the block's own font drawn smaller/larger, not a different font.
+    const uint16_t wordScale = wordScaled ? static_cast<uint16_t>(-fontSlot) : WORD_SCALE_ONE;
+    const int wordFontId = (!wordScaled && fontSlot != 0) ? fontSlot : fontId;
     const EpdFontFamily::Style currentStyle = wordStyle(i);
     const auto baseDir =
         static_cast<BidiUtils::BidiBaseDir>(BidiUtils::detectParagraphLevel(word, blockStyle.isRtl ? 1 : 0));
@@ -342,12 +354,14 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
           std::min<size_t>({static_cast<size_t>(boundary), static_cast<size_t>(wordTextLen(i)), sizeof(boldBuf) - 1});
       memcpy(boldBuf, word, boldLen);
       boldBuf[boldLen] = '\0';
-      renderer.drawText(wordFontId, drawX, wordY, boldBuf, inkBlack, boldStyle, baseDir, blockStyle.letterSpacing);
+      renderer.drawTextScaled(wordFontId, drawX, wordY, boldBuf, wordScale, inkBlack, boldStyle, baseDir,
+                              blockStyle.letterSpacing);
       const int suffixX = drawX + focusSuffixXArr[i];
-      renderer.drawText(wordFontId, suffixX, wordY, word + boldLen, inkBlack, currentStyle, baseDir,
-                        blockStyle.letterSpacing);
+      renderer.drawTextScaled(wordFontId, suffixX, wordY, word + boldLen, wordScale, inkBlack, currentStyle, baseDir,
+                              blockStyle.letterSpacing);
     } else {
-      renderer.drawText(wordFontId, drawX, wordY, word, inkBlack, currentStyle, baseDir, blockStyle.letterSpacing);
+      renderer.drawTextScaled(wordFontId, drawX, wordY, word, wordScale, inkBlack, currentStyle, baseDir,
+                              blockStyle.letterSpacing);
     }
 
     // Horizontal ruby text rendering
@@ -366,7 +380,8 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
 
     if (EpdFontFamily::hasTextDecoration(currentStyle)) {
       int lineStartX = drawX;
-      int lineWidth = renderer.getTextWidth(wordFontId, word, currentStyle, baseDir, blockStyle.letterSpacing);
+      int lineWidth =
+          renderer.getTextWidthScaled(wordFontId, word, wordScale, currentStyle, baseDir, blockStyle.letterSpacing);
 
       if ((currentStyle & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0) {
         lineWidth = (lineWidth + 1) / 2;
@@ -377,7 +392,8 @@ void TextBlock::render(const GfxRenderer& renderer, const int baseFontId, const 
           static_cast<uint8_t>(word[2]) == 0x83) {
         const char* visibleText = word + 3;
         lineStartX += renderer.getTextAdvanceX(wordFontId, "\xe2\x80\x83", currentStyle, blockStyle.letterSpacing);
-        lineWidth = renderer.getTextWidth(wordFontId, visibleText, currentStyle, baseDir, blockStyle.letterSpacing);
+        lineWidth = renderer.getTextWidthScaled(wordFontId, visibleText, wordScale, currentStyle, baseDir,
+                                                blockStyle.letterSpacing);
         if ((currentStyle & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0) {
           lineWidth = (lineWidth + 1) / 2;
         }
@@ -455,6 +471,7 @@ bool TextBlock::serialize(HalFile& file) const {
   // Drop cap. Written on every line (cp 0 = none) rather than behind a flag byte: the record
   // stays fixed-width, which is what lets deserialize() read it back without a framing branch.
   serialization::writePod(file, dropCap.cp);
+  serialization::writePod(file, dropCap.prefixCp);
   serialization::writePod(file, dropCap.inkLeft);
   serialization::writePod(file, dropCap.inkTop);
   serialization::writePod(file, dropCap.scale);
@@ -571,6 +588,7 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   if (blockStyle.inkMode != CssInkMode::Inverted) blockStyle.inkMode = CssInkMode::Normal;
 
   serialization::readPod(file, block->dropCap.cp);
+  serialization::readPod(file, block->dropCap.prefixCp);
   serialization::readPod(file, block->dropCap.inkLeft);
   serialization::readPod(file, block->dropCap.inkTop);
   serialization::readPod(file, block->dropCap.scale);

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -49,6 +49,33 @@ class TextBlock final : public Block {
     int16_t topLift;
   };
 
+  // The enlarged `::first-letter` of a drop cap paragraph, carried by that paragraph's FIRST
+  // line only (cp == 0 on every other line). The letter was removed from the text flow at
+  // layout time and the lines beside it were laid out clear of its column, so this is purely
+  // what to draw and where: an integer magnification of the block font's own glyph, its ink
+  // box top at inkTop relative to the line's y.
+  //
+  // Ten bytes on every TextBlock, drop cap or not (~300 B across a resident page's ~30 lines).
+  // A side table keyed by block would cost more than that in nodes and lookups, and the arena
+  // is per-WORD -- this is per-line data with no word to hang it on.
+  //
+  // inkLeft/inkTop are the ink box's origin relative to the block's, resolved at layout time
+  // against the same font metrics that positioned the words: RTL puts the column on the
+  // trailing edge, and render() must not have to re-derive that (or re-measure the glyph).
+  struct DropCap {
+    uint32_t cp = 0;
+    int16_t inkLeft = 0;
+    int16_t inkTop = 0;
+    uint8_t scale = 0;
+    [[nodiscard]] bool present() const { return cp != 0 && scale > 0; }
+  };
+
+  // Ceiling on the glyph magnification, applied where the scale is CHOSEN and again where a
+  // cached one is read back. A drop cap spans at most a few lines, so nothing legitimate comes
+  // near this; it exists so a corrupt cache byte cannot hand the block-replication loop a
+  // factor that paints over the page.
+  static constexpr uint8_t MAX_DROP_CAP_SCALE = 16;
+
  private:
   BlockStyle blockStyle;
   uint16_t numWords = 0;
@@ -72,6 +99,7 @@ class TextBlock final : public Block {
   // Layout-only metadata. ChapterHtmlSlimParser moves it into Page::links
   // immediately; cached TextBlocks therefore keep the same compact format.
   std::vector<LinkSpan> linkSpans;
+  DropCap dropCap;
 
   TextBlock() = default;  // deserialize() fills the fields directly
   static size_t arenaSize(uint16_t wordCount, bool hasFocus, bool hasFonts, uint16_t textBytes);
@@ -114,6 +142,8 @@ class TextBlock final : public Block {
   int getRubyShift(int ascender) const { return hasRuby() ? (ascender / 2) : 0; }
   const std::vector<std::string>& getRubyTexts() const { return rubyTexts; }
   std::vector<LinkSpan> takeLinkSpans() { return std::move(linkSpans); }
+  void setDropCap(const DropCap& value) { dropCap = value; }
+  const DropCap& getDropCap() const { return dropCap; }
 
   // suppressRuby: the per-book Furigana toggle. Kept as a render-time flag (not a layout one)
   // so flipping it needs no section rebuild -- the ruby strings stay in the block either way.

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -62,13 +62,22 @@ class TextBlock final : public Block {
   // inkLeft/inkTop are the ink box's origin relative to the block's, resolved at layout time
   // against the same font metrics that positioned the words: RTL puts the column on the
   // trailing edge, and render() must not have to re-derive that (or re-measure the glyph).
+  //
+  // `style` is the FACE (bits 0-1: regular/bold/italic) of the word the letter was taken from,
+  // so an italic chapter opening keeps its italic initial. Measuring and drawing must use the
+  // same one, or the reserved column does not match the glyph that lands in it.
   struct DropCap {
     uint32_t cp = 0;
     int16_t inkLeft = 0;
     int16_t inkTop = 0;
     uint8_t scale = 0;
+    uint8_t style = 0;
     [[nodiscard]] bool present() const { return cp != 0 && scale > 0; }
   };
+
+  // Decoration and sup/sub bits are dropped: an underlined or superscripted opening word must
+  // not carry that into a letter drawn four lines tall and outside the text flow.
+  static constexpr uint8_t DROP_CAP_STYLE_MASK = 0x03;
 
   // Ceiling on the glyph magnification, applied where the scale is CHOSEN and again where a
   // cached one is read back. A drop cap spans at most a few lines, so nothing legitimate comes

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <EpdFontFamily.h>
 #include <HalStorage.h>
 
@@ -8,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../../../src/fontIds.h"
 #include "Block.h"
 #include "BlockStyle.h"
 #include "Epub/FootnoteEntry.h"
@@ -68,6 +70,11 @@ class TextBlock final : public Block {
   // same one, or the reserved column does not match the glyph that lands in it.
   struct DropCap {
     uint32_t cp = 0;
+    // Punctuation the paragraph opens with, drawn at BODY size immediately left of the enlarged
+    // letter. CSS says `::first-letter` covers the punctuation preceding the letter, and a
+    // French chapter opens dialogue with an em dash; leaving it in the text flow would put it
+    // after the initial, since the flow starts where the reserved column ends. 0 for none.
+    uint32_t prefixCp = 0;
     int16_t inkLeft = 0;
     int16_t inkTop = 0;
     uint8_t scale = 0;
@@ -143,8 +150,40 @@ class TextBlock final : public Block {
   int16_t wordXpos(const uint16_t i) const { return xposArr[i]; }
   EpdFontFamily::Style wordStyle(const uint16_t i) const { return static_cast<EpdFontFamily::Style>(stylesArr[i]); }
   bool hasWordFonts() const { return fontsPresent; }
-  // Per-word font override; 0 = the block's font (also for blocks without the array).
-  int32_t wordFont(const uint16_t i) const { return fontsPresent ? wordFontArr[i] : 0; }
+  // Per-word font slot. It is a tagged value, and has been since it carried "0 = the block's
+  // font": a NEGATIVE value inside the scale-tag range is not a font id at all but a 256-based
+  // bitmap scale for the block's own font, used where no resident size can serve the ask (a
+  // single-size SD-card reader font has no ladder to snap to). Reusing the slot keeps the whole
+  // per-word pipeline -- arena, serialization, per-line slicing -- untouched; a parallel array
+  // would have to stay in lockstep with words[] across eighteen separate edit sites.
+  static constexpr int32_t MIN_WORD_SCALE_TAG = -512;  // 2x
+  static constexpr int32_t MAX_WORD_SCALE_TAG = -32;   // 1/8
+  static constexpr uint16_t WORD_SCALE_ONE = 256;
+  static bool isWordScaleTag(const int32_t slot) { return slot >= MIN_WORD_SCALE_TAG && slot <= MAX_WORD_SCALE_TAG; }
+  // Font ids are hashes; none may land in the tag range or a real font would decode as a scale.
+  static_assert(!(NOTOSERIF_12_FONT_ID >= -512 && NOTOSERIF_12_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSERIF_14_FONT_ID >= -512 && NOTOSERIF_14_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSERIF_16_FONT_ID >= -512 && NOTOSERIF_16_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSERIF_18_FONT_ID >= -512 && NOTOSERIF_18_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSANS_12_FONT_ID >= -512 && NOTOSANS_12_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSANS_14_FONT_ID >= -512 && NOTOSANS_14_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSANS_16_FONT_ID >= -512 && NOTOSANS_16_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(NOTOSANS_18_FONT_ID >= -512 && NOTOSANS_18_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(UI_10_FONT_ID >= -512 && UI_10_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(UI_12_FONT_ID >= -512 && UI_12_FONT_ID <= -32), "font id in scale-tag range");
+  static_assert(!(SMALL_FONT_ID >= -512 && SMALL_FONT_ID <= -32), "font id in scale-tag range");
+
+  // Per-word font override; 0 = the block's font (also for blocks without the array, and for a
+  // word carrying a scale tag instead of an id).
+  int32_t wordFont(const uint16_t i) const {
+    const int32_t slot = fontsPresent ? wordFontArr[i] : 0;
+    return isWordScaleTag(slot) ? 0 : slot;
+  }
+  // 256 = unscaled. Only ever non-256 when the slot carries a tag.
+  uint16_t wordFontScale(const uint16_t i) const {
+    const int32_t slot = fontsPresent ? wordFontArr[i] : 0;
+    return isWordScaleTag(slot) ? static_cast<uint16_t>(-slot) : WORD_SCALE_ONE;
+  }
   uint8_t focusBoundary(const uint16_t i) const { return focusPresent ? focusBoundaryArr[i] : 0; }
   uint16_t focusSuffixX(const uint16_t i) const { return focusPresent ? focusSuffixXArr[i] : 0; }
   bool hasRuby() const;

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -1216,7 +1216,10 @@ void CssParser::processRuleBlockWithStyle(std::string_view selectorGroup, const 
         std::string builtKey;
         if (scopedSelector) {
           builtKey += iequalsAscii(parsed.ancestor.cls, "hltr") ? "h|" : "v|";
-          const CssSelector::Selector subjectOnly{{}, parsed.subject, 0};
+          // The pseudo-element travels with the subject. Dropping it here would store
+          // `.hltr p::first-letter` under the plain key "h|p", where resolveStyle's own "h|"
+          // twin lookup finds it -- applying a drop cap's font-size to the whole paragraph.
+          const CssSelector::Selector subjectOnly{{}, parsed.subject, 0, parsed.firstLetter};
           CssSelector::forEachKeyPiece(
               subjectOnly, [&builtKey](const std::string_view piece) { builtKey.append(piece.data(), piece.size()); });
           sel = builtKey;
@@ -1516,15 +1519,28 @@ bool CssParser::resolveFirstLetterFontSize(const std::string_view tagName, const
   const CssStyle* best = nullptr;
   uint8_t bestSpec = 0;
 
-  const auto emit = [&](const std::string_view* pieces, const size_t count, const uint8_t spec, const bool) {
-    std::string_view keyed[CssSelector::MAX_KEY_PIECES + 1];
-    for (size_t i = 0; i < count; ++i) keyed[i] = pieces[i];
-    keyed[count] = CssSelector::FIRST_LETTER_PSEUDO;
-    const CssStyle* style = findStyle(keyed, count + 1);
+  const auto consider = [&](const std::string_view* keyed, const size_t count, const uint8_t spec) {
+    const CssStyle* style = findStyle(keyed, count);
     if (style != nullptr && style->hasFontSize() && (best == nullptr || spec >= bestSpec)) {
       best = style;
       bestSpec = spec;
     }
+  };
+
+  const auto emit = [&](const std::string_view* pieces, const size_t count, const uint8_t spec, const bool simple) {
+    // Room for the "h|" scope prefix, the key itself and the pseudo-element suffix.
+    std::string_view keyed[CssSelector::MAX_KEY_PIECES + 2];
+    for (size_t i = 0; i < count; ++i) keyed[i] = pieces[i];
+    keyed[count] = CssSelector::FIRST_LETTER_PSEUDO;
+    consider(keyed, count + 1, spec);
+
+    // The EBPAJ horizontal-mode twin, exactly as resolveStyle tries it for simple selectors:
+    // `.hltr p::first-letter` is stored as "h|p::first-letter" and is unreachable without this.
+    if (!simple) return;
+    keyed[0] = "h|";
+    for (size_t i = 0; i < count; ++i) keyed[i + 1] = pieces[i];
+    keyed[count + 1] = CssSelector::FIRST_LETTER_PSEUDO;
+    consider(keyed, count + 2, spec);
   };
 
   const bool walkAncestors = path != nullptr && (hasDescendantRules_ || hasChildRules_);

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -1267,6 +1267,9 @@ void CssParser::processRuleBlockWithStyle(std::string_view selectorGroup, const 
 void CssParser::noteCombinatorsIn(const std::string_view key) {
   if (key.find(CssSelector::DESCENDANT_COMBINATOR) != std::string_view::npos) hasDescendantRules_ = true;
   if (key.find(CssSelector::CHILD_COMBINATOR) != std::string_view::npos) hasChildRules_ = true;
+  bool firstLetter = false;
+  CssSelector::withoutFirstLetterPseudo(key, firstLetter);
+  if (firstLetter) hasFirstLetterRules_ = true;
 }
 
 // Main parsing entry point
@@ -1498,6 +1501,41 @@ CssStyle CssParser::resolveStyle(const std::string_view tagName, const std::stri
   CssStyle result;
   for (size_t i = 0; i < candidateCount; ++i) result.applyOver(*candidates[i].style);
   return result;
+}
+
+bool CssParser::resolveFirstLetterFontSize(const std::string_view tagName, const std::string_view classAttr,
+                                           const CssElementPath* path, CssLength& out) const {
+  if (!hasFirstLetterRules_) return false;
+
+  // Same candidate enumeration and cascade as resolveStyle(), with the pseudo-element suffix
+  // appended to every key tried -- which is what makes these rules reachable at all, since
+  // forEachCandidate only ever spells ordinary element keys. Tracking the winner by specificity
+  // as we go (rather than collecting and sorting) is enough here: one property, so a
+  // higher-specificity match simply replaces the previous one and there is nothing to merge.
+  // Ties keep the LATER match, matching resolveStyle's stable-sort tie-break.
+  const CssStyle* best = nullptr;
+  uint8_t bestSpec = 0;
+
+  const auto emit = [&](const std::string_view* pieces, const size_t count, const uint8_t spec, const bool) {
+    std::string_view keyed[CssSelector::MAX_KEY_PIECES + 1];
+    for (size_t i = 0; i < count; ++i) keyed[i] = pieces[i];
+    keyed[count] = CssSelector::FIRST_LETTER_PSEUDO;
+    const CssStyle* style = findStyle(keyed, count + 1);
+    if (style != nullptr && style->hasFontSize() && (best == nullptr || spec >= bestSpec)) {
+      best = style;
+      bestSpec = spec;
+    }
+  };
+
+  const bool walkAncestors = path != nullptr && (hasDescendantRules_ || hasChildRules_);
+  const size_t ancestorCount = walkAncestors ? path->ancestorCount() : 0;
+  CssSelector::forEachCandidate(
+      CssSelector::ElementRef{tagName, classAttr}, [path](const size_t i) { return path->ancestor(i); }, ancestorCount,
+      walkAncestors && path->parentRecorded(), hasDescendantRules_, hasChildRules_, emit);
+
+  if (best == nullptr) return false;
+  out = best->fontSize;
+  return true;
 }
 
 // Inline style parsing (static - doesn't need rule database)
@@ -2153,6 +2191,12 @@ bool CssParser::loadFromCache(const std::vector<std::string>* usedClasses) {
     if (usedClasses != nullptr) {
       std::string_view sel(selector);
       if (sel.size() >= 2 && sel[0] == 'h' && sel[1] == '|') sel.remove_prefix(2);
+      // The pseudo-element hangs off the SUBJECT compound with no separator, so it would
+      // otherwise be read as part of that compound's class name (".dropcap::first-letter"
+      // tests the class "dropcap::first-letter", which no chapter can ever list, and every
+      // class-based drop cap rule would be dropped on each cache-loaded open).
+      bool selHadPseudo = false;
+      sel = CssSelector::withoutFirstLetterPseudo(sel, selHadPseudo);
       bool allClassesUsed = true;
       while (!sel.empty()) {
         const size_t end = sel.find_first_of(" >");

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -1223,9 +1223,13 @@ void CssParser::processRuleBlockWithStyle(std::string_view selectorGroup, const 
           CssSelector::forEachKeyPiece(
               subjectOnly, [&builtKey](const std::string_view piece) { builtKey.append(piece.data(), piece.size()); });
           sel = builtKey;
-        } else if (parsed.combinator != 0) {
+        } else if (parsed.combinator != 0 || parsed.firstLetter) {
           // Normalized compound key: `.callout   p` and `blockquote > p` both collapse to the
           // single-character-combinator form, so the two spellings share one rule.
+          // A simple selector would otherwise be stored under its RAW text, which is only the
+          // normalized key when the author happened to write the two-colon pseudo -- the CSS 2.1
+          // `p:first-letter` would land under a key no lookup ever spells, and would not even
+          // set hasFirstLetterRules_.
           builtKey.reserve(sel.size());
           CssSelector::forEachKeyPiece(
               parsed, [&builtKey](const std::string_view piece) { builtKey.append(piece.data(), piece.size()); });

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -62,7 +62,11 @@ class CssParser {
   // v21: CssPropertyFlags::anySet() omitted `border`, so a rule defining ONLY a border was
   //      discarded before it was stored. Framing is unchanged, but every cache up to v20 is
   //      missing all of them (145 rules on the EBPAJ template) while still validating cleanly.
-  static constexpr uint8_t CSS_CACHE_VERSION = 21;
+  // v22: `X::first-letter` selectors are stored, under a key carrying the literal suffix.
+  //      Framing is unchanged; the bump exists for the same reason v16's did -- a v21 cache
+  //      was written by a parser that dropped every such rule, so reusing it would silently
+  //      leave drop caps off with no way to notice.
+  static constexpr uint8_t CSS_CACHE_VERSION = 22;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;
@@ -98,6 +102,20 @@ class CssParser {
    */
   [[nodiscard]] CssStyle resolveStyle(std::string_view tagName, std::string_view classAttr,
                                       const CssElementPath* path = nullptr) const;
+
+  /**
+   * The `font-size` an element's `::first-letter` rule declares, if any. Returns false when the
+   * table holds no first-letter rule for this element -- including the common case of a book
+   * with none at all, which costs one bool test and no lookups.
+   *
+   * Only font-size is reported: it is the whole of what a drop cap needs from the pseudo-element
+   * (the float and line-height a stylesheet pairs it with describe the wrap this renderer
+   * performs itself), and returning a length rather than a CssStyle keeps first-letter rules out
+   * of the block cascade entirely -- they are a separate key space, never merged over the
+   * element's own style. Cascade among competing first-letter rules follows resolveStyle().
+   */
+  [[nodiscard]] bool resolveFirstLetterFontSize(std::string_view tagName, std::string_view classAttr,
+                                                const CssElementPath* path, CssLength& out) const;
 
   /**
    * Parse an inline style attribute string.
@@ -282,8 +300,12 @@ class CssParser {
   // correctness.
   bool hasDescendantRules_ = false;
   bool hasChildRules_ = false;
+  // Same idea for the pseudo-element: resolveFirstLetterFontSize returns immediately unless
+  // the table actually holds one, so a book without drop caps pays a single bool test per
+  // block rather than a second pass of candidate lookups.
+  bool hasFirstLetterRules_ = false;
 
-  /** Record which combinators the table contains, from a stored (already normalized) key. */
+  /** Record which combinators and pseudo-elements the table contains, from a stored key. */
   void noteCombinatorsIn(std::string_view key);
 
   // Incremental cache writing state (beginCacheAppend/appendRulesToCache/endCacheAppend).

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -66,7 +66,9 @@ class CssParser {
   //      Framing is unchanged; the bump exists for the same reason v16's did -- a v21 cache
   //      was written by a parser that dropped every such rule, so reusing it would silently
   //      leave drop caps off with no way to notice.
-  static constexpr uint8_t CSS_CACHE_VERSION = 22;
+  // v23: the CSS 2.1 one-colon spelling `X:first-letter` is accepted too. Framing is unchanged;
+  //      same reason as v22 -- a v22 cache was written by a parser that dropped those rules.
+  static constexpr uint8_t CSS_CACHE_VERSION = 23;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;

--- a/lib/Epub/Epub/css/CssSelector.h
+++ b/lib/Epub/Epub/css/CssSelector.h
@@ -18,11 +18,17 @@
  *   compound compound     descendant .callout p        (B anywhere inside A)
  *   compound > compound   child      blockquote > p    (B a direct child of A)
  *
+ * Any of those may carry a trailing `::first-letter`, the one pseudo-element this engine
+ * implements (it is how every EPUB spells a drop cap). It is recorded on the selector and
+ * stored under a key ending in the literal suffix, which no ordinary key can collide with
+ * because ':' is rejected everywhere else. Nothing else about matching changes: an element
+ * lookup never generates the suffix, so these rules are invisible to resolveStyle().
+ *
  * THREE or more compounds (`.a .b p`) are REJECTED, not approximated by their rightmost
  * two: `.b p` matches everywhere, including outside `.a`, so the approximation applies
  * styling the author explicitly scoped away. A wrong match is worse than no match, and
  * dropping the rule is exactly the behaviour those selectors had before this existed.
- * Everything else -- attribute, pseudo, id, sibling, universal -- is rejected as before.
+ * Everything else -- attribute, other pseudos, id, sibling, universal -- is rejected.
  */
 namespace CssSelector {
 
@@ -37,7 +43,13 @@ inline constexpr char CHILD_COMBINATOR = '>';
 //   '+' adjacent sibling · '[' attribute · ':' pseudo · '#' id · '~' general sibling
 //   '*' universal · '|' namespace (which is also the scope-prefix separator, so a
 //       namespaced selector must never reach the map)
+// ':' stays here: parse() strips the ONE supported pseudo-element off the end before any
+// compound is examined, so a colon reaching a compound is still unsupported syntax.
 inline constexpr std::string_view UNSUPPORTED_CHARS = "+[]:#~*|";
+
+// The only pseudo-element that is parsed, stored and matched. Doubles as the storage-key
+// suffix; lowercase because keys are stored ASCII-lowercased.
+inline constexpr std::string_view FIRST_LETTER_PSEUDO = "::first-letter";
 
 // Specificity weights. The real cascade orders by the (ids, classes, types) triple; with
 // no id support and at most two compounds, one class can never be outranked by any number
@@ -71,13 +83,29 @@ struct Compound {
 
 /** A parsed selector: `subject`, optionally scoped by `ancestor` through `combinator`. */
 struct Selector {
-  Compound ancestor;    // meaningful only when combinator != 0
-  Compound subject;     // the element the rule styles (the rightmost compound)
-  char combinator = 0;  // 0 = simple, DESCENDANT_COMBINATOR or CHILD_COMBINATOR
+  Compound ancestor;         // meaningful only when combinator != 0
+  Compound subject;          // the element the rule styles (the rightmost compound)
+  char combinator = 0;       // 0 = simple, DESCENDANT_COMBINATOR or CHILD_COMBINATOR
+  bool firstLetter = false;  // selector ended in ::first-letter
+  // A pseudo-element adds no specificity in CSS beyond a type selector's, and this engine
+  // never cascades a first-letter rule against a non-first-letter one (they live in
+  // disjoint key spaces), so the subject/ancestor weights alone order them correctly.
   [[nodiscard]] constexpr uint8_t specificity() const {
     return static_cast<uint8_t>(subject.specificity() + (combinator ? ancestor.specificity() : 0));
   }
 };
+
+/** ASCII case-insensitive suffix test; `suffix` must already be lowercase. */
+inline bool endsWithPseudoIgnoreCase(const std::string_view s, const std::string_view suffix) {
+  if (s.size() < suffix.size()) return false;
+  const size_t start = s.size() - suffix.size();
+  for (size_t i = 0; i < suffix.size(); ++i) {
+    char c = s[start + i];
+    if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    if (c != suffix[i]) return false;
+  }
+  return true;
+}
 
 /** Parse one compound. Returns false for anything outside `tag` / `.class` / `tag.class`. */
 inline bool parseCompound(const std::string_view s, Compound& out) {
@@ -107,7 +135,17 @@ inline bool parseCompound(const std::string_view s, Compound& out) {
  * Returns false if the selector uses syntax this engine does not implement, including
  * three or more compounds. Views in `out` point into `sel`.
  */
-inline bool parse(const std::string_view sel, Selector& out) {
+inline bool parse(std::string_view sel, Selector& out) {
+  // Strip the pseudo-element FIRST, and only where CSS can put it: at the very end. A
+  // mid-selector spelling (`p::first-letter span`) keeps its colons and is then rejected by
+  // parseCompound, exactly as before. The strict `>` also rejects a bare `::first-letter`,
+  // which would need the universal selector this engine does not implement.
+  bool firstLetter = false;
+  if (sel.size() > FIRST_LETTER_PSEUDO.size() && endsWithPseudoIgnoreCase(sel, FIRST_LETTER_PSEUDO)) {
+    sel.remove_suffix(FIRST_LETTER_PSEUDO.size());
+    firstLetter = true;
+  }
+
   Compound compounds[2];
   size_t count = 0;
   char combinator = 0;
@@ -138,10 +176,10 @@ inline bool parse(const std::string_view sel, Selector& out) {
 
   if (count == 0 || pendingChild) return false;  // empty, or a trailing combinator
   if (count == 1) {
-    out = Selector{{}, compounds[0], 0};
+    out = Selector{{}, compounds[0], 0, firstLetter};
     return true;
   }
-  out = Selector{compounds[0], compounds[1], combinator};
+  out = Selector{compounds[0], compounds[1], combinator, firstLetter};
   return true;
 }
 
@@ -168,6 +206,17 @@ void forEachKeyPiece(const Selector& sel, Sink&& sink) {
     sink(sel.combinator == CHILD_COMBINATOR ? CHILD_PIECE : DESCENDANT_PIECE);
   }
   emitCompound(sel.subject);
+  if (sel.firstLetter) sink(FIRST_LETTER_PSEUDO);
+}
+
+/**
+ * Strip the `::first-letter` suffix off a STORED key (or one compound of it), reporting
+ * whether it was there. Callers that pick a key apart -- the cache's chapter-usage class
+ * filter -- must go through this, or they read the pseudo as part of the class name.
+ */
+inline std::string_view withoutFirstLetterPseudo(const std::string_view key, bool& hadPseudo) {
+  hadPseudo = key.size() > FIRST_LETTER_PSEUDO.size() && endsWithPseudoIgnoreCase(key, FIRST_LETTER_PSEUDO);
+  return hadPseudo ? key.substr(0, key.size() - FIRST_LETTER_PSEUDO.size()) : key;
 }
 
 /** An element as the matcher sees it: its tag and its raw space-separated class attribute. */

--- a/lib/Epub/Epub/css/CssSelector.h
+++ b/lib/Epub/Epub/css/CssSelector.h
@@ -18,8 +18,9 @@
  *   compound compound     descendant .callout p        (B anywhere inside A)
  *   compound > compound   child      blockquote > p    (B a direct child of A)
  *
- * Any of those may carry a trailing `::first-letter`, the one pseudo-element this engine
- * implements (it is how every EPUB spells a drop cap). It is recorded on the selector and
+ * Any of those may carry a trailing `::first-letter` (or its CSS 2.1 one-colon spelling),
+ * the one pseudo-element this engine implements -- it is how EPUBs spell a drop cap. Both
+ * spellings normalize to the same key. It is recorded on the selector and
  * stored under a key ending in the literal suffix, which no ordinary key can collide with
  * because ':' is rejected everywhere else. Nothing else about matching changes: an element
  * lookup never generates the suffix, so these rules are invisible to resolveStyle().
@@ -50,6 +51,10 @@ inline constexpr std::string_view UNSUPPORTED_CHARS = "+[]:#~*|";
 // The only pseudo-element that is parsed, stored and matched. Doubles as the storage-key
 // suffix; lowercase because keys are stored ASCII-lowercased.
 inline constexpr std::string_view FIRST_LETTER_PSEUDO = "::first-letter";
+// CSS 2.1 spelled pseudo-elements with one colon, and EPUB toolchains still emit that form
+// (often in the same stylesheet as the two-colon one). Both spellings mean the same thing and
+// normalize to the same stored key, so a book gets its drop cap whichever way it is written.
+inline constexpr std::string_view FIRST_LETTER_PSEUDO_CSS2 = ":first-letter";
 
 // Specificity weights. The real cascade orders by the (ids, classes, types) triple; with
 // no id support and at most two compounds, one class can never be outranked by any number
@@ -138,11 +143,16 @@ inline bool parseCompound(const std::string_view s, Compound& out) {
 inline bool parse(std::string_view sel, Selector& out) {
   // Strip the pseudo-element FIRST, and only where CSS can put it: at the very end. A
   // mid-selector spelling (`p::first-letter span`) keeps its colons and is then rejected by
-  // parseCompound, exactly as before. The strict `>` also rejects a bare `::first-letter`,
-  // which would need the universal selector this engine does not implement.
+  // parseCompound, exactly as before. The strict `>` also rejects a bare `::first-letter` or
+  // `:first-letter`, which would need the universal selector this engine does not implement.
+  // Two-colon first: `X::first-letter` also ends with the one-colon spelling, so testing that
+  // one first would leave a stray ':' on the compound.
   bool firstLetter = false;
   if (sel.size() > FIRST_LETTER_PSEUDO.size() && endsWithPseudoIgnoreCase(sel, FIRST_LETTER_PSEUDO)) {
     sel.remove_suffix(FIRST_LETTER_PSEUDO.size());
+    firstLetter = true;
+  } else if (sel.size() > FIRST_LETTER_PSEUDO_CSS2.size() && endsWithPseudoIgnoreCase(sel, FIRST_LETTER_PSEUDO_CSS2)) {
+    sel.remove_suffix(FIRST_LETTER_PSEUDO_CSS2.size());
     firstLetter = true;
   }
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <cstring>
 #include <iterator>
 #include <new>
@@ -879,6 +880,29 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
   wordsExtractedInBlock = 0;
   listItemBulletOnly = false;
   updateEffectiveInlineStyle();
+}
+
+void ChapterHtmlSlimParser::applyDropCap(const char* tagName, const std::string& classAttr) {
+  if (!cssParser || !currentTextBlock || !currentTextBlock->isEmpty()) return;
+
+  CssLength firstLetterSize;
+  if (!cssParser->resolveFirstLetterFontSize(tagName, classAttr, &cssPath, firstLetterSize)) return;
+
+  // Reuse the block ladder's own unit handling (%, em, rem, pt) instead of re-deriving it:
+  // `font-size: 300%` means the same multiple of the reader's size on a pseudo-element as it
+  // does anywhere else, and cssFontSizeScale already clamps the result to 0.5x..4x.
+  CssStyle sized;
+  sized.fontSize = firstLetterSize;
+  sized.defined.fontSize = 1;
+  const auto lines = static_cast<int>(std::lround(cssFontSizeScale(sized)));
+
+  // Under 2x the letter fits within its own line, so there is nothing to wrap around: leave it
+  // in the text, where it renders inline at the block's size.
+  if (lines < 2) return;
+
+  BlockStyle style = currentTextBlock->getBlockStyle();
+  style.dropCapLines = static_cast<uint8_t>(std::min(lines, MAX_DROP_CAP_LINES));
+  currentTextBlock->setBlockStyle(style);
 }
 
 void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
@@ -2050,6 +2074,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                                                                                   BlockStyle::CombineAxis::Horizontal);
       self->blockStyleStack.push_back(accumulated);
       self->startNewTextBlock(accumulated.withoutBottom());
+      // On the block itself, never on the style stack: a drop cap belongs to this one
+      // paragraph, and the stack is what every nested and sibling block inherits from.
+      self->applyDropCap(name, classAttr);
       // See the header branch above: raised only once the previous block has been flushed.
       if (cssStyle.pageBreakBefore() == CssPageBreak::Always) self->pendingForcedBreak = true;
       self->updateEffectiveInlineStyle();

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -883,10 +883,14 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
 }
 
 void ChapterHtmlSlimParser::applyDropCap(const char* tagName, const std::string& classAttr) {
-  if (!cssParser || !currentTextBlock || !currentTextBlock->isEmpty()) return;
+  if (!cssParser || !currentTextBlock || !currentTextBlock->isEmpty()) {
+    return;
+  }
 
   CssLength firstLetterSize;
-  if (!cssParser->resolveFirstLetterFontSize(tagName, classAttr, &cssPath, firstLetterSize)) return;
+  if (!cssParser->resolveFirstLetterFontSize(tagName, classAttr, &cssPath, firstLetterSize)) {
+    return;
+  }
 
   // Reuse the block ladder's own unit handling (%, em, rem, pt) instead of re-deriving it:
   // `font-size: 300%` means the same multiple of the reader's size on a pseudo-element as it
@@ -898,11 +902,56 @@ void ChapterHtmlSlimParser::applyDropCap(const char* tagName, const std::string&
 
   // Under 2x the letter fits within its own line, so there is nothing to wrap around: leave it
   // in the text, where it renders inline at the block's size.
-  if (lines < 2) return;
+  if (lines < 2) {
+    return;
+  }
 
   BlockStyle style = currentTextBlock->getBlockStyle();
   style.dropCapLines = static_cast<uint8_t>(std::min(lines, MAX_DROP_CAP_LINES));
   currentTextBlock->setBlockStyle(style);
+}
+
+void ChapterHtmlSlimParser::applyInlineDropCap(const CssStyle& style) {
+  // Only the first inline element of an otherwise-empty paragraph: an enlarged span mid-sentence
+  // is emphasis, not an initial.
+  if (!currentTextBlock) return;
+  if (currentTextBlock->getBlockStyle().hasDropCap()) return;  // a ::first-letter rule got there first
+  if (dropCapSpanDepth >= 0) return;                           // one claim per paragraph
+  if (!style.hasFontSize()) return;
+  // Not necessarily the paragraph's FIRST token: a French chapter opens dialogue with an em dash
+  // and a no-break space, both already tokenized by the time the lettrine span arrives. A short
+  // prefix is allowed and prepareDropCap has the last word -- it rejects the claim if anything
+  // ahead of the initial turns out to contain a letter.
+  const size_t wordsSoFar = currentTextBlock->size() + (partWordBufferIndex > 0 ? 1 : 0);
+  if (wordsSoFar > MAX_DROP_CAP_PREFIX_WORDS) return;
+
+  // Same ladder the block path uses, so `font-size: 270%` means the same multiple of the
+  // reader's size here as it does on a pseudo-element.
+  const auto lines = static_cast<int>(std::lround(cssFontSizeScale(style)));
+  if (lines < 2) return;
+
+  BlockStyle blockStyle = currentTextBlock->getBlockStyle();
+  blockStyle.dropCapLines = static_cast<uint8_t>(std::min(lines, MAX_DROP_CAP_LINES));
+  currentTextBlock->setBlockStyle(blockStyle);
+  // The span's text lands in the next token: the caller flushes any pending part-word right
+  // after this, and the flush makes the span's own content a token of its own.
+  currentTextBlock->setDropCapWordIndex(static_cast<uint8_t>(wordsSoFar));
+  dropCapSpanDepth = depth;
+  dropCapSpanStartOffset = visibleTextOffset;
+}
+
+// The provisional claim above, resolved once the span's content is known.
+void ChapterHtmlSlimParser::releaseInlineDropCapIfNotSingleLetter() {
+  if (dropCapSpanDepth < 0 || depth != dropCapSpanDepth) return;
+  dropCapSpanDepth = -1;
+
+  const uint32_t chars = visibleTextOffset - dropCapSpanStartOffset;
+  if (chars == 1) return;  // exactly one character: a real initial
+
+  if (!currentTextBlock) return;
+  BlockStyle blockStyle = currentTextBlock->getBlockStyle();
+  blockStyle.dropCapLines = 0;
+  currentTextBlock->setBlockStyle(blockStyle);
 }
 
 void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
@@ -2223,6 +2272,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (cssStyle.hasFontWeight() || cssStyle.hasFontStyle() || cssStyle.hasTextDecoration() ||
         cssStyle.hasDirection() || cssStyle.hasVerticalAlign() || cssStyle.hasTextEmphasis() ||
         cssStyle.hasFontVariant() || cssStyle.hasTextTransform() || cssStyle.hasFontSize() || inheritedTableTextAlign) {
+      // Before the flush below, which would make an empty block look non-empty.
+      self->applyInlineDropCap(cssStyle);
       // Flush buffer before style change so preceding text gets current style
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
@@ -2261,6 +2312,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         // reader's font as the em base): the ladder snaps to a resident 12/14/16/18pt size.
         // 0 = no distinct size resident (or SD-card base font) -> the block font is kept.
         entry.fontIdOverride = cssBlockFontId(cssStyle, self->fontId);
+        if (entry.fontIdOverride == 0) {
+          // No resident size can serve the ask: the reader font is a single-size SD-card font
+          // with no ladder, or the nearest step IS the base. Scale the block font's bitmap
+          // instead, so `<small>` really is small rather than silently rendering at body size.
+          entry.fontIdOverride = cssFontScaleTag(cssStyle);
+        }
       }
       self->inlineStyleStack.push_back(entry);
       self->updateEffectiveInlineStyle();
@@ -2739,6 +2796,8 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   if (self->italicUntilDepth == self->depth) {
     self->italicUntilDepth = INT_MAX;
   }
+
+  self->releaseInlineDropCapIfNotSingleLetter();
 
   // Pop from inline style stack if we pushed an entry at this depth
   // This handles all inline elements: b, i, u, span, etc.

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -257,6 +257,14 @@ class ChapterHtmlSlimParser {
 
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
+  // Tallest drop cap this engine will lay out. Beyond four lines the enlarged letter starts
+  // to dominate a 480px-tall page, and every line beside it is one more line broken to a
+  // narrowed width by the greedy fill rather than the optimal one.
+  static constexpr int MAX_DROP_CAP_LINES = 4;
+  // Turn the block just opened into a drop cap paragraph if CSS asked for one. Decides only
+  // the line COUNT; ParsedText resolves the glyph, its magnification and the column width,
+  // where the font metrics and the line height are known.
+  void applyDropCap(const char* tagName, const std::string& classAttr);
   void flushPendingAnchor();
   void flushPartWordBuffer();
   void fallbackTableRowToStacked();

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -261,10 +261,27 @@ class ChapterHtmlSlimParser {
   // to dominate a 480px-tall page, and every line beside it is one more line broken to a
   // narrowed width by the greedy fill rather than the optimal one.
   static constexpr int MAX_DROP_CAP_LINES = 4;
+  // Tokens a paragraph may already hold and still have its next span treated as an initial.
+  // Two covers the real openings (`--` + no-break space, guillemet + space); the bound is what
+  // keeps a large span in mid-sentence from ever being considered.
+  static constexpr size_t MAX_DROP_CAP_PREFIX_WORDS = 3;
   // Turn the block just opened into a drop cap paragraph if CSS asked for one. Decides only
   // the line COUNT; ParsedText resolves the glyph, its magnification and the column width,
   // where the font metrics and the line height are known.
   void applyDropCap(const char* tagName, const std::string& classAttr);
+  // The other way books spell a drop cap: markup rather than a pseudo-element, an enlarged
+  // `<span class="lettrine">L</span>` opening the paragraph. Claimed when the span opens (the
+  // block must still be empty) and released at its close unless it turned out to hold exactly
+  // one character -- see dropCapSpanDepth.
+  void applyInlineDropCap(const CssStyle& style);
+  void releaseInlineDropCapIfNotSingleLetter();
+  // Depth of the inline element that claimed a drop cap, or -1. A span is only a drop cap if it
+  // wraps ONE character: an enlarged span opening a paragraph is otherwise just big text, and
+  // blowing its first letter up four lines tall would wreck the page. The count is not knowable
+  // when the span opens, so the claim is provisional until the close tag confirms it.
+  int dropCapSpanDepth = -1;
+  uint32_t dropCapSpanStartOffset = 0;
+
   void flushPendingAnchor();
   void flushPartWordBuffer();
   void fallbackTableRowToStacked();

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -2683,6 +2683,58 @@ void GfxRenderer::drawTextRotated90CCW(const int fontId, const int x, const int 
   }
 }
 
+bool GfxRenderer::drawCharUpscaled(const int fontId, const uint32_t cp, const int scale, const int inkLeftX,
+                                   const int inkTopY, const bool black, const EpdFontFamily::Style style,
+                                   int* inkWidthOut, int* inkHeightOut) const {
+  if (scale < 1) return false;
+  const auto fontIt = fontMap.find(fontId);
+  if (fontIt == fontMap.end()) {
+    LOG_ERR("GFX", "Font %d not found", fontId);
+    return false;
+  }
+  const auto& font = fontIt->second;
+  const EpdGlyph* glyph = font.getGlyph(cp, style);
+  if (!glyph) return false;
+
+  const EpdFontData* fontData = font.getDataForGlyph(cp, style);
+  const uint8_t* bitmap = getGlyphBitmap(fontData, glyph);
+  if (!bitmap) return false;
+
+  const int srcW = glyph->width;
+  const int srcH = glyph->height;
+  if (inkWidthOut) *inkWidthOut = srcW * scale;
+  if (inkHeightOut) *inkHeightOut = srcH * scale;
+
+  // Each source pixel fills a scale x scale block; the ink box origin is the caller's, so no
+  // bearing arithmetic leaks out of here.
+  for (int srcY = 0; srcY < srcH; srcY++) {
+    for (int srcX = 0; srcX < srcW; srcX++) {
+      const int pos = srcY * srcW + srcX;
+      bool hasInk;
+      if (fontData->is2Bit) {
+        // 2-bit coverage: 4 px per byte, MSB first. Treat the two darker levels as ink, the
+        // same threshold the 50% path uses, so a magnified glyph keeps the stroke weight the
+        // font intends rather than growing a light antialiasing fringe into solid black.
+        const uint8_t byte = bitmap[pos >> 2];
+        const uint8_t raw = (byte >> ((3 - (pos & 3)) * 2)) & 0x3;
+        hasInk = raw >= 2;
+      } else {
+        const uint8_t byte = bitmap[pos >> 3];
+        hasInk = ((byte >> (7 - (pos & 7))) & 1) != 0;
+      }
+      if (!hasInk) continue;
+      const int dstX = inkLeftX + srcX * scale;
+      const int dstY = inkTopY + srcY * scale;
+      for (int dy = 0; dy < scale; dy++) {
+        for (int dx = 0; dx < scale; dx++) {
+          drawPixel(dstX + dx, dstY + dy, black);
+        }
+      }
+    }
+  }
+  return true;
+}
+
 void GfxRenderer::drawCharVerticalCornerTopRight(const int fontId, const int cellLeftX, const int cellTopY,
                                                  const int cellSize, const uint32_t cp, const bool black,
                                                  const EpdFontFamily::Style style) const {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -885,6 +885,12 @@ void GfxRenderer::drawTextScaled(const int fontId, const int x, const int y, con
   int lastBaseWidth = 0;
   int lastBaseTop = 0;
   int32_t prevAdvanceFP = 0;
+  // Advance is accumulated UNSCALED and the running total scaled once per glyph, so the pen ends
+  // at exactly x + scalePositive(total) -- the value getTextWidthScaled reports. Scaling each
+  // delta instead rounds every glyph independently, and those errors accumulate: a long word
+  // drawn that way is several pixels wider than it was measured, which is fine for a standalone
+  // string but silently overlaps the next word once scaled text goes through paragraph layout.
+  int unscaledAdvance = 0;
 
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
     fontCacheManager_->recordText(renderedText, resolvedFontId, style);
@@ -918,8 +924,8 @@ void GfxRenderer::drawTextScaled(const int fontId, const int x, const int y, con
     cp = font.applyLigatures(cp, textCursor, style);
     if (prevCp != 0) {
       const auto kernFP = font.getKerning(prevCp, cp, style);
-      const int advance = textAdvance::withLetterSpacing(fp4::toPixel(prevAdvanceFP + kernFP), 1, letterSpacing);
-      lastBaseX += scalePositive(advance, scale);
+      unscaledAdvance += textAdvance::withLetterSpacing(fp4::toPixel(prevAdvanceFP + kernFP), 1, letterSpacing);
+      lastBaseX = x + scalePositive(unscaledAdvance, scale);
     }
 
     const EpdGlyph* glyph = font.getGlyph(cp, style);

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -395,6 +395,21 @@ class GfxRenderer {
                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   void drawTextRotated90CCW(int fontId, int x, int y, const char* text, bool black = true,
                             EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  // Renders one codepoint magnified by an integer factor, its INK box placed at
+  // (inkLeftX, inkTopY) -- the glyph's own bearings are applied internally, so the caller
+  // positions the visible mark and never has to reason about them. Used for drop caps.
+  //
+  // Integer nearest-neighbour block replication: each source pixel becomes a scale x scale
+  // square. It needs no intermediate buffer (a 4x 18pt capital would be a ~5KB one) and, on a
+  // 1-bit panel, cannot introduce the half-lit edge pixels a resampling filter would, which
+  // would just be dithered back to hard black or white anyway.
+  //
+  // Reports the ink size actually drawn so layout can reserve exactly that column; drawing is
+  // skipped and false returned when the font or the glyph is missing.
+  bool drawCharUpscaled(int fontId, uint32_t cp, int scale, int inkLeftX, int inkTopY, bool black = true,
+                        EpdFontFamily::Style style = EpdFontFamily::REGULAR, int* inkWidthOut = nullptr,
+                        int* inkHeightOut = nullptr) const;
+
   // Renders a single upright codepoint flush to the top-right corner of the
   // cell box [cellLeftX, cellLeftX+cellSize] × [cellTopY, cellTopY+cellSize],
   // using the glyph's own metrics. Used for vertical-text small kana.

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -396,8 +396,11 @@ class GfxRenderer {
   void drawTextRotated90CCW(int fontId, int x, int y, const char* text, bool black = true,
                             EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   // Renders one codepoint magnified by an integer factor, its INK box placed at
-  // (inkLeftX, inkTopY) -- the glyph's own bearings are applied internally, so the caller
-  // positions the visible mark and never has to reason about them. Used for drop caps.
+  // (inkLeftX, inkTopY): the glyph bitmap's top-left lands exactly there, and the glyph's own
+  // left/top bearings are deliberately NOT added. The caller is positioning the visible mark
+  // directly, so a caller that wants the glyph on a baseline applies the bearings itself (see
+  // ParsedText::prepareDropCap, which derives inkTop from the ascender and the top bearing) --
+  // adding them here as well would shift every drop cap by its own bearing twice.
   //
   // Integer nearest-neighbour block replication: each source pixel becomes a scale x scale
   // square. It needs no intermediate buffer (a 4x 18pt capital would be a ~5KB one) and, on a

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -234,13 +234,22 @@ class DropCapTest : public ::testing::Test {
  protected:
   std::string filepath = "unused.xhtml";
   GfxRenderer renderer;
-  CssParser cssParser{cssCacheDir()};
+  CssParser cssParser{caseDir()};
   std::unique_ptr<ChapterHtmlSlimParser> parser;
   std::vector<std::shared_ptr<TextBlock>> lines;
 
   static constexpr int LINE_HEIGHT = 16;
   static constexpr int GLYPH_INK = 8;
   static constexpr int SPACE_WIDTH = 4;
+
+  // Its own directory per test: ctest runs these as CONCURRENT PROCESSES (`ctest -j` in
+  // ci.yml), so a shared stylesheet path lets one case read the CSS another just wrote.
+  std::string caseDir() const {
+    const auto dir = std::filesystem::temp_directory_path() /
+                     ("matcha-dropcap-" + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()));
+    std::filesystem::create_directories(dir);
+    return dir.string();
+  }
 
   void makeParser(const std::string& css) {
     ASSERT_TRUE(loadCss(css));
@@ -258,7 +267,7 @@ class DropCapTest : public ::testing::Test {
   }
 
   bool loadCss(const std::string& css) {
-    const auto path = std::filesystem::path(cssCacheDir()) / "dropcap.css";
+    const auto path = std::filesystem::path(caseDir()) / "dropcap.css";
     std::FILE* f = std::fopen(path.string().c_str(), "wb");
     if (f == nullptr) return false;
     std::fwrite(css.data(), 1, css.size(), f);

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -28,6 +28,13 @@
 #undef private
 #undef class
 
+// Recorded by the TextBlock test double in ParserLinkStubs.cpp: this binary links a stub
+// constructor (the real one flattens into an arena whose render path needs a full renderer),
+// so the per-word data a line was built from is read back from there. Global scope on
+// purpose -- an extern inside the anonymous namespace would name a different symbol.
+extern std::vector<std::vector<std::string>> stubLineWords;
+extern std::vector<std::vector<int16_t>> stubLineXPos;
+
 namespace {
 
 // A hardcoded "/tmp" isn't portable (Windows runners, sandboxes without a writable /tmp) --
@@ -216,6 +223,157 @@ TEST_F(ChapterHtmlSlimParserFrenchInversionTest, DoesNotSplitInNonFrenchBooks) {
 
   ASSERT_EQ(parser->currentTextBlock->size(), 1u);
   EXPECT_EQ(parser->currentTextBlock->words[0], "songeai-je");
+}
+
+// Drop caps, end to end: a `::first-letter` font-size has to reach the layout, take the letter
+// out of the flow, indent the lines beside the enlarged glyph and release the ones below it.
+//
+// Against the stub renderer (stubs/GfxRenderer.h): 16px lines, an 8x8 glyph ink box with
+// top bearing 8, ascender 12, 4px spaces and an 8px advance per character.
+class DropCapTest : public ::testing::Test {
+ protected:
+  std::string filepath = "unused.xhtml";
+  GfxRenderer renderer;
+  CssParser cssParser{cssCacheDir()};
+  std::unique_ptr<ChapterHtmlSlimParser> parser;
+  std::vector<std::shared_ptr<TextBlock>> lines;
+
+  static constexpr int LINE_HEIGHT = 16;
+  static constexpr int GLYPH_INK = 8;
+  static constexpr int SPACE_WIDTH = 4;
+
+  void makeParser(const std::string& css) {
+    ASSERT_TRUE(loadCss(css));
+    parser = std::make_unique<ChapterHtmlSlimParser>(
+        nullptr, filepath, renderer, 0, 1.0f, false, 0, static_cast<uint16_t>(renderer.getScreenWidth()),
+        static_cast<uint16_t>(renderer.getScreenHeight()), false, false, false,
+        std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>{}, true, "", "", 0,
+        std::vector<std::string>{}, std::function<void()>{}, &cssParser);
+    parser->currentTextBlock = std::make_unique<ParsedText>(false);
+    // The root entry beginParse() would have pushed: block elements read the enclosing style
+    // off the top of this stack, and these tests drive startElement without a full parse.
+    parser->blockStyleStack.push_back(BlockStyle{});
+    stubLineWords.clear();
+    stubLineXPos.clear();
+  }
+
+  bool loadCss(const std::string& css) {
+    const auto path = std::filesystem::path(cssCacheDir()) / "dropcap.css";
+    std::FILE* f = std::fopen(path.string().c_str(), "wb");
+    if (f == nullptr) return false;
+    std::fwrite(css.data(), 1, css.size(), f);
+    std::fclose(f);
+    HalFile file;
+    if (!file.open(path.string().c_str(), "rb")) return false;
+    return cssParser.loadFromStream(file);
+  }
+
+  void openParagraph(const char* classAttr = nullptr) {
+    if (classAttr != nullptr) {
+      const XML_Char* attributes[] = {"class", classAttr, nullptr};
+      ChapterHtmlSlimParser::startElement(parser.get(), "p", attributes);
+    } else {
+      const XML_Char* attributes[] = {nullptr};
+      ChapterHtmlSlimParser::startElement(parser.get(), "p", attributes);
+    }
+  }
+
+  void feedWord(const char* text) {
+    ChapterHtmlSlimParser::characterData(parser.get(), text, static_cast<int>(strlen(text)));
+    parser->flushPartWordBuffer();
+  }
+
+  // Enough words that the drop cap's lines fill and the paragraph runs past them.
+  void feedParagraph(const size_t wordCount) {
+    feedWord("Le");
+    for (size_t i = 1; i < wordCount; ++i) feedWord("syndicat");
+  }
+
+  void layout() {
+    parser->currentTextBlock->layoutAndExtractLines(
+        renderer, 0, static_cast<uint16_t>(renderer.getScreenWidth()),
+        [this](const std::shared_ptr<TextBlock>& line, uint32_t) { lines.push_back(line); });
+  }
+};
+
+TEST_F(DropCapTest, WrapsTheOpeningLinesAroundAnEnlargedFirstLetter) {
+  makeParser("p::first-letter { font-size: 300%; }\n");
+  openParagraph();
+  ASSERT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 3u);
+
+  feedParagraph(60);
+  layout();
+  ASSERT_GT(lines.size(), 4u);
+
+  // 300% of a 16px line is three lines tall; an 8px-tall glyph magnified by whole pixels to
+  // fill 48px is 6x, and the column it needs is that plus one space.
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.cp, static_cast<uint32_t>('L'));
+  EXPECT_EQ(cap.scale, (LINE_HEIGHT * 3) / GLYPH_INK);
+  EXPECT_EQ(cap.inkLeft, 0);
+  EXPECT_EQ(cap.inkTop, 4) << "the enlarged ink top should meet the line's own cap height";
+
+  const int expectedIndent = GLYPH_INK * cap.scale + SPACE_WIDTH;
+  ASSERT_GE(stubLineXPos.size(), 4u);
+  for (size_t i = 0; i < 3; ++i) {
+    ASSERT_FALSE(stubLineXPos[i].empty());
+    EXPECT_EQ(stubLineXPos[i][0], expectedIndent) << "line " << i << " should clear the drop cap column";
+  }
+  // The fourth line has passed the enlarged letter and returns to the full column -- with no
+  // first-line indent, which the drop cap's own opening line already stood in for.
+  ASSERT_FALSE(stubLineXPos[3].empty());
+  EXPECT_EQ(stubLineXPos[3][0], 0);
+
+  // Only the first line draws it.
+  for (size_t i = 1; i < lines.size(); ++i) {
+    EXPECT_FALSE(lines[i]->getDropCap().present()) << "line " << i << " redraws the drop cap";
+  }
+}
+
+TEST_F(DropCapTest, TheLetterLeavesTheTextFlow) {
+  makeParser("p::first-letter { font-size: 300%; }\n");
+  openParagraph();
+  feedParagraph(20);
+  layout();
+
+  ASSERT_FALSE(stubLineWords.empty());
+  ASSERT_FALSE(stubLineWords[0].empty());
+  // "Le" opened the paragraph; the L became the drop cap, so the flow starts at "e".
+  EXPECT_EQ(stubLineWords[0][0], "e");
+}
+
+TEST_F(DropCapTest, IgnoresARuleThatOnlyMildlyEnlargesTheLetter) {
+  // Under 2x there is no room beside the letter to wrap into, so the paragraph stays ordinary
+  // and the letter keeps its place in the text.
+  makeParser("p::first-letter { font-size: 130%; }\n");
+  openParagraph();
+  ASSERT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 0u);
+
+  feedParagraph(20);
+  layout();
+  ASSERT_FALSE(lines.empty());
+  EXPECT_FALSE(lines[0]->getDropCap().present());
+  ASSERT_FALSE(stubLineWords.empty());
+  ASSERT_FALSE(stubLineWords[0].empty());
+  EXPECT_EQ(stubLineWords[0][0], "Le");
+}
+
+TEST_F(DropCapTest, LeavesAParagraphOpeningWithPunctuationAlone) {
+  // `::first-letter` is applied by class across whole books; a paragraph that happens to open
+  // with a quote must not blow that mark up to three lines tall.
+  makeParser("p::first-letter { font-size: 300%; }\n");
+  openParagraph();
+  feedWord("\"Le");
+  for (int i = 0; i < 20; ++i) feedWord("syndicat");
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  EXPECT_FALSE(lines[0]->getDropCap().present());
+  ASSERT_FALSE(stubLineXPos.empty());
+  ASSERT_FALSE(stubLineXPos[0].empty());
+  // No column was reserved, so the line keeps the paragraph's ordinary first-line indent.
+  EXPECT_EQ(stubLineXPos[0][0], SPACE_WIDTH * 3);
 }
 
 }  // namespace

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -251,12 +251,12 @@ class DropCapTest : public ::testing::Test {
     return dir.string();
   }
 
-  void makeParser(const std::string& css) {
+  void makeParser(const std::string& css, const CssTextAlign alignment = CssTextAlign::Justify) {
     ASSERT_TRUE(loadCss(css));
     parser = std::make_unique<ChapterHtmlSlimParser>(
-        nullptr, filepath, renderer, 0, 1.0f, false, 0, static_cast<uint16_t>(renderer.getScreenWidth()),
-        static_cast<uint16_t>(renderer.getScreenHeight()), false, false, false,
-        std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>{}, true, "", "", 0,
+        nullptr, filepath, renderer, 0, 1.0f, false, static_cast<uint8_t>(alignment),
+        static_cast<uint16_t>(renderer.getScreenWidth()), static_cast<uint16_t>(renderer.getScreenHeight()), false,
+        false, false, std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t, uint32_t)>{}, true, "", "", 0,
         std::vector<std::string>{}, std::function<void()>{}, &cssParser);
     parser->currentTextBlock = std::make_unique<ParsedText>(false);
     // The root entry beginParse() would have pushed: block elements read the enclosing style
@@ -382,6 +382,46 @@ TEST_F(DropCapTest, DropsDecorationAndScriptBitsFromTheDropCapFace) {
   const auto& cap = lines[0]->getDropCap();
   ASSERT_TRUE(cap.present());
   EXPECT_EQ(cap.style, static_cast<uint8_t>(EpdFontFamily::BOLD));
+}
+
+// The reserved column is an obstruction, not a text-indent: every alignment has to clear it.
+// extractLine's right/center paths derive x from effectivePageWidth, which is already reduced by
+// the indent, so without adding it back the line slides left into the drop cap.
+TEST_F(DropCapTest, RightAndCentreAlignedLinesStayClearOfTheColumn) {
+  for (const auto alignment : {CssTextAlign::Right, CssTextAlign::Center}) {
+    lines.clear();
+    makeParser("p::first-letter { font-size: 300%; }\n", alignment);
+    openParagraph();
+    feedParagraph(60);
+    layout();
+
+    ASSERT_FALSE(lines.empty());
+    const auto& cap = lines[0]->getDropCap();
+    ASSERT_TRUE(cap.present());
+    const int expectedIndent = GLYPH_INK * cap.scale + SPACE_WIDTH;
+    ASSERT_GE(stubLineXPos.size(), 3u);
+    for (size_t i = 0; i < 3; ++i) {
+      ASSERT_FALSE(stubLineXPos[i].empty());
+      EXPECT_GE(stubLineXPos[i][0], expectedIndent)
+          << "alignment " << static_cast<int>(alignment) << ", line " << i << " overlaps the drop cap";
+    }
+  }
+}
+
+// `::first-letter` is applied across whole classes of paragraph, so the guard has to hold for the
+// quote marks EPUBs actually open dialogue with -- not just the ASCII one.
+TEST_F(DropCapTest, LeavesAParagraphOpeningWithANonAsciiQuoteAlone) {
+  for (const char* opening : {"\xE2\x80\x9CLe", "\xC2\xABLe"}) {  // U+201C left double quote, U+00AB «
+    lines.clear();
+    makeParser("p::first-letter { font-size: 300%; }\n");
+    openParagraph();
+    feedWord(opening);
+    for (int i = 0; i < 20; ++i) feedWord("syndicat");
+    layout();
+
+    ASSERT_FALSE(lines.empty());
+    EXPECT_FALSE(lines[0]->getDropCap().present()) << "opening " << opening << " became a drop cap";
+  }
 }
 
 TEST_F(DropCapTest, IgnoresARuleThatOnlyMildlyEnlargesTheLetter) {

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -352,6 +352,38 @@ TEST_F(DropCapTest, TheLetterLeavesTheTextFlow) {
   EXPECT_EQ(stubLineWords[0][0], "e");
 }
 
+TEST_F(DropCapTest, KeepsTheFaceOfTheWordTheLetterCameFrom) {
+  // An italic chapter opening must not get a regular initial: the glyph is measured and drawn
+  // with the first word's own face, or the reserved column does not match what lands in it.
+  makeParser("p::first-letter { font-size: 300%; }\n");
+  openParagraph();
+  parser->currentTextBlock->addWord("Le", EpdFontFamily::BOLD_ITALIC);
+  for (int i = 0; i < 20; ++i) parser->currentTextBlock->addWord("syndicat", EpdFontFamily::BOLD_ITALIC);
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.style, static_cast<uint8_t>(EpdFontFamily::BOLD_ITALIC));
+}
+
+TEST_F(DropCapTest, DropsDecorationAndScriptBitsFromTheDropCapFace) {
+  // An underlined or superscripted opening word must not carry that into a letter drawn three
+  // lines tall and outside the text flow -- only the face bits survive.
+  makeParser("p::first-letter { font-size: 300%; }\n");
+  openParagraph();
+  const auto decorated =
+      static_cast<EpdFontFamily::Style>(EpdFontFamily::BOLD | EpdFontFamily::UNDERLINE | EpdFontFamily::SUP);
+  parser->currentTextBlock->addWord("Le", decorated);
+  for (int i = 0; i < 20; ++i) parser->currentTextBlock->addWord("syndicat", decorated);
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.style, static_cast<uint8_t>(EpdFontFamily::BOLD));
+}
+
 TEST_F(DropCapTest, IgnoresARuleThatOnlyMildlyEnlargesTheLetter) {
   // Under 2x there is no room beside the letter to wrap into, so the paragraph stays ordinary
   // and the letter keeps its place in the text.

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -292,6 +292,15 @@ class DropCapTest : public ::testing::Test {
     parser->flushPartWordBuffer();
   }
 
+  // `<span class="...">text</span>`, driven through the real element callbacks so the inline
+  // drop cap claim and its release at the close tag both run.
+  void feedSpan(const char* classAttr, const char* text) {
+    const XML_Char* attributes[] = {"class", classAttr, nullptr};
+    ChapterHtmlSlimParser::startElement(parser.get(), "span", attributes);
+    ChapterHtmlSlimParser::characterData(parser.get(), text, static_cast<int>(strlen(text)));
+    ChapterHtmlSlimParser::endElement(parser.get(), "span");
+  }
+
   // Enough words that the drop cap's lines fill and the paragraph runs past them.
   void feedParagraph(const size_t wordCount) {
     feedWord("Le");
@@ -338,6 +347,151 @@ TEST_F(DropCapTest, WrapsTheOpeningLinesAroundAnEnlargedFirstLetter) {
   for (size_t i = 1; i < lines.size(); ++i) {
     EXPECT_FALSE(lines[i]->getDropCap().present()) << "line " << i << " redraws the drop cap";
   }
+}
+
+// The CSS 2.1 one-colon spelling is what a good many EPUB toolchains emit -- often beside the
+// two-colon one in the same stylesheet -- so it has to reach the layout the same way.
+TEST_F(DropCapTest, AcceptsTheCss2OneColonSpelling) {
+  makeParser("p.opener:first-letter { font-size: 300%; }\n");
+  openParagraph("opener");
+  ASSERT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 3u);
+
+  feedParagraph(20);
+  layout();
+  ASSERT_FALSE(lines.empty());
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.cp, static_cast<uint32_t>('L'));
+}
+
+// Plenty of books never write the pseudo-element at all: the initial is marked up as an enlarged
+// span opening the paragraph (`class="lettrine"` / `class="let"` in French trade EPUBs). Sizing
+// that span through the font ladder cannot produce a drop cap -- 270% of an 18pt reader font
+// snaps back to the largest resident size, i.e. no change -- so it has to reach the same
+// magnified-glyph path the pseudo-element takes.
+TEST_F(DropCapTest, ClaimsADropCapFromAnEnlargedOpeningSpan) {
+  makeParser(".let { font-size: 270%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedSpan("let", "L");
+  ASSERT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 3u);
+
+  for (int i = 0; i < 40; ++i) feedWord("syndicat");
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.cp, static_cast<uint32_t>('L'));
+}
+
+// An enlarged span holding a WORD is big text, not an initial. The count is unknowable when the
+// span opens, so the claim is provisional and has to be given back at the close tag.
+TEST_F(DropCapTest, ReleasesAnEnlargedOpeningSpanThatHoldsMoreThanOneLetter) {
+  makeParser(".let { font-size: 270%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedSpan("let", "Le");
+  EXPECT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 0u);
+
+  for (int i = 0; i < 40; ++i) feedWord("syndicat");
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  EXPECT_FALSE(lines[0]->getDropCap().present());
+}
+
+// A paragraph does not have to open with the initial: a French chapter opens dialogue with an em
+// dash and a no-break space, so both are already tokenized when the lettrine span arrives.
+TEST_F(DropCapTest, ClaimsADropCapAfterTheEmDashAFrenchChapterOpensWith) {
+  makeParser(".let { font-size: 270%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedWord("\xE2\x80\x94");  // U+2014 em dash
+  feedSpan("let", "L");
+  ASSERT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 3u);
+
+  for (int i = 0; i < 40; ++i) feedWord("syndicat");
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  const auto& cap = lines[0]->getDropCap();
+  ASSERT_TRUE(cap.present());
+  EXPECT_EQ(cap.cp, static_cast<uint32_t>('L'));
+  // The dash leaves the flow WITH the initial and is drawn at body size beside it. Left in the
+  // text it would land to the right of the letter, since the flow starts past the column.
+  EXPECT_EQ(cap.prefixCp, 0x2014u);
+  ASSERT_FALSE(stubLineWords.empty());
+  ASSERT_FALSE(stubLineWords[0].empty());
+  EXPECT_EQ(stubLineWords[0][0], "syndicat") << "the dash should no longer be in the text flow";
+  // The column holds the mark, a gap, the magnified glyph and the gap before the text.
+  const int markAdvance = GLYPH_INK + SPACE_WIDTH;  // stub: one glyph advance per character
+  ASSERT_FALSE(stubLineXPos.empty());
+  ASSERT_FALSE(stubLineXPos[0].empty());
+  EXPECT_EQ(stubLineXPos[0][0], markAdvance + GLYPH_INK * cap.scale + SPACE_WIDTH);
+  EXPECT_EQ(cap.inkLeft, markAdvance) << "the enlarged letter should start after the mark";
+}
+
+// Mid-sentence emphasis must not blow its first letter up four lines tall. The word count alone
+// cannot tell the two apart when the span opens, so the claim is provisional: prepareDropCap
+// rejects it once it can see a LETTER sitting ahead of the initial.
+TEST_F(DropCapTest, IgnoresAnEnlargedSpanThatIsNotTheParagraphOpening) {
+  makeParser(".let { font-size: 270%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedWord("Le");
+  feedSpan("let", "S");
+
+  for (int i = 0; i < 40; ++i) feedWord("syndicat");
+  layout();
+
+  ASSERT_FALSE(lines.empty());
+  EXPECT_FALSE(lines[0]->getDropCap().present());
+  // ...and the letter stays where the author put it.
+  ASSERT_GE(stubLineWords[0].size(), 2u);
+  EXPECT_EQ(stubLineWords[0][0], "Le");
+  EXPECT_EQ(stubLineWords[0][1], "S");
+}
+
+// The sub-2x gate is the same one the pseudo-element path applies.
+TEST_F(DropCapTest, IgnoresAMildlyEnlargedOpeningSpan) {
+  makeParser(".let { font-size: 130%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedSpan("let", "L");
+  EXPECT_EQ(parser->currentTextBlock->getBlockStyle().dropCapLines, 0u);
+}
+
+// A single-size reader font (an SD-card font) has no 12/14/16/18pt ladder to snap to, so
+// cssBlockFontId can only answer "no change" and an inline font-size is silently lost. A book
+// that sets its small caps as `<small>` over literal capitals then renders them at FULL size,
+// i.e. as plain capitals. Scaling the glyph bitmap is the only way to honour it.
+TEST_F(DropCapTest, ScalesAnInlineFontSizeTheLadderCannotServe) {
+  makeParser("small { font-size: 77%; }\n");
+  parser->insideBody = true;
+  openParagraph();
+  feedWord("Le");
+
+  const XML_Char* none[] = {nullptr};
+  ChapterHtmlSlimParser::startElement(parser.get(), "small", none);
+  feedWord("ORSQUE");
+  ChapterHtmlSlimParser::endElement(parser.get(), "small");
+
+  ASSERT_GE(parser->currentTextBlock->wordFonts.size(), 2u);
+  EXPECT_EQ(parser->currentTextBlock->wordFonts[0], 0) << "an unsized word must carry no tag";
+  // 77% snaps to the nearest eighth: 3/4, which decimates a 1-bit glyph on a clean period
+  // instead of beating against the stem spacing.
+  EXPECT_EQ(parser->currentTextBlock->wordFonts[1], -192);
+  EXPECT_EQ(parser->currentTextBlock->effectiveWordScale(1), 192);
+  EXPECT_EQ(parser->currentTextBlock->effectiveWordFont(1, 7), 7) << "a scale tag is not a font id";
+
+  // The measured width has to follow the drawn size, or the next word lands inside this one.
+  layout();
+  ASSERT_FALSE(stubLineWords.empty());
+  ASSERT_GE(stubLineWords[0].size(), 2u);
+  ASSERT_GE(stubLineXPos[0].size(), 2u);
+  const int leWidth = stubLineXPos[0][1] - stubLineXPos[0][0] - SPACE_WIDTH;
+  EXPECT_EQ(leWidth, 2 * GLYPH_INK) << "the unscaled word keeps its full advance";
 }
 
 TEST_F(DropCapTest, TheLetterLeavesTheTextFlow) {

--- a/test/chapter_html_slim_parser/ParserLinkStubs.cpp
+++ b/test/chapter_html_slim_parser/ParserLinkStubs.cpp
@@ -25,11 +25,21 @@ bool computeVisualWordOrder(const std::vector<std::string>& words, bool, std::ve
 }
 }  // namespace BidiUtils
 
-TextBlock::TextBlock(const std::vector<std::string>&, const std::vector<int16_t>&,
+// The real constructor flattens the per-word arrays into an arena; this double keeps them
+// where a test can read them instead, since the arena accessors it would need belong to
+// TextBlock.cpp (which cannot be linked here -- its render() calls a GfxRenderer far richer
+// than the stub). Appended in construction order, which is the order lines are emitted.
+std::vector<std::vector<std::string>> stubLineWords;
+std::vector<std::vector<int16_t>> stubLineXPos;
+
+TextBlock::TextBlock(const std::vector<std::string>& words, const std::vector<int16_t>& wordXpos,
                      const std::vector<EpdFontFamily::Style>&, const std::vector<uint8_t>&,
                      const std::vector<uint16_t>&, const BlockStyle& blockStyle, std::vector<std::string> rubyTexts,
                      const std::vector<int32_t>&, std::vector<LinkSpan> linkSpans)
-    : blockStyle(blockStyle), rubyTexts(std::move(rubyTexts)), linkSpans(std::move(linkSpans)) {}
+    : blockStyle(blockStyle), rubyTexts(std::move(rubyTexts)), linkSpans(std::move(linkSpans)) {
+  stubLineWords.push_back(words);
+  stubLineXPos.push_back(wordXpos);
+}
 
 bool TextBlock::hasRuby() const { return false; }
 

--- a/test/chapter_html_slim_parser/stubs/GfxRenderer.h
+++ b/test/chapter_html_slim_parser/stubs/GfxRenderer.h
@@ -26,4 +26,18 @@ class GfxRenderer {
   int getSpaceAdvance(int, uint32_t, uint32_t, EpdFontFamily::Style, int8_t = 0) const { return 4; }
   bool isSdCardFont(int) const { return false; }
   void ensureSdCardFontReady(int, const std::deque<std::string>&, bool, uint8_t) const {}
+  // Square 8x8 ink box with a 1px left bearing, sitting on the baseline. Matches the 8px
+  // advance getTextAdvanceX reports per character, so a drop cap's reserved column and the
+  // words measured beside it stay consistent in the tests.
+  bool getGlyphMetrics(int, uint32_t, EpdFontFamily::Style, int* left, int* width, int* top, int* height) const {
+    if (left) *left = 1;
+    if (width) *width = 8;
+    if (top) *top = 8;
+    if (height) *height = 8;
+    return true;
+  }
+  bool drawCharUpscaled(int, uint32_t, int, int, int, bool = true, EpdFontFamily::Style = EpdFontFamily::REGULAR,
+                        int* = nullptr, int* = nullptr) const {
+    return true;
+  }
 };

--- a/test/chapter_html_slim_parser/stubs/GfxRenderer.h
+++ b/test/chapter_html_slim_parser/stubs/GfxRenderer.h
@@ -18,8 +18,12 @@ class GfxRenderer {
   int getFontAscenderSize(int) const { return 12; }
   int getSpaceWidth(int, EpdFontFamily::Style, int8_t = 0) const { return 4; }
   int getTextAdvanceX(int, const char* text, EpdFontFamily::Style, int8_t = 0) const {
+    // Per CHARACTER, not per byte: the real renderer advances once per glyph, so counting bytes
+    // would measure any non-ASCII text (an em dash, a guillemet) two or three times too wide.
     int width = 0;
-    while (*text++) width += 8;
+    for (const char* p = text; *p != '\0'; ++p) {
+      if ((static_cast<unsigned char>(*p) & 0xC0) != 0x80) width += 8;  // skip continuation bytes
+    }
     return width;
   }
   int getKerning(int, uint32_t, uint32_t, EpdFontFamily::Style) const { return 0; }

--- a/test/css_parser/CssParserTest.cpp
+++ b/test/css_parser/CssParserTest.cpp
@@ -298,4 +298,20 @@ TEST_F(CssParserTest, FirstLetterRuleSurvivesTheFilteredCacheRoundTrip) {
   EXPECT_FLOAT_EQ(size.value, 300.0f);
 }
 
+// The EBPAJ writing-mode scope ("h|"/"v|") rebuilds a subject-only selector to build its key.
+// That rebuild must carry the pseudo-element: without it the rule is stored under the PLAIN
+// scoped key, where resolveStyle's own "h|" twin lookup finds it -- so a drop cap's 300% would
+// be applied to the whole paragraph instead of its first letter.
+TEST_F(CssParserTest, ScopedFirstLetterRuleDoesNotLeakIntoTheElementCascade) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser, ".hltr p::first-letter { font-size: 300%; }\n"));
+
+  const CssStyle block = parser.resolveStyle("p", "");
+  EXPECT_FALSE(block.defined.fontSize) << "the drop cap size leaked onto the paragraph itself";
+
+  CssLength size;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "", nullptr, size));
+  EXPECT_FLOAT_EQ(size.value, 300.0f);
+}
+
 }  // namespace

--- a/test/css_parser/CssParserTest.cpp
+++ b/test/css_parser/CssParserTest.cpp
@@ -226,4 +226,76 @@ TEST_F(CssParserTest, CompoundSelectorsSurviveTheCacheRoundTrip) {
   EXPECT_TRUE(style.defined.textAlign);
 }
 
+// ::first-letter is the one pseudo-element the selector parser accepts. It has to be reachable
+// through its own lookup and INVISIBLE to the ordinary element cascade -- a drop cap's 300%
+// must never become the paragraph's own font-size.
+TEST_F(CssParserTest, FirstLetterRuleIsSeparateFromTheElementStyle) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser, "p { text-align: justify; }\np::first-letter { font-size: 300%; }\n"));
+
+  const CssStyle block = parser.resolveStyle("p", "");
+  EXPECT_TRUE(block.defined.textAlign);
+  EXPECT_FALSE(block.defined.fontSize) << "the pseudo-element rule leaked into the block cascade";
+
+  CssLength size;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "", nullptr, size));
+  EXPECT_EQ(size.unit, CssUnit::Percent);
+  EXPECT_FLOAT_EQ(size.value, 300.0f);
+
+  CssLength other;
+  EXPECT_FALSE(parser.resolveFirstLetterFontSize("div", "", nullptr, other));
+}
+
+TEST_F(CssParserTest, FirstLetterMatchesClassAndCompoundSelectors) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser,
+                      ".opener::first-letter { font-size: 3em; }\n"
+                      ".chapter p::first-letter { font-size: 4em; }\n"));
+
+  CssLength size;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "opener", nullptr, size));
+  EXPECT_FLOAT_EQ(size.value, 3.0f);
+
+  CssElementPath path;
+  path.push("div");
+  path.setTopClasses("chapter");
+  path.push("p");
+  CssLength descendant;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "", &path, descendant));
+  EXPECT_FLOAT_EQ(descendant.value, 4.0f);
+}
+
+// Everything else with a colon stays rejected, and a mid-selector spelling is not a suffix.
+TEST_F(CssParserTest, OtherPseudoSelectorsAreStillRejected) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser,
+                      "p:hover { font-size: 300%; }\n"
+                      "p::before { font-size: 300%; }\n"
+                      "p::first-letter span { font-size: 300%; }\n"
+                      "::first-letter { font-size: 300%; }\n"));
+  EXPECT_EQ(parser.ruleCount(), 0u);
+
+  CssLength size;
+  EXPECT_FALSE(parser.resolveFirstLetterFontSize("p", "", nullptr, size));
+}
+
+// A class-based first-letter rule has to survive the chapter-usage filter loadFromCache applies:
+// the pseudo hangs off the compound with no separator, so the class name is only recoverable
+// once the suffix is stripped.
+TEST_F(CssParserTest, FirstLetterRuleSurvivesTheFilteredCacheRoundTrip) {
+  {
+    CssParser writer(cachePath());
+    ASSERT_TRUE(loadCss(writer, "p.opener::first-letter { font-size: 300%; }\n"));
+    ASSERT_TRUE(writer.saveToCache());
+  }
+
+  CssParser reader(cachePath());
+  const std::vector<std::string> usedClasses = {"opener"};
+  ASSERT_TRUE(reader.loadFromCache(&usedClasses));
+
+  CssLength size;
+  ASSERT_TRUE(reader.resolveFirstLetterFontSize("p", "opener", nullptr, size));
+  EXPECT_FLOAT_EQ(size.value, 300.0f);
+}
+
 }  // namespace

--- a/test/css_parser/CssParserTest.cpp
+++ b/test/css_parser/CssParserTest.cpp
@@ -265,14 +265,54 @@ TEST_F(CssParserTest, FirstLetterMatchesClassAndCompoundSelectors) {
   EXPECT_FLOAT_EQ(descendant.value, 4.0f);
 }
 
+// CSS 2.1 spelled pseudo-elements with one colon and EPUB toolchains still emit that form, so
+// both spellings have to reach the same stored rule.
+TEST_F(CssParserTest, FirstLetterAcceptsTheCss2OneColonSpelling) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser,
+                      "p:first-letter { font-size: 300%; }\n"
+                      "p.opener:first-letter { font-size: 4em; }\n"));
+
+  const CssStyle block = parser.resolveStyle("p", "");
+  EXPECT_FALSE(block.defined.fontSize) << "the pseudo-element rule leaked into the block cascade";
+
+  CssLength size;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "", nullptr, size));
+  EXPECT_FLOAT_EQ(size.value, 300.0f);
+
+  CssLength scoped;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "opener", nullptr, scoped));
+  EXPECT_FLOAT_EQ(scoped.value, 4.0f);
+}
+
+// Both spellings normalize to ONE key, so a stylesheet using both (they routinely coexist in the
+// same file) cascades them against each other rather than stashing two unrelated rules.
+TEST_F(CssParserTest, BothFirstLetterSpellingsShareOneStoredKey) {
+  CssParser parser(cachePath());
+  ASSERT_TRUE(loadCss(parser,
+                      "p::first-letter { font-size: 300%; }\n"
+                      "p:first-letter { font-size: 4em; }\n"));
+  EXPECT_EQ(parser.ruleCount(), 1u);
+
+  CssLength size;
+  ASSERT_TRUE(parser.resolveFirstLetterFontSize("p", "", nullptr, size));
+  EXPECT_EQ(size.unit, CssUnit::Em) << "the later rule should win, as it would in a browser";
+  EXPECT_FLOAT_EQ(size.value, 4.0f);
+}
+
 // Everything else with a colon stays rejected, and a mid-selector spelling is not a suffix.
+// The bare forms need the universal selector this engine does not implement; the one-colon
+// strip must not turn `::first-letter` into a compound with a stray leading ':'.
 TEST_F(CssParserTest, OtherPseudoSelectorsAreStillRejected) {
   CssParser parser(cachePath());
   ASSERT_TRUE(loadCss(parser,
                       "p:hover { font-size: 300%; }\n"
                       "p::before { font-size: 300%; }\n"
+                      "p:first-line { font-size: 300%; }\n"
                       "p::first-letter span { font-size: 300%; }\n"
-                      "::first-letter { font-size: 300%; }\n"));
+                      "p:first-letter span { font-size: 300%; }\n"
+                      "::first-letter { font-size: 300%; }\n"
+                      ":first-letter { font-size: 300%; }\n"));
   EXPECT_EQ(parser.ruleCount(), 0u);
 
   CssLength size;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** A chapter opening styled `p::first-letter { font-size: 300% }` — the way essentially every EPUB *documents* a drop cap — currently renders as ordinary body text, because the CSS engine rejects pseudo-elements outright. This makes the reader honour it: the initial is drawn enlarged and the opening lines wrap around it.

  Hardware testing then showed that a real book may well use **none** of that, so the PR also covers the three other ways a drop cap actually reaches the page — see *Device testing* below.

* **What changes are included?**

**CSS engine.** `::first-letter` becomes the one pseudo-element `CssSelector::parse` accepts, in both its CSS 2.1 one-colon and CSS 3 two-colon spellings. It is stripped off the *end* of a selector before any compound is examined, so `:` stays in `UNSUPPORTED_CHARS` and every other pseudo (`:hover`, `::before`, `:first-line`, a mid-selector `p::first-letter span`, a bare `::first-letter`) is rejected exactly as before. Both spellings normalize to one key carrying the literal `::first-letter` suffix — no ordinary key can collide, since colons are rejected everywhere else — read back through the new `CssParser::resolveFirstLetterFontSize`. They live in a separate key space from the element cascade, so a drop cap's `300%` can never leak into the paragraph's own `font-size`.

**Two latent bugs this exposed.** `loadFromCache`'s chapter-usage filter derived a class name by taking everything after a compound's first `.`; for `.dropcap::first-letter` that tests the class `"dropcap::first-letter"`, which no chapter can ever list, so every class-based first-letter rule was silently dropped on each cache-loaded open. Separately, a *simple* selector is stored under its **raw text**, which is only the normalized key when the author happened to write two colons — so `p:first-letter` landed under a key no lookup ever spells, and did not even set `hasFirstLetterRules_`. Both fixed, with regression tests.

**Layout.** `BlockStyle` carries the line count; `ParsedText` claims the letter, picks a whole-pixel magnification against the line height, reserves the column and lays out the lines beside it. Both the narrowed width and the shifted x origin come from a single resolver (`resolveLineIndent`), so measurement and drawing cannot disagree — the DP's own first-line indent now routes through it too. Direction-aware: because the indent shrinks `effectivePageWidth`, RTL naturally reserves the column on the trailing edge.

**Rendering.** `GfxRenderer::drawCharUpscaled` block-replicates the glyph by an integer factor. No intermediate buffer (a 4× capital would need ~5 KB) and no half-lit edge pixels a resampling filter would produce, which a 1-bit panel would just dither back to hard black or white. No new font is loaded from SD.

## Device testing

Everything above was written against the pseudo-element. Flashed against a real French EPUB it produced **nothing**, and the trace explained why — the book never uses `::first-letter` at all. Three further changes came out of that, each driven by on-device evidence rather than speculation.

**1. The initial is often markup, not a pseudo-element.** The chapter opens `<p class="txt_courant_ssalinea">—&#160;<span class="let">L</span><small>ORSQUE</small>…` — `let` for *lettrine*, styled `.let { font-size: 270% }`. A paragraph opened by an enlarged single-letter span now reaches the same magnified-glyph path. Sizing that span through the font ladder cannot produce a drop cap in the first place (see 3).

The claim is **provisional in both directions**, because a word count cannot distinguish an initial from mid-sentence emphasis at the moment the span opens: it is released at the close tag unless the span held exactly one character, and rejected at layout if a *letter* sits ahead of the initial. `Le<span class="let">S</span>` therefore stays ordinary text.

**2. The initial need not be the paragraph's first token.** A French chapter opens dialogue with an em dash and a no-break space, both tokenized before the lettrine arrives. `ParsedText` carries a `dropCapWordIndex` so the letter is claimed from the right token; `::first-letter` keeps index 0 and is untouched. The punctuation ahead of it **joins the drop cap** rather than staying in the flow — left in the text the dash drew to the *right* of the letter it introduces, since the flow begins where the reserved column ends. This also matches CSS, which defines `::first-letter` as covering the punctuation preceding the letter. Guarded to a single visible mark, no letters, LTR only.

**3. An inline `font-size` the font ladder cannot serve is now honoured by scaling the glyph bitmap.** Inline sizing works by substituting a resident font from the 12/14/16/18pt ladder; a single-size reader font (an SD-card font) has no siblings, so `cssBlockFontId` can only answer "no change". This book sets its small caps as `<small>` over literal capitals and relies on `font-size: 77%` to shrink them — with no ladder, the 77% was silently inert and they rendered as plain full-size capitals.

The scale is snapped to an eighth (77% → 3/4). The resampler is nearest-neighbour, so a clean ratio drops whole pixels on a short regular period — 3/4 keeps three rows of every four — whereas an arbitrary factor beats against the stem spacing and thins strokes unevenly on a 1-bit panel.

It rides in the **existing per-word `int32_t` font slot** as a negative tag rather than in a new parallel array. That slot has always been a tagged value (`0` = block font); a value in `[-512, -32]` is a 256-based scale, guarded by `static_assert`s that none of the eleven built-in font ids can land in the range. The whole existing pipeline — arena, serialization, per-line slicing — carries it untouched: four production sites changed instead of the ~forty a parallel array would have needed, and none of the eighteen `words[]` lockstep sites in `ParsedText` had to move.

**A latent drift bug this surfaced.** `drawTextScaled` advanced the pen by `scalePositive(advance)` **per glyph**, while `getTextWidthScaled` is `scalePositive(sum)`. Those diverge by up to ~½px per glyph, so a long word draws several pixels wider than it measures. Invisible while Word Lookup was the only caller — it draws standalone strings and never measures for line breaking — but it would have put scaled words straight through their neighbours under paragraph layout. It now accumulates unscaled and scales the running total, landing exactly where `getTextWidthScaled` says.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the CSS engine documents pseudo-elements as deliberately unsupported (`CssSelector.h`), so the declaration is dropped before it reaches layout.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Why the drop cap lines are filled greedily rather than by `computeLineBreaks`' optimal DP.** `dp[i]` is keyed by the word that *starts* a line, and of the lines beside a drop cap only line 0's start is known before the solution exists — lines 1..N−1 begin wherever line 0 happened to break. Threading a line count through that DP would change the cost function every paragraph in every book goes through, to gain optimality on at most four lines of one paragraph per chapter whose width is *fixed* (unlike the paragraph tail the DP exists to balance). The hyphenated path is greedy for whole paragraphs already, so this matches shipped behaviour either way.

**Memory / flash impact.** RAM is unchanged at 17.3% (56,828 bytes) — identical to `develop`. The device-testing work above adds 1,452 bytes of flash on top of the original +4.8 KB. The `DropCap` struct adds ~300 bytes across a resident page's ~30 line blocks, plus 4 bytes per line for the opening mark's codepoint — it is per-line data, and the `TextBlock` arena is per-word, so there is nothing to hang it on there. The glyph scale adds **no** per-word storage at all (it reuses the existing font slot). No new heap allocation: the glyph is scaled straight into the framebuffer.

**Cache versions.** `section.bin` 84 → 90, CSS cache 21 → 23. Each step is recorded in `Section.cpp` and `docs/file-formats.md`. Several bumps are behavioural rather than structural, for exactly the reason v16's was: a cache written by a parser that dropped these rules would silently leave drop caps off with no way to notice. v87 in particular exists because v86 had already been built and run on a device, so a v86 section on disk was laid out by code that did not know about the span form.

**Conservative gates** — the letter simply stays inline when any fails: under 2× magnification (not a wrap, just a bigger letter); a non-letter opening character, including the non-ASCII quotes and guillemets EPUBs open dialogue with; a column wider than a third of the text width; a missing glyph; a span holding more than one character; a letter appearing ahead of the initial.

### Defects found during review and fixed here

Recording these because three of them were interactions with pre-existing machinery rather than new code, and each is a regression risk worth a reviewer's eye:

1. **Drop cap ignored the paragraph's face.** Measured and drawn with `REGULAR` regardless of the opening word's style, so an italic chapter opening got a regular initial — and the column was reserved from the wrong glyph's metrics. The face now travels on the `DropCap` payload, masked to the face bits so an underlined or superscripted word doesn't drag decorations into it.
2. **Writing-mode-scoped rules leaked into the element cascade.** `processRuleBlockWithStyle` rebuilds a subject-only selector to key the EBPAJ `.hltr`/`.vrtl` scope via aggregate init, which value-initialised the new `firstLetter` flag to false. `.hltr p::first-letter { font-size: 300% }` was therefore stored as plain `h|p` — which `resolveStyle`'s own `h|` twin lookup finds for any `<p>`, applying 300% to the **whole paragraph** on a Japanese-template book. `resolveFirstLetterFontSize` also didn't mirror that twin lookup, so scoped rules were unreachable through it. Both fixed.
3. **Right/centre alignment placed text inside the reserved column.** `extractLine`'s LTR right/centre paths derive x from `effectivePageWidth`, already reduced by the indent, so the line sat a whole indent too far left — right-aligned text started at x=12 and centred at x=6 inside a 52 px column. Reachable in practice because the reader's paragraph-alignment setting overrides the book's CSS.
4. **Unicode punctuation became drop caps.** The guard treated every non-ASCII codepoint as a letter, so `“Le` and `«Le` both produced three-line quote marks — precisely the case the guard existed for, since opening punctuation in real EPUBs is mostly non-ASCII.
5. **Flaky new tests under `ctest -j`.** The new cases shared one stylesheet path and CI runs them as concurrent processes. Each now gets its own temp directory, matching `CssParserTest`.
6. **The renderer test stub measured advance per byte, not per character.** `getTextAdvanceX` added 8px for every *byte*, while its own comment said per character — so any non-ASCII text (a 3-byte em dash) measured ~3× too wide. No existing test asserted a width on non-ASCII text, so it had gone unnoticed; the em-dash test above does.

**Areas to focus on / known trade-offs:**
- **The magnified glyph is legibly chunky at the edges** — inherent to block-replicating a bitmap font rather than loading a larger one, which was the explicit constraint. Verified on device and judged acceptable.
- **`<small>` runs now measure narrower**, so line breaks shift in any justified paragraph containing one. This is the intended fix, but it is a visible reflow.
- **At the smallest reader font size there is still no headroom**: 77% of the smallest resident size snaps back to itself on the built-in ladder. Only the single-size (SD-card font) path goes through the glyph scaler.
- The greedy prefix does **not** hyphenate, so a very long word on a narrowed line can overhang slightly; the column cap bounds how narrow those lines get.
- The RTL path (column on the trailing edge) is implemented but I could not exercise it against a real RTL book. Leading punctuation before an initial explicitly declines in RTL rather than guessing.

**Testing.** 253 host tests, all passing, and 3× clean under `ctest -j` to catch ordering flakes: pseudo-element parsing in both spellings and their isolation from the element cascade, class/compound matching, the writing-mode scope leak, other pseudos still rejected, the filtered cache round-trip, and end-to-end layout — wrap geometry, the letter leaving the text flow, the face and its decoration masking, right/centre alignment clearing the column, the sub-2× no-op, the ASCII and non-ASCII punctuation guards, the span claim and its release, the em-dash opening, and the scaled inline font size. Every review-found defect above got a test written first and confirmed failing against the old code.

**Verified on hardware** against the French book from the original report: drop cap, opening mark placement and small-caps sizing all confirmed on device.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
