### PR TITLE
fix: never claim a second font page slot for the same font

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -370,6 +370,20 @@ int32_t FontDecompressor::findGlyphIndex(const EpdFontData* fontData, uint32_t c
 int FontDecompressor::prewarmCache(const EpdFontData* fontData, const char* utf8Text) {
   if (!fontData || !fontData->groups || !utf8Text) return 0;
 
+  // One slot per font, enforced here: getBitmap() consults only the FIRST slot whose fontData
+  // matches and stops there ("don't check other slots"), so a second slot for the same font is
+  // never read -- its decompressed glyphs are dead memory, and it costs a slot that a DIFFERENT
+  // font then cannot have. That is the whole failure mode this guard removes: measured on device,
+  // one screen claimed six slots for four distinct fonts (a font reached through two ids, plus a
+  // fallback family shared by two others) and the last two fonts were refused.
+  //
+  // Returning here leaves any glyph this call needed but the existing slot lacks to the
+  // hot-group path -- exactly where a second slot would have left it anyway, since it could
+  // never be read.
+  for (uint8_t i = 0; i < pageSlotCount; i++) {
+    if (pageSlots[i].fontData == fontData && pageSlots[i].glyphCount > 0) return 0;
+  }
+
   // Allocate the next available slot (caller must call freePageBuffer/clearCache to reset)
   if (pageSlotCount >= MAX_PAGE_SLOTS) {
     LOG_ERR("FDC", "All %u page buffer slots full, cannot prewarm fontData=%p", MAX_PAGE_SLOTS, (void*)fontData);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Remove the recurring `[FDC] All 4 page buffer slots full, cannot prewarm` errors, and with them the per-page glyph cost they were reporting.
* **What changes are included?** One guard in `FontDecompressor::prewarmCache()`: do not claim a slot when one already exists for this `fontData`.

### A duplicate slot is never read

`getBitmap()` walks the page slots, and on the first slot whose `fontData` matches it either returns the glyph or gives up:

```cpp
break;  // Found the right slot but glyph wasn't in it; don't check other slots
```

So a second slot for the same font is **unreachable**. Everything it decompresses is dead memory, and it occupies one of only four slots that a genuinely different font then cannot have.

### Measured on device

Instrumenting every slot claim showed one screen making **six claims for four distinct fonts**:

| claim | fontData | |
|---|---|---|
| #0 | `0x3c371984` | new |
| #1 | `0x3c371984` | **duplicate of slot 0** — same font reached through a second font id |
| #2 | `0x3c42c9ac` | new |
| #3 | `0x3c309c68` | new (shared fallback) |
| #4 | `0x3c3f3664` | **refused — pool full** |
| #4 | `0x3c309c68` | **duplicate of slot 3, refused** — the same shared fallback again |

Two slots held data that could never be looked up, and two real fonts were turned away. The pool was exactly the right size all along.

Two hypotheses this ruled out, for reviewers who would reach for them first: every requested `styleMask` was single-style (`0x01`/`0x02`), so nothing was warming unused styles; and slots were being released normally between screens, so these were not stale.

### Why it is worth fixing rather than quietening

A refused font is not free — it falls back to the per-glyph on-demand loader, which [EpubReaderActivity.cpp:1899](../blob/develop/src/activities/reader/EpubReaderActivity.cpp) puts at 40–74 SD loads per page at ~7 ms each. Downgrading the log would have hidden a real cost.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **The check that matters, and it passes.** If those duplicate slots had actually been reachable, suppressing them would push their glyphs onto the on-demand path and show up immediately in `bw_render`. It did not move: **54 ms after, against 53–58 ms across three runs before.** That is the evidence the slots were dead rather than merely redundant.
* Total render median also fell (956 -> 697 ms) but I am **not** claiming that — grayscale refinement varies with content, and an earlier run was already at 760 ms before this change. Confounded.
* **Behaviour when a font legitimately needs more glyphs than its existing slot holds:** they go to the hot-group path — exactly where a second slot would have left them, since it could never be read. So this is strictly better, not a trade.
* Memory / flash impact: strictly less heap used during prewarm; no flash change of note.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
