### PR TITLE
fix: manga page turns inverted on a rotated panel

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -29,6 +29,11 @@ bool MappedInputManager::isNavDirectionSwapped() const {
 }
 
 MappedInputManager::Button MappedInputManager::mapScreenDirection(const Button button) const {
+  return mapScreenDirectionFor(button, static_cast<uint8_t>(renderer.getOrientation()));
+}
+
+MappedInputManager::Button MappedInputManager::mapScreenDirectionFor(const Button button,
+                                                                     const uint8_t orientation) const {
   // Rows follow GfxRenderer::Orientation's declared order.
   static constexpr Button directions[][4] = {
       {Button::Left, Button::Right, Button::Up, Button::Down},
@@ -60,15 +65,19 @@ MappedInputManager::Button MappedInputManager::mapScreenDirection(const Button b
   // through that predicate, so gating this on the setting alone would silently drop the rotation
   // for touch users who leave the toggle off.
   const bool followOrientation = gpio.hasTouch() || SETTINGS.frontButtonFollowOrientation;
-  const uint8_t orientation = followOrientation ? static_cast<uint8_t>(renderer.getOrientation()) : 0;
-  return directions[orientation][direction];
+  const uint8_t row = followOrientation ? orientation : 0;
+  return directions[row][direction];
 }
 
 // True when the screen's vertical axis currently resolves to the front buttons -- i.e. in either
 // landscape, where the rotation hands the horizontal pair to the side buttons instead.
-bool MappedInputManager::frontPairIsVertical() const {
-  const Button up = mapScreenDirection(Button::ScreenUp);
+bool MappedInputManager::frontPairIsVerticalFor(const uint8_t orientation) const {
+  const Button up = mapScreenDirectionFor(Button::ScreenUp, orientation);
   return up == Button::Left || up == Button::Right;
+}
+
+bool MappedInputManager::frontPairIsVertical() const {
+  return frontPairIsVerticalFor(static_cast<uint8_t>(renderer.getOrientation()));
 }
 
 MappedInputManager::Button MappedInputManager::frontPairPrevious() const {
@@ -77,6 +86,14 @@ MappedInputManager::Button MappedInputManager::frontPairPrevious() const {
 
 MappedInputManager::Button MappedInputManager::frontPairNext() const {
   return frontPairIsVertical() ? Button::ScreenDown : Button::ScreenRight;
+}
+
+MappedInputManager::Button MappedInputManager::frontPairPrevious(const uint8_t orientation) const {
+  return frontPairIsVerticalFor(orientation) ? Button::ScreenUp : Button::ScreenLeft;
+}
+
+MappedInputManager::Button MappedInputManager::frontPairNext(const uint8_t orientation) const {
+  return frontPairIsVerticalFor(orientation) ? Button::ScreenDown : Button::ScreenRight;
 }
 
 bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -35,7 +35,8 @@ MappedInputManager::Button MappedInputManager::mapScreenDirection(const Button b
 MappedInputManager::Button MappedInputManager::mapScreenDirectionFor(const Button button,
                                                                      const uint8_t orientation) const {
   // Rows follow GfxRenderer::Orientation's declared order.
-  static constexpr Button directions[][4] = {
+  static constexpr uint8_t ORIENTATION_COUNT = 4;
+  static constexpr Button directions[ORIENTATION_COUNT][4] = {
       {Button::Left, Button::Right, Button::Up, Button::Down},
       {Button::Down, Button::Up, Button::Left, Button::Right},
       {Button::Right, Button::Left, Button::Down, Button::Up},
@@ -65,7 +66,9 @@ MappedInputManager::Button MappedInputManager::mapScreenDirectionFor(const Butto
   // through that predicate, so gating this on the setting alone would silently drop the rotation
   // for touch users who leave the toggle off.
   const bool followOrientation = gpio.hasTouch() || SETTINGS.frontButtonFollowOrientation;
-  const uint8_t row = followOrientation ? orientation : 0;
+  // Clamped, not trusted: the orientation can arrive from a caller-supplied override (a persisted
+  // setting), and an out-of-range value would index past the table.
+  const uint8_t row = (followOrientation && orientation < ORIENTATION_COUNT) ? orientation : 0;
   return directions[row][direction];
 }
 
@@ -88,12 +91,19 @@ MappedInputManager::Button MappedInputManager::frontPairNext() const {
   return frontPairIsVertical() ? Button::ScreenDown : Button::ScreenRight;
 }
 
+// These return an ALREADY-RESOLVED logical button (Left/Right/Up/Down), unlike the live-orientation
+// pair above which return a Screen* direction. That is the whole point: a Screen* button is resolved
+// later by mapButton() -> mapScreenDirection(), which reads the LIVE orientation -- so handing one
+// back here would let the content rotation the caller is trying to ignore creep in through the back
+// door. Resolving now pins the answer to the orientation the caller actually asked for.
 MappedInputManager::Button MappedInputManager::frontPairPrevious(const uint8_t orientation) const {
-  return frontPairIsVerticalFor(orientation) ? Button::ScreenUp : Button::ScreenLeft;
+  const Button dir = frontPairIsVerticalFor(orientation) ? Button::ScreenUp : Button::ScreenLeft;
+  return mapScreenDirectionFor(dir, orientation);
 }
 
 MappedInputManager::Button MappedInputManager::frontPairNext(const uint8_t orientation) const {
-  return frontPairIsVerticalFor(orientation) ? Button::ScreenDown : Button::ScreenRight;
+  const Button dir = frontPairIsVerticalFor(orientation) ? Button::ScreenDown : Button::ScreenRight;
+  return mapScreenDirectionFor(dir, orientation);
 }
 
 bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -111,6 +111,12 @@ class MappedInputManager {
   // and without stealing the side buttons, whose page-turn role the user can disable separately.
   Button frontPairPrevious() const;
   Button frontPairNext() const;
+  // Same, resolved against an explicit orientation instead of the live one. For a viewer that
+  // rotates the DISPLAY to fit its content (the manga reader turns a panel 90 degrees when its
+  // aspect does not match the screen): that rotation is a content transform, not the reader
+  // picking the device up differently, so input must not follow it.
+  Button frontPairPrevious(uint8_t orientation) const;
+  Button frontPairNext(uint8_t orientation) const;
 
   Labels mapLabels(const char* back, const char* confirm, const char* previous, const char* next) const;
   // Maps four screen-direction labels onto the two physical front-button roles
@@ -134,6 +140,8 @@ class MappedInputManager {
   const GfxRenderer& renderer;
 
   Button mapScreenDirection(Button button) const;
+  Button mapScreenDirectionFor(Button button, uint8_t orientation) const;
+  bool frontPairIsVerticalFor(uint8_t orientation) const;
   Labels mapFrontLabels(const char* back, const char* confirm, const char* left, const char* right) const;
   bool frontPairIsVertical() const;
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -114,7 +114,8 @@ class MappedInputManager {
   // Same, resolved against an explicit orientation instead of the live one. For a viewer that
   // rotates the DISPLAY to fit its content (the manga reader turns a panel 90 degrees when its
   // aspect does not match the screen): that rotation is a content transform, not the reader
-  // picking the device up differently, so input must not follow it.
+  // picking the device up differently, so input must not follow it. These return an already-
+  // RESOLVED logical button rather than a Screen* direction -- see the definitions.
   Button frontPairPrevious(uint8_t orientation) const;
   Button frontPairNext(uint8_t orientation) const;
 

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -610,7 +610,12 @@ void MangaReaderActivity::loop() {
     }
   }
 
-  auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
+  // Resolve against the reader's OWN orientation, not the live one: a panel whose aspect does not
+  // match the screen is displayed rotated 90 degrees, and that rotation stays applied while the
+  // panel is on screen. Following it inverted the front pair, so the same press stepped forward on
+  // an upright panel and back on a rotated one -- observed on device as walking backwards through
+  // a page's panels (orient flipping 0 <-> 3 between presses, the front pair swapping with it).
+  auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput, SETTINGS.orientation);
   prevTriggered = prevTriggered || touch.prev;
   nextTriggered = nextTriggered || touch.next;
   if (!prevTriggered && !nextTriggered) {

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -615,7 +615,8 @@ void MangaReaderActivity::loop() {
   // panel is on screen. Following it inverted the front pair, so the same press stepped forward on
   // an upright panel and back on a rotated one -- observed on device as walking backwards through
   // a page's panels (orient flipping 0 <-> 3 between presses, the front pair swapping with it).
-  auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput, SETTINGS.orientation);
+  auto [prevTriggered, nextTriggered, fromTilt] =
+      ReaderUtils::detectPageTurnForOrientation(mappedInput, SETTINGS.orientation);
   prevTriggered = prevTriggered || touch.prev;
   nextTriggered = nextTriggered || touch.next;
   if (!prevTriggered && !nextTriggered) {

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -115,8 +115,10 @@ struct PageTurnResult {
 };
 
 // orientationOverride (>= 0) resolves the front pair against that orientation instead of the live
-// one, for a viewer that rotates the display to fit its content -- see the overloads it calls.
-inline PageTurnResult detectPageTurn(const MappedInputManager& input, const int orientationOverride = -1) {
+// one, for a viewer that rotates the display to fit its content. Private: callers use
+// detectPageTurn() or detectPageTurnForOrientation() below, which cannot be confused for one
+// another at a call site.
+inline PageTurnResult detectPageTurnImpl(const MappedInputManager& input, const int orientationOverride) {
   const bool usePress = SETTINGS.longPressButtonBehavior == SETTINGS.OFF;
   const bool tiltNext = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedForward();
   const bool tiltPrev = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedBack();
@@ -140,6 +142,17 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input, const int 
   const bool next = tiltNext || pageButtonTriggered(MappedInputManager::Button::PageForward) || powerTurn ||
                     pageButtonTriggered(nextButton);
   return {prev, next, tiltPrev || tiltNext};
+}
+
+// Page turns resolved against the live orientation -- the normal case.
+inline PageTurnResult detectPageTurn(const MappedInputManager& input) { return detectPageTurnImpl(input, -1); }
+
+// Page turns resolved against an explicit orientation, for a viewer that rotates the DISPLAY to fit
+// its content. A separate name rather than a defaulted parameter on detectPageTurn(): an extra
+// numeric argument there would bind silently to whatever the parameter happens to be, so a caller
+// passing an orientation could compile into something else entirely.
+inline PageTurnResult detectPageTurnForOrientation(const MappedInputManager& input, const uint8_t orientation) {
+  return detectPageTurnImpl(input, static_cast<int>(orientation));
 }
 
 // A short power-button click closes the dictionary / word-lookup screens, but only when that same

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -114,7 +114,9 @@ struct PageTurnResult {
   bool fromTilt;
 };
 
-inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
+// orientationOverride (>= 0) resolves the front pair against that orientation instead of the live
+// one, for a viewer that rotates the display to fit its content -- see the overloads it calls.
+inline PageTurnResult detectPageTurn(const MappedInputManager& input, const int orientationOverride = -1) {
   const bool usePress = SETTINGS.longPressButtonBehavior == SETTINGS.OFF;
   const bool tiltNext = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedForward();
   const bool tiltPrev = SETTINGS.tiltPageTurn && halTiltSensor.wasTiltedBack();
@@ -123,8 +125,10 @@ inline PageTurnResult detectPageTurn(const MappedInputManager& input) {
   // buttons in landscape -- they already turn pages through PageBack/PageForward, so the front
   // buttons would simply do nothing, which is what happened. It also must not reach the side
   // buttons by another name: their page-turn role is the user's to disable via sideButtonLayout.
-  const auto prevButton = input.frontPairPrevious();
-  const auto nextButton = input.frontPairNext();
+  const auto prevButton = orientationOverride >= 0 ? input.frontPairPrevious(static_cast<uint8_t>(orientationOverride))
+                                                   : input.frontPairPrevious();
+  const auto nextButton =
+      orientationOverride >= 0 ? input.frontPairNext(static_cast<uint8_t>(orientationOverride)) : input.frontPairNext();
   const auto pageButtonTriggered = [&](const MappedInputManager::Button button) {
     if (usePress) return input.wasPressed(button);
     return input.wasLongPressed(button, SKIP_HOLD_MS) || input.wasReleased(button);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop manga page turns inverting themselves on a rotated panel, which made the reader walk backwards through a page.
* **What changes are included?** Orientation-explicit overloads of the front-pair helpers, an override on `detectPageTurn()`, and the manga reader resolving against its own orientation.

### The bug

The manga reader rotates the **display** 90° for any panel whose aspect does not match the screen ([MangaReaderActivity.cpp:762](../blob/develop/src/activities/reader/MangaReaderActivity.cpp)), and leaves that rotation applied while the panel is shown. `frontPairPrevious()` / `frontPairNext()` resolve against the *live* orientation, so the same physical button meant "next" on an upright panel and "previous" on a rotated one.

Landing on a rotated panel reversed navigation for as long as it stayed on screen. Traced on device:

| orient | front pair resolves to | same press produces |
|---|---|---|
| `0` Portrait | ScreenLeft / ScreenRight | `next=1` — forward |
| `3` LandscapeCCW | ScreenUp / ScreenDown | `prev=1` — backward |

With `orient` flipping between presses, the reader looped 1/2 → 2/2 → 1/2 between two panels forever; on a five-panel page it walked 4 → 3 → 2 → 1.

### The fix

A fit-rotation is a **content transform** — the reader has not picked the device up differently — so input must not follow it. The manga reader now resolves the front pair against `SETTINGS.orientation`. Every other caller is unchanged and keeps using the live orientation, which is correct for them: they only rotate when the user actually turns the device.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **This is a regression from #219**, which made page turning orientation-relative via the front-pair helpers. Nothing before it read the live orientation on this path, so manga was unaffected until that merged. Flagging it as my own to make the history clear rather than filing it as a pre-existing fault.
* **Device-verified**: reproduced with instrumentation logging `orient` and the resolved buttons per press, fixed, and re-tested — panels now step forward continuously through a page and on to the next.
* **What reviewers should check**: the EPUB, TXT and XTC readers pass no override and must behave exactly as before; only the manga reader opts out of the live orientation. And a manga read in landscape should still respect the reader's own landscape setting — the override is the reader's configured orientation, not a hardcoded portrait.
* Memory / flash impact: none of note; two overloads and an int parameter.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
