### PR TITLE
fix: stop a bordered block's closing edge cutting through its last line

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,13 +90,22 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 90 (fork numbering)
+### Version 91 (fork numbering)
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
-Version 90 keeps the version 89 framing unchanged. An inline `font-size`
+Version 91 keeps the version 90 framing unchanged. Only the geometry stored in
+`PageBox` changes: a bordered block's closing edge is no longer allowed above
+the bottom of the last line inside it. The edge is still pulled up toward the
+text to absorb trailing block spacing, but a block carrying little or none used
+to have that pull-up land inside the final line's glyphs, drawing the border
+through the text. Because the box height is computed at build time and stored,
+existing caches keep the old geometry and must be rebuilt — hence the version
+bump rather than a pure code fix.
+
+Version 90 kept the version 89 framing unchanged. An inline `font-size`
 that the built-in font ladder cannot serve — a single-size SD-card reader font
 has no 12/14/16/18pt siblings to snap to — is now honoured by scaling the
 glyph bitmap instead of being dropped, at a scale snapped to an eighth. The

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -239,7 +239,7 @@ namespace {
 //      eighth. `<small>` runs that used to render at body size are narrower, so every line
 //      holding one breaks and positions differently. The per-word font slot carries the scale as
 //      a negative tag, so the framing is unchanged.
-constexpr uint8_t SECTION_FILE_VERSION = 90;
+constexpr uint8_t SECTION_FILE_VERSION = 91;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -239,6 +239,10 @@ namespace {
 //      eighth. `<small>` runs that used to render at body size are narrower, so every line
 //      holding one breaks and positions differently. The per-word font slot carries the scale as
 //      a negative tag, so the framing is unchanged.
+// v91: a bordered block's closing edge is no longer pulled up past the bottom of the last line
+//      inside it, so a block with little or no trailing spacing gets a slightly taller box.
+//      PageBox height is computed at layout time and stored, so cached geometry must be rebuilt.
+//      The framing is unchanged.
 constexpr uint8_t SECTION_FILE_VERSION = 91;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -805,6 +805,9 @@ void ChapterHtmlSlimParser::emitBoxRect(const bool openBottom) {
 
 void ChapterHtmlSlimParser::maybeEmitOpenBoxForPageBreak() {
   if (boxDepth < 0) return;
+  // Nothing of the box is on this page yet, so no open-bottomed rect is emitted -- and it must not
+  // be marked continued either, or the first page that does hold it would omit its top edge.
+  if (boxAwaitingFirstLine) return;
   emitBoxRect(/*openBottom=*/true);
   boxContinued = true;
   // The continuation starts at y = 0 on the next page, so the floor from this page's last line

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -743,11 +743,17 @@ void ChapterHtmlSlimParser::emitBoxRect(const bool openBottom) {
   // Closing edge: currentPageNextY at close already includes the last block's bottom spacing
   // (margin/padding + extra paragraph spacing), so the line must be pulled back UP toward the
   // text ink rather than padded further down (device feedback, three rounds).
+  //
+  // ...but never above the bottom of the last line inside the box. That pull-up assumes there IS
+  // trailing spacing to eat into; a block with little or none has currentPageNextY sitting right
+  // at the last line's bottom, and a third of a line above that lands inside its glyphs -- the
+  // closing border drew THROUGH the final line of text, striking it out (reported on a German
+  // EPUB whose bordered blocks carry no bottom margin).
   const int lineHeight2 = static_cast<int>(renderer.getLineHeight(fontId) * lineCompression);
+  const int pulledUp = std::max<int>(boxLastLineBottomY, currentPageNextY - lineHeight2 / 3);
   const auto yBottom = openBottom
                            ? static_cast<int16_t>(viewportHeight - 1)
-                           : static_cast<int16_t>(std::min<int>(
-                                 viewportHeight - 1, std::max<int>(yTop + 1, currentPageNextY - lineHeight2 / 3)));
+                           : static_cast<int16_t>(std::min<int>(viewportHeight - 1, std::max<int>(yTop + 1, pulledUp)));
   if (yBottom <= yTop) return;
   uint8_t edges = CssStyle::edgeMaskOf(boxBorderSpec);
   if (boxContinued) edges &= static_cast<uint8_t>(~CssStyle::BORDER_TOP);
@@ -801,6 +807,9 @@ void ChapterHtmlSlimParser::maybeEmitOpenBoxForPageBreak() {
   if (boxDepth < 0) return;
   emitBoxRect(/*openBottom=*/true);
   boxContinued = true;
+  // The continuation starts at y = 0 on the next page, so the floor from this page's last line
+  // would sit far below anything drawn there and push the closing edge to the wrong place.
+  boxLastLineBottomY = 0;
 }
 
 void ChapterHtmlSlimParser::closeBoxBlock() {
@@ -830,6 +839,7 @@ void ChapterHtmlSlimParser::closeBoxBlock() {
   boxShrinkToContent = false;
   boxContinued = false;
   boxAwaitingFirstLine = false;
+  boxLastLineBottomY = 0;
 }
 
 void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
@@ -2038,6 +2048,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->boxBorderSpec = cssStyle.borderEdges;
     self->boxContinued = false;
     self->boxAwaitingFirstLine = true;
+    self->boxLastLineBottomY = 0;
     self->boxShrinkToContent = cssStyle.display == CssDisplay::InlineBlock;
     self->boxFirstElementIndex = self->currentPage ? self->currentPage->elements.size() : 0;
     // Adjacent CSS vertical margins collapse. For an empty worksheet paragraph, advancing by the
@@ -3111,6 +3122,8 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const
   }
   currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
   currentPageNextY += lineHeight;
+  // Floor for the box's closing edge: it may be pulled up into trailing spacing, never into text.
+  if (boxDepth >= 0) boxLastLineBottomY = currentPageNextY;
 }
 
 void ChapterHtmlSlimParser::makePages() {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -65,6 +65,9 @@ class ChapterHtmlSlimParser {
   bool boxShrinkToContent = false;
   bool boxContinued = false;          // continued from the previous page: omit the top edge
   bool boxAwaitingFirstLine = false;  // capture boxStartY from the first line the box lays out
+  // Bottom of the last line placed inside the open box. emitBoxRect() pulls its closing edge up
+  // toward the text, and this is the floor it must not cross -- see the comment there.
+  int16_t boxLastLineBottomY = 0;
   // Inverted-block panel tracking (CSS color/background-color, see CssInkMode). Each line of an
   // inverted block gets a filled PageBox pushed just before it, so the panel survives a page break
   // and needs no knowledge of the block's total height. Only the block's own padding needs


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop a bordered block's bottom border being drawn through the last line of text inside it.
* **What changes are included?** A floor on the closing edge in `ChapterHtmlSlimParser::emitBoxRect()`, its resets, and the `section.bin` version bump the stored geometry requires.

### The bug

`emitBoxRect()` pulls the closing edge up by a third of a line:

```cpp
yBottom = std::max(yTop + 1, currentPageNextY - lineHeight2 / 3);
```

with good reason — `currentPageNextY` at close already carries the block's trailing margin/padding, so without the pull-up the border floats well below the text (the comment there records three rounds of device feedback).

It assumes there **is** trailing spacing to absorb. A bordered block carrying little or none leaves `currentPageNextY` sitting at the last line's bottom, and a third of a line above that lands inside its glyphs — the border draws straight through the final line, striking it out. Reported on a German EPUB whose bordered blocks have no bottom margin; the reporter's photo shows the closing edge crossing "dem wir leben können."

### The fix

Keep the pull-up, floor it at the bottom of the last line placed inside the box. It can still absorb trailing spacing; it can no longer reach into text.

The floor resets in two places, both necessary:
* when a box opens, so a previous box cannot leak its floor into the next one;
* when a box is **continued across a page break** — the continuation restarts at `y = 0` on the new page, where a floor carried over from the previous page would sit far below anything drawn and push the closing edge to the wrong place.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **`SECTION_FILE_VERSION` 90 -> 91 is required, not incidental.** The box height is computed during layout and stored in `PageBox`, so without the bump existing caches keep the old geometry and the fix silently appears not to work. `docs/file-formats.md` updated to describe what changed in the stored geometry.
* **Cost of the bump:** every book re-paginates on first open after upgrading — one slow build per book, then normal.
* **What reviewers should check**, since this touches every bordered block: a box **with** generous bottom margin (headings, pull-quotes) should look exactly as before — the pull-up is unchanged there, only floored — and a box split across a page boundary should still draw an open bottom on the first page and no top edge on the second.
* **Device-tested** on X4: the reported page now draws the border below the final line, confirmed by the reporter.
* Memory / flash impact: one `int16_t` of parser state; no allocations.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
