### PR TITLE
fix: chapter failing to open on a fragmented heap, and unexplained section-cache rejections

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -386,8 +386,45 @@ bool Section::loadSectionFile(const ReaderRenderSpec& spec) {
         spec.hyphenationEnabled != fileHyphenationEnabled || spec.embeddedStyle != fileEmbeddedStyle ||
         spec.imageRendering != fileImageRendering || spec.focusReadingEnabled != fileFocusReadingEnabled ||
         spec.honorBookInsets != fileHonorBookInsets || spec.furiganaEnabled != fileFuriganaEnabled) {
+      // Name the field(s). A mismatch here throws the whole chapter away and rebuilds it, and on a
+      // build long enough to be SUSPENDED (which persists a partial) an unexplained rejection is
+      // indistinguishable from an infinite rebuild loop -- reported in #209 as the orientation
+      // flip "indexing" three times, with the persisted page count going 164 -> 138 -> 126 as each
+      // restart discarded work it already had. Which field disagrees is the whole diagnosis, and
+      // it cost nothing to record.
+      char why[224];
+      size_t at = 0;
+      const auto note = [&](const char* name, const long long want, const long long got) {
+        if (at + 1 >= sizeof(why)) return;
+        const int n = snprintf(why + at, sizeof(why) - at, "%s %lld!=%lld ", name, want, got);
+        if (n > 0) at += static_cast<size_t>(n) < sizeof(why) - at ? static_cast<size_t>(n) : sizeof(why) - at - 1;
+      };
+      if (spec.fontId != fileFontId) note("fontId", spec.fontId, fileFontId);
+      if (spec.lineCompression != fileLineCompression) {
+        if (at + 1 < sizeof(why)) {
+          const int n = snprintf(why + at, sizeof(why) - at, "lineCompression %.3f!=%.3f ",
+                                 static_cast<double>(spec.lineCompression), static_cast<double>(fileLineCompression));
+          if (n > 0) at += static_cast<size_t>(n) < sizeof(why) - at ? static_cast<size_t>(n) : sizeof(why) - at - 1;
+        }
+      }
+      if (spec.extraParagraphSpacing != fileExtraParagraphSpacing)
+        note("extraParagraphSpacing", spec.extraParagraphSpacing, fileExtraParagraphSpacing);
+      if (spec.paragraphAlignment != fileParagraphAlignment)
+        note("paragraphAlignment", spec.paragraphAlignment, fileParagraphAlignment);
+      if (spec.viewportWidth != fileViewportWidth) note("viewportWidth", spec.viewportWidth, fileViewportWidth);
+      if (spec.viewportHeight != fileViewportHeight) note("viewportHeight", spec.viewportHeight, fileViewportHeight);
+      if (spec.hyphenationEnabled != fileHyphenationEnabled)
+        note("hyphenation", spec.hyphenationEnabled, fileHyphenationEnabled);
+      if (spec.embeddedStyle != fileEmbeddedStyle) note("embeddedStyle", spec.embeddedStyle, fileEmbeddedStyle);
+      if (spec.imageRendering != fileImageRendering) note("imageRendering", spec.imageRendering, fileImageRendering);
+      if (spec.focusReadingEnabled != fileFocusReadingEnabled)
+        note("focusReading", spec.focusReadingEnabled, fileFocusReadingEnabled);
+      if (spec.honorBookInsets != fileHonorBookInsets)
+        note("honorBookInsets", spec.honorBookInsets, fileHonorBookInsets);
+      if (spec.furiganaEnabled != fileFuriganaEnabled) note("furigana", spec.furiganaEnabled, fileFuriganaEnabled);
+      why[at] = '\0';
       file.close();
-      LOG_ERR("SCT", "Deserialization failed: Parameters do not match");
+      LOG_ERR("SCT", "Cache rejected (%s): want!=file %s", filePartial ? "partial" : "complete", why);
       clearCache();
       return false;
     }

--- a/lib/Epub/Epub/VerticalSection.cpp
+++ b/lib/Epub/Epub/VerticalSection.cpp
@@ -1367,8 +1367,17 @@ struct LayoutPageSink final : ParagraphSink {
           GfxRenderer::FrameBufferLoan loan(renderer);
           // Prefer 16KB chunks when the framebuffer loan is available or the heap is already
           // roomy; SD write throughput is per-chunk-latency bound. 4KB remains the fallback.
-          const bool useFastChunks = canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024;
-          const size_t chunkSize = useFastChunks ? 16384 : 4096;
+          // The loan feeds InflateStream's 32KB window and state through buildscratch, but the
+          // two chunkSize buffers readItemContentsToStream allocates (file read + inflate output)
+          // are plain heap, so a loan alone does NOT make the fast path affordable. Require room
+          // for both before choosing it: on device, at maxAlloc=31732 the first 16KB buffer
+          // succeeded and the second failed, and the chapter then did not render at all --
+          // "Failed to allocate memory for output buffer" -> "Failed to stream chapter HTML" ->
+          // "Failed to build vertical section". The 4KB fallback would have loaded it fine.
+          constexpr size_t kFastChunk = 16384;
+          const bool useFastChunks = (canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024) &&
+                                     ESP.getMaxAllocHeap() >= 2 * kFastChunk + 4 * 1024;
+          const size_t chunkSize = useFastChunks ? kFastChunk : 4096;
           extracted = epub.readItemContentsToStream(resolvedSrc, cachedFile, chunkSize);
         }
         cachedFile.flush();
