### PR TITLE
feat: look up words split by layout hyphenation

### DIFF
--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -71,6 +71,7 @@ void DictionaryWordSelectActivity::extractWords() {
   std::string pageText;
   pageText.reserve(2048);
   uint8_t styleMask = 0;
+  int16_t pendingHyphen = -1;  // line-final word ending in '-', awaiting its remainder
 
   for (const auto& element : page->elements) {
     if (element->getTag() != TAG_PageLine) continue;
@@ -80,6 +81,7 @@ void DictionaryWordSelectActivity::extractWords() {
 
     bool rowHasWords = false;
     const int lineFontId = block->getBlockStyle().resolveFontId(fontId);
+    const uint16_t lastWordIndex = block->wordCount() > 0 ? static_cast<uint16_t>(block->wordCount() - 1) : 0;
     const int ascender = renderer.getFontAscenderSize(lineFontId);
     const int rubyShift = block->getRubyShift(ascender);
     for (uint16_t i = 0; i < block->wordCount(); i++) {
@@ -97,7 +99,20 @@ void DictionaryWordSelectActivity::extractWords() {
       // word alone, exactly as TextBlock::render resolves it. 0 = no override.
       const int32_t wordFont = block->wordFont(i);
       box.fontId = wordFont != 0 ? static_cast<int>(wordFont) : lineFontId;
+      // Link a hyphenated pair as it is discovered: the prefix was remembered when its line ended,
+      // and this is the first selectable word of the next line -- the remainder.
+      if (pendingHyphen >= 0) {
+        words[static_cast<size_t>(pendingHyphen)].joinNext = static_cast<int16_t>(words.size());
+        box.joinPrev = pendingHyphen;
+        pendingHyphen = -1;
+      }
       words.push_back(box);
+      // A trailing hyphen on the LINE'S last word is layout hyphenation, not the author's text.
+      // Remember it so the next line's first word can be joined to it.
+      if (i == lastWordIndex) {
+        const size_t len = strlen(text);
+        if (len > 1 && text[len - 1] == '-') pendingHyphen = static_cast<int16_t>(words.size() - 1);
+      }
       rowHasWords = true;
 
       pageText.append(text);
@@ -112,6 +127,36 @@ void DictionaryWordSelectActivity::extractWords() {
   for (auto& word : words) {
     word.width = static_cast<int16_t>(renderer.getTextAdvanceX(word.fontId, word.text, word.style));
   }
+}
+
+// Either half of a hyphenated pair looks up the whole word: "any-" joins the remainder that
+// follows it, "one" joins the prefix before it. The hyphen itself is dropped -- layout put it
+// there, the author did not. Words that are not part of a split are returned untouched, with no
+// allocation.
+const char* DictionaryWordSelectActivity::lookupTextFor(const size_t index, std::string& scratch) const {
+  const WordBox& box = words[index];
+  const WordBox* prefix = nullptr;
+  const WordBox* remainder = nullptr;
+  if (box.joinNext >= 0 && static_cast<size_t>(box.joinNext) < words.size()) {
+    prefix = &box;
+    remainder = &words[static_cast<size_t>(box.joinNext)];
+  } else if (box.joinPrev >= 0 && static_cast<size_t>(box.joinPrev) < words.size()) {
+    prefix = &words[static_cast<size_t>(box.joinPrev)];
+    remainder = &box;
+  } else {
+    return box.text;
+  }
+  scratch.assign(prefix->text);
+  if (!scratch.empty() && scratch.back() == '-') scratch.pop_back();
+  scratch.append(remainder->text);
+  return scratch.c_str();
+}
+
+const DictionaryWordSelectActivity::WordBox* DictionaryWordSelectActivity::joinedPartner(const size_t index) const {
+  const WordBox& box = words[index];
+  const int16_t other = box.joinNext >= 0 ? box.joinNext : box.joinPrev;
+  if (other < 0 || static_cast<size_t>(other) >= words.size()) return nullptr;
+  return &words[static_cast<size_t>(other)];
 }
 
 int DictionaryWordSelectActivity::wordHeight(const WordBox& word) const {
@@ -189,7 +234,9 @@ void DictionaryWordSelectActivity::performLookup() {
   std::string definition;
   std::string headword;
   Dictionary::LookupResult result = Dictionary::LookupResult::NotFound;
-  const bool found = ok && dict.lookup(words[selected].text, definition, headword, &result);
+  std::string joined;
+  const bool found =
+      ok && dict.lookup(lookupTextFor(static_cast<size_t>(selected), joined), definition, headword, &result);
 
   if (found) {
     popup = Popup::None;
@@ -335,6 +382,11 @@ void DictionaryWordSelectActivity::loop() {
 // next cursor move must do a full repaint.
 bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   const WordBox& word = words[selected];
+  // A hyphenated word is highlighted in both halves, so the reader sees the whole word they are
+  // looking up rather than the fragment on this line. The second box sits on another line, which
+  // one saved region cannot restore -- so the snapshot fast path is skipped and the next cursor
+  // move repaints fully. That costs a refresh only on the rare split word.
+  const WordBox* partner = joinedPartner(static_cast<size_t>(selected));
   int hx = word.x - 2;
   int hy = word.y - 2;
   int hw = word.width + 4;
@@ -350,7 +402,7 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   }
 
   bool saved = false;
-  if (snapshot && hw > 0 && hh > 0) {
+  if (!partner && snapshot && hw > 0 && hh > 0) {
     saved = renderer.readFramebufferRegion(hx, hy, hw, hh, snapshot.get(), SNAPSHOT_CAPACITY) > 0;
   }
   snapshotX = static_cast<int16_t>(hx);
@@ -364,6 +416,24 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
   // word out in, so drawing it in a different size spills white glyphs past the black panel and
   // over the neighbouring words (the page's own ink is only erased inside the box).
   renderer.drawText(word.fontId, word.x, word.y, word.text, false, word.style);
+  if (partner) {
+    int px = partner->x - 2;
+    int py = partner->y - 2;
+    int pw = partner->width + 4;
+    int ph = wordHeight(*partner) + 4;
+    if (px < 0) {
+      pw += px;
+      px = 0;
+    }
+    if (py < 0) {
+      ph += py;
+      py = 0;
+    }
+    if (pw > 0 && ph > 0) {
+      renderer.fillRect(px, py, pw, ph, true);
+      renderer.drawText(partner->fontId, partner->x, partner->y, partner->text, false, partner->style);
+    }
+  }
   return saved;
 }
 

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -74,10 +74,18 @@ void DictionaryWordSelectActivity::extractWords() {
   int16_t pendingHyphen = -1;  // line-final word ending in '-', awaiting its remainder
 
   for (const auto& element : page->elements) {
-    if (element->getTag() != TAG_PageLine) continue;
+    // Layout hyphenation only ever continues onto the IMMEDIATELY following text line, so
+    // anything else in between (an image, a line with no usable block) disarms the join.
+    if (element->getTag() != TAG_PageLine) {
+      pendingHyphen = -1;
+      continue;
+    }
     const auto* line = static_cast<const PageLine*>(element.get());
     const auto& block = line->getBlock();
-    if (!block || !block->valid()) continue;
+    if (!block || !block->valid()) {
+      pendingHyphen = -1;
+      continue;
+    }
 
     bool rowHasWords = false;
     const int lineFontId = block->getBlockStyle().resolveFontId(fontId);
@@ -119,7 +127,12 @@ void DictionaryWordSelectActivity::extractWords() {
       pageText.push_back(' ');
       styleMask |= static_cast<uint8_t>(1u << (static_cast<uint8_t>(box.style) & 0x03));
     }
-    if (rowHasWords) rowCount++;
+    if (rowHasWords) {
+      rowCount++;
+    } else {
+      // A line with nothing selectable on it: same rule, the pending prefix cannot reach past it.
+      pendingHyphen = -1;
+    }
   }
 
   if (styleMask == 0) styleMask = 0x01;  // REGULAR

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -45,7 +45,19 @@ class DictionaryWordSelectActivity final : public Activity {
     // one font and repainting the word with another sizes the highlight for text that is not
     // there -- see drawHighlightWithSnapshot.
     int fontId;
+    // Layout hyphenation splits a word across a line break ("any-" / "one"), and each half reaches
+    // this list as its own selectable token. These link the two halves so either one looks up the
+    // whole word; -1 when the word is not part of a split. Indices into `words`.
+    int16_t joinNext = -1;  // set on the "any-" half: index of the remainder
+    int16_t joinPrev = -1;  // set on the "one" half: index of the hyphenated prefix
   };
+  // The word to look up for a box, joining a hyphenated pair back together. Returns a reference
+  // into `scratch` when a join happened, so the caller owns the storage.
+  const char* lookupTextFor(size_t index, std::string& scratch) const;
+  // The other half of a hyphenated pair, or nullptr. Both halves are highlighted together: the
+  // reader selected one word, and showing only the half they pointed at makes the selection look
+  // like it stopped at the line break.
+  const WordBox* joinedPartner(size_t index) const;
 
   enum class Popup : uint8_t { None, NotFound, Error };
 

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -270,12 +270,14 @@ void WordSelectionScan::initFromPage(const Page& page) {
       continue;
     }
     const TextBlock& block = *line.getBlock();
+    bool lineHadWord = false;
     for (uint16_t wi = 0; wi < block.wordCount(); wi++) {
       if (oom) break;
       // The arena stores words as NUL-terminated spans, not std::strings (upstream 1.5.0).
       // Braces, not parens: Arduino.h defines a function-like `word(...)` macro.
       std::string_view word{block.wordText(wi), block.wordTextLen(wi)};
       if (word.empty()) continue;
+      lineHadWord = true;
       // A word broken by layout hyphenation ends the line with a hyphen the AUTHOR never wrote
       // ("Mu-" / "sik"), and the two halves reach the scan as separate words. Drop that hyphen and
       // suppress the space after it, so the lookup text reads "Musik" and the word resolves (#225).
@@ -323,6 +325,9 @@ void WordSelectionScan::initFromPage(const Page& page) {
         lastCp = cp;
       }
     }
+    // A line that emitted nothing (an empty block) is still a line in between: the pending join
+    // cannot reach across it.
+    if (!lineHadWord) joinToPrevious = false;
   }
   scanTruncated = oom;
   // No upfront reserve for selectableGlyphs: only ~5% of positions become selectable, so

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -258,9 +258,17 @@ void WordSelectionScan::initFromPage(const Page& page) {
   bool joinToPrevious = false;  // previous line ended on a layout hyphen; see below
   for (const auto& el : page.elements) {
     if (oom) break;
-    if (el->getTag() != TAG_PageLine) continue;
+    // Layout hyphenation only ever continues onto the IMMEDIATELY following text line, so
+    // anything else in between (an image, a line with no block) disarms the join.
+    if (el->getTag() != TAG_PageLine) {
+      joinToPrevious = false;
+      continue;
+    }
     const auto& line = static_cast<const PageLine&>(*el);
-    if (!line.getBlock()) continue;
+    if (!line.getBlock()) {
+      joinToPrevious = false;
+      continue;
+    }
     const TextBlock& block = *line.getBlock();
     for (uint16_t wi = 0; wi < block.wordCount(); wi++) {
       if (oom) break;

--- a/src/activities/reader/WordSelectionScan.cpp
+++ b/src/activities/reader/WordSelectionScan.cpp
@@ -255,6 +255,7 @@ void WordSelectionScan::initFromPage(const Page& page) {
   };
   uint32_t lastCp = 0;
   bool oom = false;
+  bool joinToPrevious = false;  // previous line ended on a layout hyphen; see below
   for (const auto& el : page.elements) {
     if (oom) break;
     if (el->getTag() != TAG_PageLine) continue;
@@ -265,16 +266,29 @@ void WordSelectionScan::initFromPage(const Page& page) {
       if (oom) break;
       // The arena stores words as NUL-terminated spans, not std::strings (upstream 1.5.0).
       // Braces, not parens: Arduino.h defines a function-like `word(...)` macro.
-      const std::string_view word{block.wordText(wi), block.wordTextLen(wi)};
+      std::string_view word{block.wordText(wi), block.wordTextLen(wi)};
       if (word.empty()) continue;
-      // Insert a separating space only between two ASCII-word boundaries.
-      if (lastCp && isAsciiWord(static_cast<unsigned char>(lastCp)) &&
+      // A word broken by layout hyphenation ends the line with a hyphen the AUTHOR never wrote
+      // ("Mu-" / "sik"), and the two halves reach the scan as separate words. Drop that hyphen and
+      // suppress the space after it, so the lookup text reads "Musik" and the word resolves (#225).
+      //
+      // Only a LINE-FINAL hyphen qualifies, which is the strongest signal available here: the
+      // layout's own continuation flag lives in ParsedText and does not survive into the page. A
+      // real hyphen falling at a line end is therefore joined too. That is deliberate -- a wrong
+      // join simply finds nothing, exactly as today, while the right one is the whole feature.
+      const bool lineFinal = wi + 1 == block.wordCount();
+      const bool joinHyphen = lineFinal && word.size() > 1 && word.back() == '-';
+      if (joinHyphen) word.remove_suffix(1);
+      // Insert a separating space only between two ASCII-word boundaries -- unless the previous
+      // line ended mid-word, where a space is exactly what must not appear.
+      if (!joinToPrevious && lastCp && isAsciiWord(static_cast<unsigned char>(lastCp)) &&
           isAsciiWord(static_cast<unsigned char>(word[0]))) {
         if (!pushGlyphSafe(allGlyphs, GlyphRef{0, 0, 0, 0, ' ', 0, 0})) {
           oom = true;
           break;
         }
       }
+      joinToPrevious = joinHyphen;
       size_t b = 0;
       while (b < word.size()) {
         auto c0 = static_cast<unsigned char>(word[b]);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Closes #225 — a word hyphenated for layout ("Mu-" / "sik") can now be looked up, and shows as one selection.
* **What changes are included?** Linking the two halves in `DictionaryWordSelectActivity`, joining them at lookup time, highlighting both, and the same join in the Japanese path's `WordSelectionScan`.

### The problem

Layout hyphenation appends a literal `'-'` to the prefix and inserts the remainder as a separate word ([ParsedText.cpp:1538](../blob/develop/lib/Epub/Epub/ParsedText.cpp)). Both halves reach the word list as their own selectable tokens, so selecting either searched a fragment.

### The fix

A trailing hyphen on the **line's last word** is layout hyphenation, so the next line's first selectable word is its remainder. The halves are linked when the list is built, and `lookupTextFor()` rebuilds the whole word at lookup time with the hyphen dropped.

**Either half resolves** — "any-" joins forward, "one" joins back. Nothing on the page tells the reader which half to point at, so both had to work.

**Both halves highlight together.** Showing only the fragment the reader pointed at makes the selection look like it stopped at the line break, when the word being looked up is the whole thing.

### Two costs, both deliberate

* **Links are two `int16_t` indices per `WordBox`, not an owned string.** At ~200 words a page a `std::string` each would be 5–6 KB; the joined text is built only for the word actually selected.
* **A split word skips the highlight snapshot fast path**, so moving the cursor off it repaints fully. Two boxes on different lines cannot be restored from one saved region, and a second buffer is real RAM for a rare case. Every other word keeps the fast path.

### The judgement call

Only a **line-final** hyphen qualifies — the strongest signal available here, since the layout's own continuation flag lives in `ParsedText` and does not survive into the page data. A *real* hyphen falling at a line end ("Nord-" / "Ost") is therefore joined too.

That is deliberate: **a wrong join finds nothing, exactly as today, while the right one is the whole feature.** The failure mode is unchanged; only the success case is new. The residual risk is a wrong join landing on a real word and showing a plausible-but-wrong definition, judged rare enough not to build machinery for. The strict alternative is plumbing `wordContinues` through `TextBlock` into the page format — a `section.bin` version bump and a per-word bit, for a case that currently costs nothing when it misses.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Device-tested** on X4: a hyphenated German/English word now resolves from either half, with both halves highlighted.
* **`WordSelectionScan` carries the same join and is NOT device-tested.** It is the Japanese word lookup's equivalent path, where a Latin word inside a Japanese book hyphenates identically — the same bug in the sibling path. Exercising it needs a JP book containing hyphenated Latin text. Flagging rather than implying it was verified; happy to split it out if a maintainer would rather not take an untested path.
* Existing `wlscan.bin` scan caches rebuild once, since the glyph stream changed (that file self-validates on a hash of it).
* Memory: 4 bytes per `WordBox` for the links; no new allocations except the joined string for the selected word.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
