### PR TITLE
feat: look up words split across a page boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Look up any word on the page, vertically or horizontally. Conjugations resolve t
 
 In vertical text, lookup opens on the page itself: the current word is highlighted where it stands, the side buttons step word by word down the column, Left and Right jump a column, and the definition opens only when you press Look Up. Back returns to the highlighted page, so several words on a page are a few presses apart. The cursor opens mid-page and the scan starts there too, so the half you are looking at is ready first; words it has not reached yet can still be selected, and the highlight moves as soon as the scan arrives. No button labels are drawn over the page — vertical text would be covered by them. Horizontal text opens straight into the definition view as before.
 
+A word broken across a page break still resolves. The lookup reads a few characters past the end of the page, so the half you can see finds the whole word; the highlight stays on the page and covers only the characters that are there.
+
 The definition itself opens as a panel floating over the page you were reading: the word sits above a divider at the top, the entry fills the middle, and the dictionary it came from is named along the bottom. In vertical text and in English books the entry is paged a screenful at a time with a page counter in the top right; horizontal Japanese and manga scroll the entry freely and show your position among the page's words instead.
 
 Vocabulary, names and grammar each come from their own dictionary. If the book itself annotated a reading, the entry opens with "In this book: はやし" and remembers it for the rest of the book. See [Setup](#setup) for the files, and [§6.2](USER_GUIDE.md#62-word-lookup) for how to drive it.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -814,6 +814,10 @@ In **horizontal text** and in manga, lookup opens directly in the definition vie
 The header counts your position (e.g. 10/35). The page is pre-scanned, so you only ever land on a word the
 dictionary actually has.
 
+A Japanese word broken by the page break still resolves: the lookup reads a few characters past the last one on
+screen, so selecting the part you can see gives the whole word. The highlight stays on the page, covering only
+the characters that are actually there.
+
 Enable **Settings → Controls → Navigate with Side Buttons in Word Lookup** to use the side buttons for moving
 between words and the front Left / Right buttons for scrolling. The default mapping above remains active when
 **Side Button Layout** is set to **Disabled**.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4021,6 +4021,9 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
       // pointer into the section's page cache, so asking for another page can invalidate the one
       // already held.
       std::string lookupTail;
+      // Worst case 4 UTF-8 bytes per context character: one reserve instead of repeated growth
+      // on a heap that was just reclaimed.
+      lookupTail.reserve(WordSelectionScan::kLookupContextChars * 4);
       uint32_t lookupTailParagraph = 0;
       if (const VerticalPage* nextPage = verticalSection->getPage(verticalSection->currentPage + 1)) {
         int taken = 0;
@@ -4083,6 +4086,7 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
       // loadPageAt() returns an owned page, so unlike the vertical path there is no cache pointer
       // to invalidate and the order does not matter.
       std::string lookupTail;
+      lookupTail.reserve(WordSelectionScan::kLookupContextChars * 4);  // see the vertical path
       if (auto nextPage = section->loadPageAt(section->currentPage + 1)) {
         // Flattened the way initFromPage() flattens the current page -- a separating space only
         // between two ASCII words, CJK runs concatenated -- so a split Japanese word still meets

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4016,10 +4016,28 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
         prewarmedHPage_ = -1;
       }
       LOG_DBG("ERS", "Word lookup (vertical): maxAlloc after reclaim = %u", ESP.getMaxAllocHeap());
+      // Start of the NEXT page, so a word split across the boundary can still be looked up
+      // (#201). Fetched BEFORE the current page and copied into a string: getPage() hands out a
+      // pointer into the section's page cache, so asking for another page can invalidate the one
+      // already held.
+      std::string lookupTail;
+      uint32_t lookupTailParagraph = 0;
+      if (const VerticalPage* nextPage = verticalSection->getPage(verticalSection->currentPage + 1)) {
+        int taken = 0;
+        for (const auto& g : nextPage->glyphs) {
+          if (g.renderKind == VerticalGlyph::RotatedRun) continue;
+          if (taken == 0) lookupTailParagraph = g.paragraphIndex;
+          // One paragraph only: a word cannot span a paragraph break, and the scan would discard
+          // the rest anyway.
+          if (g.paragraphIndex != lookupTailParagraph) break;
+          WordSelectionScan::encodeUtf8(g.codepoint, lookupTail);
+          if (++taken >= WordSelectionScan::kLookupContextChars) break;
+        }
+      }
       if (const VerticalPage* page = verticalSection->getPage()) {
         panel = makeUniqueNoThrow<EpubReaderWordLookupActivity>(
             renderer, mappedInput, *page, scanCachePath, static_cast<uint16_t>(currentSpineIndex),
-            static_cast<uint16_t>(verticalSection->currentPage), selectCtx);
+            static_cast<uint16_t>(verticalSection->currentPage), selectCtx, lookupTail, lookupTailParagraph);
         if (!panel) LOG_ERR("ERS", "OOM: word lookup panel");
       }
     }
