### PR TITLE
fix: one orientation gesture should cost one repagination, not three

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -531,6 +531,12 @@ void EpubReaderActivity::readerLoop() {
       requestUpdate();
       return;
     }
+  } else if (pendingOrientation != 0xFF) {
+    // The setting swung back to what is already applied before the window elapsed. Nothing needs
+    // reflowing, and a pending value left behind would carry its old timestamp: the next change
+    // back to that same orientation would find the settle window already "elapsed" and apply
+    // immediately, which is exactly the coalescing this is meant to provide.
+    pendingOrientation = 0xFF;
   }
 
   // A horizontal image is shown immediately in BW; refine it only after the reader

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -517,9 +517,20 @@ void EpubReaderActivity::readerLoop() {
   // center's orientation tile). Reflow before the next render, or the page
   // would be drawn with a layout built for the previous frame size.
   if (appliedOrientation != SETTINGS.orientation) {
-    applyOrientation(SETTINGS.orientation);
-    requestUpdate();
-    return;
+    // Reflow only once the setting has stopped moving. Each reflow repaginates the whole chapter,
+    // so rotating through an intermediate orientation used to cost one full rebuild per step --
+    // reported in #209 as repeated "Indexing..." for a single shortcut. Deliberately does NOT
+    // return while waiting: input must keep being handled, and the reader simply keeps drawing
+    // the old layout for the settle window.
+    if (pendingOrientation != SETTINGS.orientation) {
+      pendingOrientation = SETTINGS.orientation;
+      pendingOrientationSinceMs = millis();
+    } else if (millis() - pendingOrientationSinceMs >= kOrientationSettleMs) {
+      pendingOrientation = 0xFF;
+      applyOrientation(SETTINGS.orientation);
+      requestUpdate();
+      return;
+    }
   }
 
   // A horizontal image is shown immediately in BW; refine it only after the reader

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -541,6 +541,14 @@ class EpubReaderActivity final : public ReaderActivity {
   // the activity stack, and Pop restores it without onEnter(), so the drift has
   // to be noticed here rather than assumed away.
   uint8_t appliedOrientation = 0;
+  // Coalescing state for orientation changes. The control-centre tile steps one orientation at a
+  // time, so portrait->landscape passes through an intermediate, and reflowing per step means a
+  // full chapter repagination per step. Wait for the setting to hold still, then reflow once.
+  uint8_t pendingOrientation = 0xFF;  // 0xFF = nothing pending
+  uint32_t pendingOrientationSinceMs = 0;
+  // Comfortably longer than a multi-step gesture, and negligible against the repagination it
+  // saves (seconds to tens of seconds on a long chapter).
+  static constexpr uint32_t kOrientationSettleMs = 400;
 
   bool loadBook() override;
   bool hasBook() const override { return epub != nullptr; }

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -157,13 +157,25 @@ void FrontlightPanelActivity::runTile(const int idx) {
       renderer.promoteNextRefresh(HalDisplay::FULL_REFRESH);
       close();
       break;
-    case 2:  // Cycle the reading orientation
+    case 2: {  // Cycle the reading orientation
+      // Ignore a repeat of the same gesture. Every step here changes the reader's viewport, and
+      // the reader reflows on any change -- a full chapter repagination, seconds to tens of
+      // seconds on a long chapter. So a tile that fires three times for one hold does not just
+      // overshoot the orientation, it rebuilds the chapter three times, which is what #209
+      // reports as "flip, indexing, flip, indexing, flip, indexing" for a single shortcut.
+      const uint32_t now = millis();
+      if (lastOrientationTileMs != 0 && now - lastOrientationTileMs < kOrientationTileDebounceMs) {
+        LOG_INF("FLP", "Ignoring repeated orientation tile within %ums", now - lastOrientationTileMs);
+        break;
+      }
+      lastOrientationTileMs = now;
       SETTINGS.orientation = static_cast<uint8_t>((SETTINGS.orientation + 1) % 4);
       SETTINGS.saveToFile();
       // Only the setting changes: turning the renderer cropped the portrait-only
       // screens the panel opens over. The reader reflows on its next loop().
       requestUpdate();
       break;
+    }
     case 3:  // Touch reader controls (for reading with the palm on the glass)
       // Toggles the existing Settings -> Controls option, nothing lower-level:
       // that setting only governs the reader's tap/swipe handling, so the

--- a/src/activities/util/FrontlightPanelActivity.h
+++ b/src/activities/util/FrontlightPanelActivity.h
@@ -33,6 +33,12 @@ class FrontlightPanelActivity final : public Activity, private UiAppHost {
   // remembered mode, so a Swipe or Inverted Tap user gets their mode back
   // rather than the Tap default. Seeded from the setting in onEnter().
   uint8_t touchModeRestore = CrossPointSettings::TOUCH_READER_ON;
+  // When the orientation tile last fired. Each activation costs the reader a full chapter
+  // repagination, so a repeated event must not be taken as a repeated intent -- see runTile().
+  uint32_t lastOrientationTileMs = 0;
+  // A deliberate second rotation is seconds apart; a repeat from one gesture is tens of
+  // milliseconds. Well clear of both.
+  static constexpr uint32_t kOrientationTileDebounceMs = 750;
   int panelBottom = 0;
 
   // Quick-setting tiles, in grid order (2 columns): night mode, refresh,


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make one orientation gesture cost one chapter repagination instead of two or three. Partially addresses #209.
* **What changes are included?** Two independent causes, both in the rotation path:

**1. Reflow coalescing** (`EpubReaderActivity`)

The control-centre tile steps **one** orientation per activation (`(orientation + 1) % 4`), and `readerLoop()` reflows on any change to `SETTINGS.orientation`. So portrait → landscape passes through PortraitInverted and cost **two** full rebuilds even for a single clean press — 7–25s each on a long chapter.

It now waits for the setting to hold still (400ms) and reflows once to wherever it landed. Deliberately it does *not* return while waiting: input keeps being handled and the old layout stays on screen for the settle window.

**2. Tile debounce** (`FrontlightPanelActivity`)

The orientation tile ignores a repeat within 750ms. A deliberate second rotation is seconds apart; a repeat from one hold is tens of milliseconds.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — *N/A: touches neither; only `src/activities/`.*

## Additional Context

**Memory / flash impact:** negligible — three small members (a `uint8_t` and two `uint32_t`) and two constants.

**What is verified, and what is not.** Change 1 is device-verified: a portrait→landscape rotation now produces exactly one `Cache not found, building...`. The section-cache rejection that precedes it names a genuine viewport change:

```
[SCT] Cache rejected (partial): want!=file viewportWidth 778!=464 viewportHeight 450!=764
```

so the rejection is **correct** — it was the *count* of rebuilds that was wrong, not the cache logic. (That diagnostic line comes from #212.)

Change 2 is **not verified**. The triple-fire could not be reproduced on an X4 across several attempts — no `Suspended build` ever occurred there, because builds complete in a single slice. The debounce therefore addresses the mechanism as the reporter describes it rather than one observed here; it is inert when no repeat occurs.

**This does not fully close #209.** Two parts of that report remain:

* **The rotation is still slow.** One rotation legitimately invalidates the section cache (the viewport really did change) and rebuilds the chapter — 7–25s on a long chapter, worse on X3 at font size 20. This PR removes the *duplicate* rebuilds; it does not make a single rebuild fast. That is the underlying heap-fragmentation problem (`maxAlloc` collapsing to ~3–6KB mid-build), which is separate work.
* **The "Indexing…" indicator disappears while the device is still busy**, which the reporter explicitly asked about. Not addressed here.

**Testing.** X4 only, vertical Japanese EPUB and a horizontal chapter. Not tested on X3 or x4pro, which is where the triple-fire was reported.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — written with Claude Code, driven by device serial logs; the change-1 behaviour was measured before and after, change 2 is reasoned from the report.
