### PR TITLE
perf: bound the background build tick with a time budget

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -712,7 +712,7 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   return true;
 }
 
-bool Section::buildSomeMore(const int maxPages) {
+bool Section::buildSomeMore(const int maxPages, const uint32_t maxMillis) {
   if (!build_ || !build_->parser) {
     LOG_ERR("SCT", "buildSomeMore with no active build");
     return false;
@@ -721,6 +721,7 @@ bool Section::buildSomeMore(const int maxPages) {
   // pageCount stays pinned at the partial's watermark until the build passes it, which
   // would otherwise turn one "small" chunk into a blocking rebuild of the whole watermark.
   const int startCount = builtPageCount_;
+  const uint32_t startMs = millis();
   for (;;) {
     const auto status = build_->parser->parseStep();
     if (status == ChapterHtmlSlimParser::ParseStatus::Error) {
@@ -741,8 +742,15 @@ bool Section::buildSomeMore(const int maxPages) {
     if (status == ChapterHtmlSlimParser::ParseStatus::Done) {
       return finalizeBuild();
     }
-    // ParseStatus::More: yield once we've laid out the requested number of pages.
+    // ParseStatus::More: yield once we've laid out the requested number of pages, or once the
+    // caller's time budget is spent -- whichever comes first. One parse step is the floor: a
+    // single slow page still runs to completion, so this bounds the tick at roughly one page
+    // rather than the full maxPages worth.
     if (maxPages > 0 && (builtPageCount_ - startCount) >= maxPages) {
+      build_->bytesConsumed = build_->parser->parseBytesConsumed();
+      return true;
+    }
+    if (maxMillis > 0 && millis() - startMs >= maxMillis) {
       build_->bytesConsumed = build_->parser->parseBytesConsumed();
       return true;
     }

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -115,7 +115,17 @@ class Section {
   bool startBuild(const ReaderRenderSpec& spec, const std::function<void()>& popupFn = nullptr);
   // Lay out up to maxPages more pages (maxPages <= 0 = build to completion). Returns
   // false on error (the build is abandoned). Sets isBuildComplete() when finished.
-  bool buildSomeMore(int maxPages);
+  //
+  // maxMillis (0 = no limit) additionally ends the call once that much wall time has passed,
+  // checked between parse steps. Background ticks run on the loop task, so whatever one call
+  // costs is exactly how long input handling is delayed; pacing on pages alone bounds that only
+  // as well as pages happen to be uniform, and they are not. The build keeps its state and
+  // resumes next tick, so this is a yield, not a cancellation.
+  //
+  // Deliberately a clock, not an input check: reading the buttons from in here means calling
+  // InputManager::getState(), which runs the touch state machine as a side effect and consumes
+  // the very edge events the loop task is waiting to handle.
+  bool buildSomeMore(int maxPages, uint32_t maxMillis = 0);
   bool isBuilding() const { return static_cast<bool>(build_); }
   bool isBuildComplete() const { return buildComplete_; }
   // Best-known total page count: the exact pageCount once finalized, or a smoothed byte-based

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -647,7 +647,7 @@ void EpubReaderActivity::readerLoop() {
     // always true.
     // cppcheck-suppress knownConditionTrueFalse
     if (section->isBuilding() && buildTickHeapGate()) {
-      if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
+      if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK, BACKGROUND_BUILD_BUDGET_MS)) {
         LOG_ERR("ERS", "Background section build failed");
         section.reset();
         requestUpdate();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -346,6 +346,10 @@ class EpubReaderActivity final : public ReaderActivity {
   // background build chunk never noticeably delays input or a pending render.
   static constexpr int BUILD_PAGES_PER_CHUNK = 8;
   static constexpr int BACKGROUND_BUILD_PAGES_PER_TICK = 2;
+  // Wall-clock cap on one background build tick. The tick runs on the loop task, so this is
+  // also the delay it can add to handling a button press. Pages are not uniform (median ~23ms,
+  // p90 ~79ms measured on device), so the page count alone does not bound it.
+  static constexpr uint32_t BACKGROUND_BUILD_BUDGET_MS = 30;
 
   // MEMFIX-PORT: background-build heap floor; portable
   // Skip background build ticks below this free-heap floor. The parse path grows


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the reader stay responsive while a horizontal chapter indexes in the background — the ask in #176 ("cancellable lazy indexing for horizontal books, so the device reacts immediately after a button click").
* **What changes are included?** `Section::buildSomeMore()` takes an optional wall-clock budget, checked between parse steps; the reader's background tick passes 30 ms.

### Why a clock and not an input check

The background build ticks on the loop task, so whatever one `buildSomeMore()` call costs *is* how long a button press waits. Pacing on a page count bounds that only as well as pages are uniform, and they are not — measured on device, page layout is ~29 ms median, ~119 ms p90, and over 1s at the tail. A two-page tick was anywhere from 50 ms to seconds.

I first tried the obvious thing — poll the buttons from inside the build and yield on a press, mirroring `VerticalSection`'s cancel hook. **That broke input completely on device.** `mappedInput.anyButtonDownRaw()` reaches `InputManager::getState()`, which calls `serviceTouch()` — it polls the touch controller over I2C *and mutates the input state machine* (`touchPressed`, `touchReleasedEvent`, `touchSuppressed`, long-press and multi-touch state). Called once per parse step, it raised and consumed edge events before `update()` could ever see them, so the reader stopped reacting to presses at all. The header comment records this so the trap is not walked into again.

A clock measures the thing we actually care about and touches nothing shared.

### Safety

* **Yield, not cancel.** The build keeps its state and resumes on the next tick; nothing laid out is discarded, so no partial result is persisted.
* **Opt-in per call.** The three catch-up loops that spin until a target page exists pass no budget. They must not yield — with the earlier input-polling design a *held* button would have livelocked them (yield, re-enter, yield again). With a budget they simply never yield.

## Measured on device

User actions taken while a chapter was indexing:

| observation | result |
|---|---|
| page laid out -> reader menu entered | **19 ms** |
| page turns mid-build | served, rendered normally |
| builds still complete | yes — 53 and 55 pages, no errors |
| ticks exceeding 2x budget | none (temporary diagnostic, since removed) |

Page-to-page gaps *rise* in the logs (median 17 -> 29 ms), which is the intended trade and not a regression: the large gaps now contain renders and menu activity interleaved into the build, i.e. the work the reader yielded to.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Relationship to #214:** that PR did most of the work for #176 on its own — it stopped the CPU being throttled to 10 MHz mid-build, which took the two-page tick from ~330 ms to ~46 ms. This PR handles the remaining tail. Worth reviewing #214 first; this is the smaller half.
* **Known limit:** one parse step is the floor. A single slow page still runs to completion, so the budget bounds a tick at roughly one page, not less. Going below that means interrupting inside page layout, which is out of scope here.
* 30 ms is a starting value, not a tuned one — it is above the median page cost so typical ticks still lay out a page, and it caps the two-slow-pages case. Happy to change it.
* Memory / flash impact: none of note — one `uint32_t` parameter and a `millis()` comparison per parse step.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