@@ -1482,8 +1491,12 @@ bool VerticalSection::streamParseAndLayout(HalFile& out, const int fontId, const
     {
       const bool canLendFrameBuffer = renderer.hasFrameBuffer();
       GfxRenderer::FrameBufferLoan loan(renderer);
-      const bool useFastChunks = canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024;
-      const size_t chunkSize = useFastChunks ? 16384 : PARSE_BUFFER_SIZE;
+      // Same reasoning as the image path above: the loan does not cover the two chunkSize heap
+      // buffers, so ask for them explicitly rather than inferring affordability from the loan.
+      constexpr size_t kFastChunk = 16384;
+      const bool useFastChunks = (canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024) &&
+                                 ESP.getMaxAllocHeap() >= 2 * kFastChunk + 4 * 1024;
+      const size_t chunkSize = useFastChunks ? kFastChunk : PARSE_BUFFER_SIZE;
       success = epub->readItemContentsToStream(localPath, tmpHtml, chunkSize);
     }
     tmpHtml.close();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a chapter that could fail to open entirely on a fragmented heap, and make section-cache rejections explain themselves instead of silently discarding a chapter. Both came out of investigating #209.
* **What changes are included?**

**1. Don't pick 16KB inflate chunks the heap cannot afford** (`VerticalSection.cpp`)

A chapter could refuse to render at all:

```
streamParseAndLayout start spine=6 free=67356 maxAlloc=31732
[ERR] [ZIP] Failed to allocate memory for output buffer   (x3)
[ERR] [VSC] Failed to stream chapter HTML
[ERR] [ERS] Failed to build vertical section
```

The fast path was selected from the wrong signal:

```cpp
const bool useFastChunks = canLendFrameBuffer || ESP.getMaxAllocHeap() >= 96 * 1024;
```

The framebuffer loan feeds `InflateStream`'s 32KB window and state through `buildscratch`, but the two `chunkSize` buffers `readItemContentsToStream` allocates (file read + inflate output) are ordinary heap — so a loan says nothing about whether 2 × 16KB is affordable. At `maxAlloc=31732` the first `malloc` succeeded, the second failed, and the chapter never opened. The 4KB fallback would have loaded it fine. Both sites now require room for both buffers.

**2. Say WHICH parameter rejected a section cache** (`Section.cpp`)

`Deserialization failed: Parameters do not match` discards a whole chapter and rebuilds it without saying what disagreed. When a build is long enough to be *suspended* (which persists a partial), an unexplained rejection is indistinguishable from an infinite rebuild loop. The message now names the field(s) and both values:

```
[SCT] Cache rejected (partial): want!=file viewportWidth 480!=800 ...
```

Formatting cost is paid only on the failure path.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — *N/A: touches neither; only `lib/Epub/`.*

Sits on SCOPE.md's current focus: **"Memory footprint: Reducing DRAM usage and heap fragmentation."**

## Additional Context

**Memory / flash impact:** none added. Change 1 *reduces* peak usage on a tight heap (4KB chunks instead of 16KB when 2 × 16KB will not fit). Change 2 adds a 224-byte stack buffer on the cache-rejection path only.

**Relation to #209 — please read before assuming this fixes it.** It does not, and I want to be explicit about that.

While investigating I formed and discarded three hypotheses:

* *The JP companion font flips `fontId`* — refuted for the attached logs: both are the same English-titled book (`epub_254746941`, Snow Crash) with zero `Effective font: companion` lines.
* *Orientation changes which branch `effectiveReaderFontId()` takes* — refuted by code: `useVerticalText()` returns false unless `isJapaneseBook()`, so `jpBook` reduces to the language tag and is orientation-independent.
* *The resume path corrupts or mismatches the header* — the write/read are symmetric; no defect found.

The current best explanation is **not** a cache bug at all. The reporter means portrait↔landscape, and [`FrontlightPanelActivity.cpp:161`](../blob/develop/src/activities/util/FrontlightPanelActivity.cpp#L161) cycles `(orientation + 1) % 4` — one step at a time through all four orientations. Every step changes `viewportWidth`/`viewportHeight`, so **every step legitimately invalidates the cache and rebuilds the chapter**. Portrait→landscape passes through PortraitInverted on the way, and if the hold fires the action more than once you get three rebuilds landing on a valid orientation — exactly what was reported. So those cache rejections are correct behaviour, and change 2 exists to make that visible rather than to fix it.

I could not reproduce #209 on an X4 across four attempts — no `Suspended build` ever occurred, because my builds complete in a single slice. The reporter's X3 has a tighter heap and font size 20.

**Testing.** Change 1 verified on hardware: the chapter that would not open now builds, and the three ZIP/VSC/ERS errors are gone. Change 2 verified in use — it correctly identified a rejection as legitimate (`fontId -1723365078!=1456371937 lineCompression 1.000!=0.950`) after a genuine font change, a distinction the old message could not make. Tested on X4 only; not on X3, and not in manga mode.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — written with Claude Code, driven by serial-log measurement on device; several hypotheses were tested and discarded on the evidence, as noted above.