@@ -4058,9 +4076,33 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
       // here needs the build to still be live.
       LOG_DBG("ERS", "Word lookup: maxAlloc after reclaim = %u", ESP.getMaxAllocHeap());
 
+      // Start of the next page, so a word split across the boundary can still be looked up (#201).
+      // loadPageAt() returns an owned page, so unlike the vertical path there is no cache pointer
+      // to invalidate and the order does not matter.
+      std::string lookupTail;
+      if (auto nextPage = section->loadPageAt(section->currentPage + 1)) {
+        const std::string nextText = PageTextExtractor::fromHorizontalPage(*nextPage);
+        int taken = 0;
+        for (size_t i = 0; i < nextText.size() && taken < WordSelectionScan::kLookupContextChars;) {
+          const auto lead = static_cast<unsigned char>(nextText[i]);
+          size_t len = 1;
+          if ((lead & 0xE0) == 0xC0)
+            len = 2;
+          else if ((lead & 0xF0) == 0xE0)
+            len = 3;
+          else if ((lead & 0xF8) == 0xF0)
+            len = 4;
+          if (i + len > nextText.size()) break;
+          if (lead == '\n') break;  // paragraph break: a word cannot span it
+          lookupTail.append(nextText, i, len);
+          i += len;
+          taken++;
+        }
+      }
+
       startActivityForResult(std::make_unique<EpubReaderWordLookupActivity>(
                                  renderer, mappedInput, *page, scanCachePath, static_cast<uint16_t>(currentSpineIndex),
-                                 static_cast<uint16_t>(section->currentPage)),
+                                 static_cast<uint16_t>(section->currentPage), lookupTail),
                              [this](const ActivityResult&) { requestUpdate(); });
     }
   }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -4026,6 +4026,9 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
         int taken = 0;
         for (const auto& g : nextPage->glyphs) {
           if (g.renderKind == VerticalGlyph::RotatedRun) continue;
+          // Both run kinds keep their text in the page's pool and leave codepoint == 0; encoding
+          // that would put a NUL byte into the tail and be read back as a real character.
+          if (g.codepoint == 0) continue;
           if (taken == 0) lookupTailParagraph = g.paragraphIndex;
           // One paragraph only: a word cannot span a paragraph break, and the scan would discard
           // the rest anyway.
@@ -4081,22 +4084,44 @@ void EpubReaderActivity::openWordLookupPanel(const bool pageOnScreen) {
       // to invalidate and the order does not matter.
       std::string lookupTail;
       if (auto nextPage = section->loadPageAt(section->currentPage + 1)) {
-        const std::string nextText = PageTextExtractor::fromHorizontalPage(*nextPage);
+        // Flattened the way initFromPage() flattens the current page -- a separating space only
+        // between two ASCII words, CJK runs concatenated -- so a split Japanese word still meets
+        // its continuation. PageTextExtractor spaces EVERY word, which would break that; walking
+        // the first few words directly also avoids building the whole next page's text.
+        auto isAsciiWord = [](unsigned char c) {
+          return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+        };
         int taken = 0;
-        for (size_t i = 0; i < nextText.size() && taken < WordSelectionScan::kLookupContextChars;) {
-          const auto lead = static_cast<unsigned char>(nextText[i]);
-          size_t len = 1;
-          if ((lead & 0xE0) == 0xC0)
-            len = 2;
-          else if ((lead & 0xF0) == 0xE0)
-            len = 3;
-          else if ((lead & 0xF8) == 0xF0)
-            len = 4;
-          if (i + len > nextText.size()) break;
-          if (lead == '\n') break;  // paragraph break: a word cannot span it
-          lookupTail.append(nextText, i, len);
-          i += len;
-          taken++;
+        for (const auto& el : nextPage->elements) {
+          if (taken >= WordSelectionScan::kLookupContextChars) break;
+          if (el->getTag() != TAG_PageLine) continue;
+          const auto& line = static_cast<const PageLine&>(*el);
+          if (!line.getBlock()) continue;
+          const TextBlock& block = *line.getBlock();
+          for (uint16_t wi = 0; wi < block.wordCount() && taken < WordSelectionScan::kLookupContextChars; wi++) {
+            // Braces, not parens: Arduino.h defines a function-like `word(...)` macro.
+            const std::string_view w{block.wordText(wi), block.wordTextLen(wi)};
+            if (w.empty()) continue;
+            if (!lookupTail.empty() && isAsciiWord(static_cast<unsigned char>(lookupTail.back())) &&
+                isAsciiWord(static_cast<unsigned char>(w[0]))) {
+              lookupTail += ' ';
+              taken++;
+            }
+            for (size_t b = 0; b < w.size() && taken < WordSelectionScan::kLookupContextChars;) {
+              const auto lead = static_cast<unsigned char>(w[b]);
+              size_t len = 1;
+              if ((lead & 0xE0) == 0xC0)
+                len = 2;
+              else if ((lead & 0xF0) == 0xE0)
+                len = 3;
+              else if ((lead & 0xF8) == 0xF0)
+                len = 4;
+              if (b + len > w.size()) break;
+              lookupTail.append(w.data() + b, len);
+              b += len;
+              taken++;
+            }
+          }
         }
       }
 

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -361,7 +361,7 @@ bool EpubReaderWordLookupActivity::stepCursor(const int delta, int& outIndex) {
 }
 
 void EpubReaderWordLookupActivity::moveSelection(const int delta) {
-  if (provisionalGlyph < scan.allGlyphs.size()) {
+  if (provisionalGlyph < scan.onPageGlyphCount()) {
     const auto& current = scan.allGlyphs[provisionalGlyph];
     size_t target = SIZE_MAX;
     int bestDistance = INT_MAX;
@@ -418,7 +418,7 @@ void EpubReaderWordLookupActivity::moveSelection(const int delta) {
 // resolvePendingMove() as the frontier reaches it.
 void EpubReaderWordLookupActivity::jumpColumn(const int direction) {
   const size_t currentGlyph = currentAllGlyphIndex();
-  if (currentGlyph >= scan.allGlyphs.size()) return;
+  if (currentGlyph >= scan.onPageGlyphCount()) return;
   const auto& cur = scan.allGlyphs[currentGlyph];
   uint16_t minColumn = 0;
   uint16_t maxColumn = 0;
@@ -849,7 +849,7 @@ void EpubReaderWordLookupActivity::refreshCursorBoxes() {
   // observe a half-built set. Only the publish at the end runs with the render task locked out.
   HighlightBox boxes[kMaxHighlightBoxes];
   int count = 0;
-  if (provisionalGlyph < scan.allGlyphs.size()) {
+  if (provisionalGlyph < scan.onPageGlyphCount()) {
     const auto& glyph = scan.allGlyphs[provisionalGlyph];
     boxes[0] = HighlightBox{static_cast<int16_t>(glyph.x + selectCtx.marginLeft),
                             static_cast<int16_t>(glyph.y + selectCtx.marginTop), static_cast<int16_t>(selectCtx.cellPx),
@@ -926,7 +926,7 @@ void EpubReaderWordLookupActivity::renderSelect() {
 }
 
 size_t EpubReaderWordLookupActivity::currentAllGlyphIndex() const {
-  if (provisionalGlyph < scan.allGlyphs.size()) return provisionalGlyph;
+  if (provisionalGlyph < scan.onPageGlyphCount()) return provisionalGlyph;
   if (cursorIndex < 0 || static_cast<size_t>(cursorIndex) >= scan.selectToAllIdx.size()) return SIZE_MAX;
   return scan.selectToAllIdx[static_cast<size_t>(cursorIndex)];
 }

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -30,7 +30,9 @@
 EpubReaderWordLookupActivity::EpubReaderWordLookupActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                                            const VerticalPage& page, std::string scanCachePath,
                                                            const uint16_t spineIndex, const uint16_t pageIndex,
-                                                           const VerticalSelectContext& selectContext)
+                                                           const VerticalSelectContext& selectContext,
+                                                           const std::string& lookupContext,
+                                                           const uint32_t lookupContextParagraph)
     : Activity("WordLookup", renderer, mappedInput),
       selectCtx(selectContext),
       scanCachePath(std::move(scanCachePath)),
@@ -46,12 +48,14 @@ EpubReaderWordLookupActivity::EpubReaderWordLookupActivity(GfxRenderer& renderer
   }
   reclaimFontHeap();  // BEFORE building the scan -- see reclaimFontHeap()
   scan.initFromVerticalPage(page);
+  if (!lookupContext.empty()) scan.appendLookupContext(lookupContext, lookupContextParagraph);
   initScanFromCacheOrBurst("vertical");
 }
 
 EpubReaderWordLookupActivity::EpubReaderWordLookupActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                                            const Page& page, std::string scanCachePath,
-                                                           const uint16_t spineIndex, const uint16_t pageIndex)
+                                                           const uint16_t spineIndex, const uint16_t pageIndex,
+                                                           const std::string& lookupContext)
     : Activity("WordLookup", renderer, mappedInput),
       scanCachePath(std::move(scanCachePath)),
       scanSpine(spineIndex),
@@ -60,6 +64,8 @@ EpubReaderWordLookupActivity::EpubReaderWordLookupActivity(GfxRenderer& renderer
   if (slash != std::string::npos) bookCachePath = this->scanCachePath.substr(0, slash);
   reclaimFontHeap();  // BEFORE building the scan -- see reclaimFontHeap()
   scan.initFromPage(page);
+  // Horizontal glyphs all carry paragraphIndex 0, so the context matches by construction.
+  if (!lookupContext.empty()) scan.appendLookupContext(lookupContext, 0);
   initScanFromCacheOrBurst("horizontal");
 }
 

--- a/src/activities/reader/EpubReaderWordLookupActivity.cpp
+++ b/src/activities/reader/EpubReaderWordLookupActivity.cpp
@@ -367,7 +367,7 @@ void EpubReaderWordLookupActivity::moveSelection(const int delta) {
     int bestDistance = INT_MAX;
     size_t wrapped = SIZE_MAX;
     uint16_t wrappedRow = delta > 0 ? UINT16_MAX : 0;
-    for (size_t i = 0; i < scan.allGlyphs.size(); i++) {
+    for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
       const auto& glyph = scan.allGlyphs[i];
       if (glyph.column != current.column || !WordSelectionScan::isLookupableChar(glyph.codepoint)) continue;
       const int distance = static_cast<int>(glyph.row) - static_cast<int>(current.row);
@@ -455,7 +455,7 @@ void EpubReaderWordLookupActivity::jumpColumn(const int direction) {
 
 bool EpubReaderWordLookupActivity::columnRange(const uint16_t column, size_t& first, size_t& last) const {
   bool found = false;
-  for (size_t i = 0; i < scan.allGlyphs.size(); i++) {
+  for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
     if (scan.allGlyphs[i].column != column) continue;
     if (!found) {
       first = i;
@@ -470,7 +470,7 @@ bool EpubReaderWordLookupActivity::closestUnmappedInColumn(const uint16_t column
                                                            size_t& outGlyph, int& outDistance) const {
   bool found = false;
   outDistance = INT_MAX;
-  for (size_t i = 0; i < scan.allGlyphs.size(); i++) {
+  for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
     const auto& glyph = scan.allGlyphs[i];
     if (glyph.column != column || scan.isGlyphMapped(i)) continue;
     const int distance = std::abs(static_cast<int>(glyph.row) - static_cast<int>(anchorRow));
@@ -487,7 +487,7 @@ bool EpubReaderWordLookupActivity::closestGlyphInColumn(const uint16_t column, c
                                                         size_t& outGlyph) const {
   bool found = false;
   int bestDistance = INT_MAX;
-  for (size_t i = 0; i < scan.allGlyphs.size(); i++) {
+  for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
     const auto& glyph = scan.allGlyphs[i];
     if (glyph.column != column || !WordSelectionScan::isLookupableChar(glyph.codepoint)) continue;
     const int distance = std::abs(static_cast<int>(glyph.row) - static_cast<int>(anchorRow));
@@ -504,7 +504,8 @@ bool EpubReaderWordLookupActivity::columnBounds(uint16_t& outMin, uint16_t& outM
   if (scan.allGlyphs.empty()) return false;
   outMin = UINT16_MAX;
   outMax = 0;
-  for (const auto& g : scan.allGlyphs) {
+  for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
+    const auto& g = scan.allGlyphs[i];
     outMin = std::min(outMin, g.column);
     outMax = std::max(outMax, g.column);
   }
@@ -550,7 +551,8 @@ bool EpubReaderWordLookupActivity::middleTarget(uint16_t& outColumn, uint16_t& o
   uint16_t maxColumn = 0;
   uint16_t minRow = UINT16_MAX;
   uint16_t maxRow = 0;
-  for (const auto& g : scan.allGlyphs) {
+  for (size_t i = 0; i < scan.onPageGlyphCount(); i++) {
+    const auto& g = scan.allGlyphs[i];
     minColumn = std::min(minColumn, g.column);
     maxColumn = std::max(maxColumn, g.column);
     minRow = std::min(minRow, g.row);
@@ -798,10 +800,11 @@ int EpubReaderWordLookupActivity::buildBoxesFor(const int selectableIndex, Highl
   if (selectableIndex < 0 || static_cast<size_t>(selectableIndex) >= scan.selectToAllIdx.size()) return 0;
 
   const size_t start = scan.selectToAllIdx[static_cast<size_t>(selectableIndex)];
-  if (start >= scan.allGlyphs.size()) return 0;
+  if (start >= scan.onPageGlyphCount()) return 0;
 
   const size_t span = std::max<size_t>(scan.selectableGlyphs[static_cast<size_t>(selectableIndex)].matchLen, 1);
-  const size_t end = std::min(start + span, scan.allGlyphs.size());
+  // Bounded on the page: a match running into the next page's context has no cells to draw here.
+  const size_t end = std::min(start + span, scan.onPageGlyphCount());
   const int cellPx = selectCtx.cellPx;
 
   size_t i = start;

--- a/src/activities/reader/EpubReaderWordLookupActivity.h
+++ b/src/activities/reader/EpubReaderWordLookupActivity.h
@@ -55,11 +55,16 @@ class EpubReaderWordLookupActivity final : public Activity {
   explicit EpubReaderWordLookupActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                         const VerticalPage& page, std::string scanCachePath = "",
                                         uint16_t spineIndex = 0, uint16_t pageIndex = 0,
-                                        const VerticalSelectContext& selectContext = {});
+                                        const VerticalSelectContext& selectContext = {},
+                                        // Start of the next page, so a word split across the page
+                                        // boundary still resolves. See appendLookupContext().
+                                        const std::string& lookupContext = "", uint32_t lookupContextParagraph = 0);
   // Horizontal (yokogaki) reading mode.
   explicit EpubReaderWordLookupActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const Page& page,
-                                        std::string scanCachePath = "", uint16_t spineIndex = 0,
-                                        uint16_t pageIndex = 0);
+                                        std::string scanCachePath = "", uint16_t spineIndex = 0, uint16_t pageIndex = 0,
+                                        // See the vertical constructor: start of the next page, so
+                                        // a word split across the boundary still resolves.
+                                        const std::string& lookupContext = "");
 
   void onEnter() override;
   void onExit() override;

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -209,6 +209,7 @@ void WordSelectionScan::reset() {
   skipUntil = 0;
   scanTruncated = false;
   restoredCursorIndex = kNoRestoredCursor;
+  contextStart = 0;
 }
 
 void WordSelectionScan::restartStepScan() {
@@ -242,6 +243,39 @@ void WordSelectionScan::initFromVerticalPage(const VerticalPage& page) {
   // lifetime -- exactly the margin the font decompressor needed while rendering definitions
   // (confirmed crash_report: FDC 16KB temp buffers failing). pushGlyphSafe grows the vector
   // with guarded doubling instead.
+  contextStart = allGlyphs.size();
+  allocScannedBits();
+}
+
+void WordSelectionScan::appendLookupContext(const std::string& utf8, const uint32_t paragraphIndex) {
+  contextStart = allGlyphs.size();
+  int added = 0;
+  for (size_t i = 0; i < utf8.size() && added < kLookupContextChars;) {
+    const auto lead = static_cast<unsigned char>(utf8[i]);
+    size_t len = 1;
+    uint32_t cp = lead;
+    if ((lead & 0xE0) == 0xC0) {
+      len = 2;
+      cp = lead & 0x1F;
+    } else if ((lead & 0xF0) == 0xE0) {
+      len = 3;
+      cp = lead & 0x0F;
+    } else if ((lead & 0xF8) == 0xF0) {
+      len = 4;
+      cp = lead & 0x07;
+    }
+    if (i + len > utf8.size()) break;  // truncated trailing sequence
+    for (size_t k = 1; k < len; k++) cp = (cp << 6) | (static_cast<unsigned char>(utf8[i + k]) & 0x3F);
+    // Zero position: these are never drawn and never selectable, so there is nothing to place.
+    if (!pushGlyphSafe(allGlyphs, GlyphRef{0, 0, 0, 0, cp, paragraphIndex, 0})) {
+      scanTruncated = true;
+      break;
+    }
+    i += len;
+    added++;
+  }
+  // The bitmap is sized from allGlyphs, so it has to cover the appended cells even though the walk
+  // never records them -- isGlyphMapped() is consulted by index.
   allocScannedBits();
 }
 
@@ -308,6 +342,7 @@ void WordSelectionScan::initFromPage(const Page& page) {
   // lifetime -- exactly the margin the font decompressor needed while rendering definitions
   // (confirmed crash_report: FDC 16KB temp buffers failing). pushGlyphSafe grows the vector
   // with guarded doubling instead.
+  contextStart = allGlyphs.size();
   allocScannedBits();
 }
 
@@ -343,6 +378,7 @@ void WordSelectionScan::initFromUtf8Text(const std::string& text) {
   // lifetime -- exactly the margin the font decompressor needed while rendering definitions
   // (confirmed crash_report: FDC 16KB temp buffers failing). pushGlyphSafe grows the vector
   // with guarded doubling instead.
+  contextStart = allGlyphs.size();
   allocScannedBits();
 }
 
@@ -400,7 +436,9 @@ bool WordSelectionScan::step(const uint32_t maxMillis) {
     // Walked off the end, or onto cells another pass already did: pick up the next unfinished
     // cell wherever it is. Searching from 0 keeps the sweep in page order once the demand-driven
     // jumps have filled in the parts the reader actually looked at.
-    if (scanPos >= allGlyphs.size() || (scanPos >= recordFrom && isGlyphMapped(scanPos))) {
+    // contextStart, not allGlyphs.size(): the walk records selectable words, and the cells past
+    // contextStart are off-page context that can be MATCHED into but never pointed at.
+    if (scanPos >= contextStart || (scanPos >= recordFrom && isGlyphMapped(scanPos))) {
       // Without the bitmap the walk is a single sequential pass, so the end of the page IS the
       // end of the work. Consulting nextUnscanned() here would restart at 0 forever, since with
       // no bits every cell reports unmapped.
@@ -923,7 +961,11 @@ void WordSelectionScan::scanOnePosition() {
     // digits plus the dictionary match. Recorded now because the caller drawing a highlight over
     // the page must not have to repeat the lookup just to learn how many cells to cover.
     GlyphRef entry = g;
-    const size_t span = static_cast<size_t>(digitGlyphs) + static_cast<size_t>(std::max(matchChars, 1));
+    size_t span = static_cast<size_t>(digitGlyphs) + static_cast<size_t>(std::max(matchChars, 1));
+    // A word running into the next page matches in full but is only PRESENT up to the boundary,
+    // and matchLen is what draws the highlight box -- so clamp it to the cells that exist here.
+    // The match itself is untouched: the whole point is that the split word still resolves.
+    if (i + span > contextStart) span = contextStart - i;
     entry.matchLen = static_cast<uint8_t>(std::min<size_t>(span, 255));
     // Push selectableGlyphs first -- if it can't grow, the heap is exhausted, so stop the scan
     // rather than push a mismatched selectToAllIdx entry with no corresponding glyph.

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -249,6 +249,7 @@ void WordSelectionScan::initFromVerticalPage(const VerticalPage& page) {
 }
 
 void WordSelectionScan::appendLookupContext(const std::string& utf8, const uint32_t paragraphIndex) {
+  const bool hadBits = !scannedBits.empty();
   contextStart = allGlyphs.size();
   int added = 0;
   for (size_t i = 0; i < utf8.size() && added < kLookupContextChars;) {
@@ -267,17 +268,26 @@ void WordSelectionScan::appendLookupContext(const std::string& utf8, const uint3
     }
     if (i + len > utf8.size()) break;  // truncated trailing sequence
     for (size_t k = 1; k < len; k++) cp = (cp << 6) | (static_cast<unsigned char>(utf8[i + k]) & 0x3F);
-    // Zero position: these are never drawn and never selectable, so there is nothing to place.
-    if (!pushGlyphSafe(allGlyphs, GlyphRef{0, 0, 0, 0, cp, paragraphIndex, 0})) {
-      scanTruncated = true;
-      break;
-    }
+    // Zero position: these are never drawn and never selectable, so there is nothing to place --
+    // every consumer of a glyph's geometry stops at onPageGlyphCount().
+    // NOT scanTruncated on failure: the context is optional and the on-page glyph stream is
+    // intact, so the scan result is still complete and still worth caching.
+    if (!pushGlyphSafe(allGlyphs, GlyphRef{0, 0, 0, 0, cp, paragraphIndex, 0})) break;
     i += len;
     added++;
   }
-  // The bitmap is sized from allGlyphs, so it has to cover the appended cells even though the walk
-  // never records them -- isGlyphMapped() is consulted by index.
+  if (allGlyphs.size() == contextStart) return;  // nothing appended: leave the bitmap alone
+  // The bitmap is sized from allGlyphs, so it has to be re-sized to cover the appended cells even
+  // though the walk never records them -- isGlyphMapped() is consulted by index.
   allocScannedBits();
+  if (hadBits && scannedBits.empty()) {
+    // The longer bitmap did not fit. It is worth more than the optional context -- without it the
+    // walk drops to a strictly sequential pass and select mode loses its column jumps -- so drop
+    // the context and go back to the size that already fitted.
+    allGlyphs.resize(contextStart);
+    allocScannedBits();
+    return;
+  }
   markContextScanned();
 }
 

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -222,6 +222,7 @@ void WordSelectionScan::restartStepScan() {
   recordFrom = 0;
   // Every cell is unsegmented again: the re-walk rebuilds selectableGlyphs from scratch.
   std::fill(scannedBits.begin(), scannedBits.end(), 0);
+  markContextScanned();
   skipUntil = 0;
   scanTruncated = false;
   restoredCursorIndex = kNoRestoredCursor;
@@ -277,6 +278,7 @@ void WordSelectionScan::appendLookupContext(const std::string& utf8, const uint3
   // The bitmap is sized from allGlyphs, so it has to cover the appended cells even though the walk
   // never records them -- isGlyphMapped() is consulted by index.
   allocScannedBits();
+  markContextScanned();
 }
 
 void WordSelectionScan::initFromPage(const Page& page) {

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -446,8 +446,11 @@ bool WordSelectionScan::step(const uint32_t maxMillis) {
         phase = Phase::Done;
         break;
       }
+      // contextStart, not allGlyphs.size(): the context cells past it are never walked, so they
+      // never get marked scanned -- treating a resume there as the end keeps the sweep from
+      // returning to them forever.
       const size_t resume = nextUnscanned(0);
-      if (resume >= allGlyphs.size()) {
+      if (resume >= contextStart) {
         phase = Phase::Done;
         break;
       }

--- a/src/activities/reader/WordSelectionScan.h
+++ b/src/activities/reader/WordSelectionScan.h
@@ -161,6 +161,12 @@ class WordSelectionScan {
   void markScanned(size_t glyphIndex) {
     if (glyphIndex < allGlyphs.size() && !scannedBits.empty()) scannedBits[glyphIndex >> 3] |= (1u << (glyphIndex & 7));
   }
+  // Off-page context cells are never walked, so they would stay unmapped forever: mark them
+  // segmented so nextUnscanned() and the select-mode "closest unmapped cell" search skip them
+  // instead of repeatedly aiming the walk at work it will never do.
+  void markContextScanned() {
+    for (size_t i = contextStart; i < allGlyphs.size(); i++) markScanned(i);
+  }
   // Next cell at or after `from` that has not been segmented; allGlyphs.size() when none remain.
   size_t nextUnscanned(size_t from) const;
   // Size the per-cell bitmap for the glyph list just built. Nothrow: on OOM the bitmap stays

--- a/src/activities/reader/WordSelectionScan.h
+++ b/src/activities/reader/WordSelectionScan.h
@@ -59,7 +59,7 @@ class WordSelectionScan {
   // geometry (column/row/x/y) must stop here: context cells carry no position, and 0/0 is a valid
   // vertical cell. Text building may read past it -- that is what the context is for.
   size_t onPageGlyphCount() const { return contextStart; }
-  static constexpr int kLookupContextChars = 8;
+  static constexpr int kLookupContextChars = 8;  // == kMaxLookupChars, asserted below
 
   // Run scan/filter work for up to maxMillis (pass UINT32_MAX to run to completion).
   // Returns true when the scan is fully done.
@@ -128,6 +128,9 @@ class WordSelectionScan {
 
   // Shared helpers, also used by EpubReaderWordLookupActivity's runtime lookups.
   static constexpr int kMaxLookupChars = 8;
+  // The context is exactly one lookup window: a word beginning on the last on-page character
+  // reaches at most kMaxLookupChars - 1 further, and nothing past that can ever be matched.
+  static_assert(kLookupContextChars == kMaxLookupChars, "context must cover one lookup window");
   static void encodeUtf8(uint32_t cp, std::string& out);
   static bool isLookupableChar(uint32_t cp);
   static bool isKatakana(uint32_t cp);

--- a/src/activities/reader/WordSelectionScan.h
+++ b/src/activities/reader/WordSelectionScan.h
@@ -55,6 +55,10 @@ class WordSelectionScan {
   // matter: WordLookup's longest window is MAX_WINDOW_CHARS (8), so a word beginning on the last
   // on-page character reaches at most 7 further.
   void appendLookupContext(const std::string& utf8, uint32_t paragraphIndex);
+  // Number of leading allGlyphs entries that are really on the page. Anything reading a glyph's
+  // geometry (column/row/x/y) must stop here: context cells carry no position, and 0/0 is a valid
+  // vertical cell. Text building may read past it -- that is what the context is for.
+  size_t onPageGlyphCount() const { return contextStart; }
   static constexpr int kLookupContextChars = 8;
 
   // Run scan/filter work for up to maxMillis (pass UINT32_MAX to run to completion).

--- a/src/activities/reader/WordSelectionScan.h
+++ b/src/activities/reader/WordSelectionScan.h
@@ -44,6 +44,19 @@ class WordSelectionScan {
   // Manga mode: a plain UTF-8 text blob (panel or combined page text). Newlines are dropped.
   void initFromUtf8Text(const std::string& text);
 
+  // Append the start of the NEXT page as lookup context, so a word split across the page boundary
+  // can still be segmented and looked up. Call after an initFrom*(); paragraphIndex is the next
+  // page's first paragraph, which makes the check free: the text builder already stops at a
+  // paragraph change, so context from a DIFFERENT paragraph is ignored without a special case.
+  //
+  // Context only. These glyphs carry no page position and never become selectable -- the reader
+  // cannot put a cursor on a character that is not on screen -- so they extend what a word at the
+  // page end can MATCH without adding anywhere new to point at. 8 characters is the most that can
+  // matter: WordLookup's longest window is MAX_WINDOW_CHARS (8), so a word beginning on the last
+  // on-page character reaches at most 7 further.
+  void appendLookupContext(const std::string& utf8, uint32_t paragraphIndex);
+  static constexpr int kLookupContextChars = 8;
+
   // Run scan/filter work for up to maxMillis (pass UINT32_MAX to run to completion).
   // Returns true when the scan is fully done.
   bool step(uint32_t maxMillis);
@@ -79,6 +92,9 @@ class WordSelectionScan {
   std::vector<GlyphRef> allGlyphs;         // Full glyph list for building lookup text
   std::vector<GlyphRef> selectableGlyphs;  // Positions with a dictionary match
   std::vector<size_t> selectToAllIdx;      // Maps selectableGlyphs index -> allGlyphs index
+  // First index in allGlyphs that is off-page lookup context (see appendLookupContext).
+  // allGlyphs.size() when there is none, so it is always a valid "end of the page" bound.
+  size_t contextStart = 0;
 
   // Where the walk currently sits in allGlyphs. Every cell's page position is known from
   // initFrom*(), but only segmented cells can be selected.


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Closes #201 — a Japanese word whose kanji straddle a page break can now be looked up.
* **What changes are included?** `WordSelectionScan::appendLookupContext()`, plus wiring in both the vertical and horizontal word-lookup paths.

### Which of the issue's two routes, and why

The issue offered "either try to avoid split words, or allow look-up of a word that's been just split". **Avoiding the split is the expensive one**: Japanese is unspaced, so the layout would have to consult the dictionary to find word boundaries at every line break — and it changes pagination for everyone. This takes the other route and extends what the *lookup* can see past the boundary, which touches nothing else.

### How

The scan builds its lookup text from the **current page's** glyphs, so the continuation was simply absent and the word resolved as a truncated fragment or not at all. `appendLookupContext()` appends the first **8** characters of the next page to `allGlyphs`.

Eight is exact rather than a guess: `WordLookup`'s longest window is `MAX_WINDOW_CHARS` (8), so a word beginning on the last on-page character reaches at most 7 further.

### Three properties it had to preserve

* **Context is never selectable.** The walk is bounded at `contextStart` rather than `allGlyphs.size()` — the reader cannot put a cursor on a character that is not on screen, so these extend what a word can MATCH, not what there is to point at.
* **The highlight stays on the page.** `matchLen` draws the highlight box, so a match running past the boundary is clamped to the cells that exist here. The match itself is untouched — resolving the split word is the entire point.
* **The paragraph guard is free.** Context carries the NEXT page's paragraph index, and the text builder already stops at a paragraph change, so context from a new paragraph is ignored with no special case.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well (the issue notes stock CJK support is poor to none).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **A cache-pointer hazard worth reviewing.** The vertical path extracts the tail **before** fetching the current page: `getPage()` hands out a pointer into the section's page cache, so asking for another page can invalidate the one already held (the same contract `warmNextPageImageCache()` documents). The horizontal path uses `loadPageAt()`, which returns an owned page, so ordering does not matter there — the two are deliberately different and both are commented.
* **Existing `wlscan.bin` scan caches miss once and rebuild.** The file self-validates on a hash of `allGlyphs`, which now includes the context. That is the correct outcome — the scan result really did change — and costs one slower first lookup per page.
* **Memory:** at most 8 extra `GlyphRef` entries per page (~160 bytes), and only when a next page exists. No new allocations on the render path.
* **Both paths are wired**, vertical and horizontal: a Japanese book read with vertical text off has the same problem.
* **Device-tested** on X4 with a vertical Japanese book: a word split across the boundary now resolves.
* **What reviewers should check**: that a word at the very end of a *chapter* (no next page) still behaves — `contextStart` is set to `allGlyphs.size()` by every `initFrom*()`, so it is a valid bound before any context call.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
