### PR TITLE
perf: don't build a per-line ruby vector for ruby-less blocks

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -1603,8 +1603,14 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   const int firstLineIndent = resolveLineIndent(breakIndex, renderer, fontId);
 
-  std::vector<std::string> lineRubyTexts(lineWordCount);
+  // Sized only when this block actually carries ruby. TextBlock's constructor discards an
+  // all-empty rubyTexts anyway (see the invariant there), so building one per line for a
+  // ruby-less block allocates a vector and default-constructs lineWordCount strings, has
+  // hasRuby() scan all of them to prove they are empty, and frees them again -- for every line
+  // of every paragraph. Every read of it is already bounds-checked, here and in TextBlock.
+  std::vector<std::string> lineRubyTexts;
   if (!rubyTexts.empty() && lastBreakAt < rubyTexts.size()) {
+    lineRubyTexts.resize(lineWordCount);
     const size_t copyCount = std::min(lineBreak, rubyTexts.size()) - lastBreakAt;
     std::copy(rubyTexts.begin() + lastBreakAt, rubyTexts.begin() + lastBreakAt + copyCount, lineRubyTexts.begin());
   }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Remove a per-line heap allocation on the chapter-build path that does nothing for the overwhelming majority of lines.
* **What changes are included?** One change in `ParsedText::extractLine()`: `lineRubyTexts` is only sized when the block actually carries ruby.

`extractLine()` sized `lineRubyTexts` to the line's word count unconditionally. For a block with no ruby — every line of most books — that allocates a vector, default-constructs one `std::string` per word, has `TextBlock`'s `hasRuby()` scan all of them to prove they are empty, then frees them again. Once per line, per paragraph, per chapter build.

`TextBlock`'s constructor already discards an all-empty `rubyTexts` (its documented invariant), so the vector was never reaching the page in this case. Every read of it is already bounds-checked, here and in `TextBlock`, so leaving it empty is safe.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **No performance number is claimed.** An earlier measurement suggesting ~25% was taken across a CPU-throttle boundary (see #214) and was not controlled, so it is withdrawn. This stands on the mechanism alone: it removes an allocation plus N string constructions per line, and it cannot make anything slower.
* Reviewers should focus on the ruby-carrying path: books **with** furigana must be unaffected. The `resize(lineWordCount)` moved inside the existing `!rubyTexts.empty() && lastBreakAt < rubyTexts.size()` guard, which is the same condition that previously guarded the copy into it — so any line that used to receive ruby data still gets a correctly sized vector first.
* Memory / flash impact: strictly less heap churn during builds; no flash change of note.
* Not separately verified on hardware yet.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
