### PR TITLE
fix: stop the section-file probes logging a missing cache as an error

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -1072,9 +1072,21 @@ std::unique_ptr<Page> Section::loadPageDuringBuild(const int page) {
 // Read a page from the committed file at filePath (finalized section or partial from a
 // previous session). Uses a local handle so it is safe while a build holds the member
 // `file` open on the tmp .bin.
+// Open the committed section file for one of the read-only probes below.
+//
+// A missing file is the NORMAL case for these, not an error: the chapter may never have been
+// built, or its build may still be running with nothing committed yet. SDCardManager's
+// openFileForRead prints unconditionally on failure (raw Serial, so it is not even filtered by
+// the log level), which turned every such probe into console noise. Check first and stay quiet,
+// exactly as loadSectionFile() already does for the same reason.
+bool Section::openCommittedFile(HalFile& f) const {
+  if (!Storage.exists(filePath.c_str())) return false;
+  return Storage.openFileForRead("SCT", filePath, f);
+}
+
 std::unique_ptr<Page> Section::loadPageAt(const int page) const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return nullptr;
   }
 
@@ -1145,7 +1157,7 @@ std::string Section::getTextFromSectionFile() {
 
 std::optional<uint16_t> Section::getCachedPageCount() const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return std::nullopt;
   }
 
@@ -1171,7 +1183,7 @@ std::optional<uint16_t> Section::getCachedPageCount() const {
 
 std::optional<uint16_t> Section::getPageForAnchor(const std::string& anchor) const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return std::nullopt;
   }
 
@@ -1201,7 +1213,7 @@ std::optional<uint16_t> Section::getPageForAnchor(const std::string& anchor) con
 
 std::optional<uint16_t> Section::getPageForParagraphIndex(const uint16_t pIndex) const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return std::nullopt;
   }
 
@@ -1240,7 +1252,7 @@ std::optional<uint16_t> Section::getPageForParagraphIndex(const uint16_t pIndex)
 
 std::optional<uint16_t> Section::getParagraphIndexForPage(const uint16_t page) const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return std::nullopt;
   }
 
@@ -1272,7 +1284,7 @@ std::optional<uint16_t> Section::getParagraphIndexForPage(const uint16_t page) c
 
 std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex) const {
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) {
+  if (!openCommittedFile(f)) {
     return std::nullopt;
   }
 
@@ -1321,7 +1333,7 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
 bool Section::loadSectionFootnotes(std::vector<std::pair<uint16_t, FootnoteEntry>>& out) {
   out.clear();
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f)) return false;
+  if (!openCommittedFile(f)) return false;
   const size_t fileSize = f.size();
   if (fileSize < sizeof(uint32_t)) return false;
   f.seek(fileSize - sizeof(uint32_t));
@@ -1355,7 +1367,7 @@ std::optional<uint32_t> Section::getVisibleTextOffsetForPage(const uint16_t page
   }
 
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f) || f.size() < HEADER_SIZE) {
+  if (!openCommittedFile(f) || f.size() < HEADER_SIZE) {
     return std::nullopt;
   }
 
@@ -1411,7 +1423,7 @@ std::optional<uint16_t> Section::getPageForVisibleTextOffset(const uint32_t offs
   }
 
   HalFile f;
-  if (!Storage.openFileForRead("SCT", filePath, f) || f.size() < HEADER_SIZE) {
+  if (!openCommittedFile(f) || f.size() < HEADER_SIZE) {
     return std::nullopt;
   }
 

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -64,6 +64,10 @@ class Section {
     // BuildContext ties it to exactly the span that must stay at full speed.
     HalPowerManager::Lock powerLock;
   };
+  // Opens the committed section file for the read-only probes, quietly when it is absent.
+  // See the definition: a missing file is expected there, and the SDK logs unconditionally.
+  bool openCommittedFile(HalFile& f) const;
+
   std::unique_ptr<BuildContext> build_;
   bool buildComplete_ = false;
   // Pages laid out by the active build (== build_->lut.size()). Distinct from pageCount,


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop a bare `[SCT] Failed to open file for reading: /.crosspoint/.../sections/N.bin` appearing several times per session during entirely normal operation.
* **What changes are included?** A private `Section::openCommittedFile()` that checks `Storage.exists()` before opening, with the nine read-only probes routed through it.

### It is not an error

Nine probes on `Section` open the committed section file and tolerate its absence: `loadPageAt`, `getCachedPageCount`, `getPageForAnchor`, `getPageForParagraphIndex`, `getParagraphIndexForPage`, `getPageForListItemIndex`, `loadSectionFootnotes`, `getVisibleTextOffsetForPage`, `getPageForVisibleTextOffset`. A missing file is the *normal* case for every one of them — the chapter may never have been built, or its build may still be running with nothing committed yet. All nine already handled it by returning `false`/`nullopt`.

The message comes from `SDCardManager::openFileForRead`, which prints on every failed open through raw `Serial` — not `LOG_ERR`, which is why it carries no level tag and is not filtered by the log level.

### The fix was already in the file

`loadSectionFile()` guards its own open with `Storage.exists()` and says why:

> Missing cache file is the normal case for unbuilt chapters (the book-progress counter probes every spine per page turn) — check silently instead of logging per probe.

The other nine never got the same treatment. Rather than nine copies of that guard, this adds one helper carrying one explanation. `loadSectionFile` keeps its existing guard untouched — it works, and rewriting it buys nothing.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Verified on device.** The line is gone (0 occurrences over a session that previously produced 3–8), and the features these probes back still work: progress saves keep `offsetKnown=1` with correctly advancing offsets (0 → 268 → 609 → 966 → 1321 across pages 0–4), page counts deserialize, chapter footnotes resolve. Those are the checks that would have caught a helper that wrongly refused to open a file that *does* exist.
* **What is lost:** if a section file goes missing for a real reason, we now learn it from behaviour rather than that line. I think that is the right trade — the line fired constantly in normal operation, so it carried no signal, and each of these call sites already treated absence as expected.
* **Cost:** one directory lookup on paths that already do file I/O.
* An alternative would be a quiet variant of `openFileForRead`, but the print lives in `SDCardManager`, and `freeink-sdk/` changes need maintainer coordination for a cosmetic fix. This stays entirely on our side.
* Memory / flash impact: none of note.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
