### PR TITLE
perf: drop the placeholder pass before a cold image decode

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3259,7 +3259,6 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
 
   const bool pageHasImages = page->hasImages();
   shownPageHasImages_ = pageHasImages;
-  const bool pageHasImagesNeedingDecode = pageHasImages && page->hasImagesNeedingDecode();
   const bool manualRefreshPending = !grayscaleRefineOnly && forcedRefreshPending;
   if (!grayscaleRefineOnly) forcedRefreshPending = false;
   // The reader starts with zero here, which means the normal refresh cycle
@@ -3298,13 +3297,13 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     }
   };
 
-  if (!grayscaleRefineOnly && pageHasImagesNeedingDecode) {
-    page->renderWithImagePlaceholders(renderer, fontId, orientedMarginLeft, orientedMarginTop);
-    renderStatusBar();
-    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
-    renderer.clearScreen();
-  }
-
+  // No placeholder pass before this. A cold image cache used to paint placeholder rectangles and
+  // spend a whole FAST refresh (~500ms) showing them, then decode, then refresh again -- two
+  // visible stages and an extra panel cycle for a page the reader only ever wanted once. E-ink
+  // holds the PREVIOUS page for free while the decode runs, so the turn now costs one refresh and
+  // shows one picture. Measured on device: a 464x709 first visit was 2463ms total with 1708ms of
+  // that the decode itself; a warm .pxc is 33ms of render inside a 605ms panel-bound turn, so the
+  // cold path is the only one that ever showed placeholders.
   auto tBwRender = tPrewarm;
   auto tDisplay = tBwRender;
   if (!grayscaleRefineOnly) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -3297,13 +3297,9 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     }
   };
 
-  // No placeholder pass before this. A cold image cache used to paint placeholder rectangles and
-  // spend a whole FAST refresh (~500ms) showing them, then decode, then refresh again -- two
-  // visible stages and an extra panel cycle for a page the reader only ever wanted once. E-ink
-  // holds the PREVIOUS page for free while the decode runs, so the turn now costs one refresh and
-  // shows one picture. Measured on device: a 464x709 first visit was 2463ms total with 1708ms of
-  // that the decode itself; a warm .pxc is 33ms of render inside a 605ms panel-bound turn, so the
-  // cold path is the only one that ever showed placeholders.
+  // Skip the placeholder pre-pass on cold image pages: it caused a visible two-stage update
+  // (placeholder boxes, then the real image) and an extra panel cycle.
+  // Instead, keep the previous page displayed while decoding and do a single refresh to the final image.
   auto tBwRender = tPrewarm;
   auto tDisplay = tBwRender;
   if (!grayscaleRefineOnly) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make a first visit to an image page show one finished picture instead of placeholder boxes followed by the real image. Part of #181.
* **What changes are included?** Removal of the placeholder pre-pass on the cold-cache path in `EpubReaderActivity::renderPage()`.

A page whose images were not yet cached painted placeholder rectangles, spent a whole FAST refresh (~500 ms) *showing* them, then decoded and refreshed again — two visible stages and an extra panel cycle for a single picture. E-ink holds the previous page for free while the decode runs, so the turn now costs one refresh and shows one finished image.

This is what the vertical path already does on purpose: *"No blank-white intermediate pass: it read as a distracting flash on full-page images."*

## Measured on device

Horizontal image pages, from a serial capture of a picture-heavy book:

| case | prewarm | bw_render | display | total |
|---|---|---|---|---|
| cold cache, 464x709 | 187 ms | **1708 ms** | 568 ms | 2463 ms |
| cold cache, 211x77 | 10 ms | 771 ms | 571 ms | 1352 ms |
| warm `.pxc` | 0 ms | **33 ms** | 572 ms | 605 ms |

Two things follow. The placeholder pass only ever fired on the cold path — and a warm page is already panel-bound, 33 ms of work inside a 605 ms turn, with nothing left to win in the render path at all.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **The trade is deliberate and worth reviewing.** During a long decode the reader now sees the PREVIOUS page rather than placeholders — on a ~1.7 s decode that is a stretch where a button press appears to do nothing. The alternative was the two-stage flicker this removes. Reverting is a one-line change if the silence turns out to read worse than the placeholders did.
* **This does not address the decode itself**, which is the bulk of a cold visit. The log shows `jpegScale 1/1, fineScale 0.97` — the JPEG is already decoded at its smallest useful DCT scale (480x731 into 464x707), so there is no cheap scaling win there. The remaining lever is the background warm, tracked separately.
* `Page::renderWithImagePlaceholders()` and `Page::hasImagesNeedingDecode()` lose their only callers. I left them in place rather than deleting them: they are upstream `Page` API and removing them invites conflicts on the next upstream merge. Happy to delete them if maintainers would rather not carry dead API.
* Memory / flash impact: strictly less work per cold image page; no new allocations.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
