### PR TITLE
fix: Insights: swipe to scroll

### DIFF
--- a/src/activities/home/ReadingStatsActivity.cpp
+++ b/src/activities/home/ReadingStatsActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalClock.h>
 #include <I18n.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <ctime>
@@ -76,6 +77,19 @@ void ReadingStatsActivity::loop() {
     StatsWidgets::stepMonth(calYear, calMonth, +1);
     requestUpdate();
   }
+  // Swipe to scroll, a page at a time — the same gesture and direction the
+  // lists use (swipe up to go forward). The keys below stay the fine control.
+  const auto swipe = mappedInput.wasSwipe();
+  if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
+    const int delta = swipe == MappedInputManager::SwipeDir::Up ? scrollPageHeight : -scrollPageHeight;
+    const int target = std::clamp(scrollOffset + delta, 0, maxScrollOffset);
+    if (target != scrollOffset) {
+      scrollOffset = target;
+      requestUpdate();
+    }
+    return;
+  }
+
   // Up/Down to scroll
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::ScreenDown}, [this] {
     if (scrollOffset < maxScrollOffset) {
@@ -154,6 +168,7 @@ void ReadingStatsActivity::render(RenderLock&&) {
   const int visibleHeight = renderer.getScreenHeight() - headerBottom - 50;  // 50 for button hints
   maxScrollOffset = contentEndY - headerBottom - visibleHeight + scrollOffset;
   if (maxScrollOffset < 0) maxScrollOffset = 0;
+  scrollPageHeight = visibleHeight;
 
   // Redraw header on top of scrolled content so text doesn't bleed through.
   // Clear only up to the header line, then redraw the header (which draws the line).

--- a/src/activities/home/ReadingStatsActivity.h
+++ b/src/activities/home/ReadingStatsActivity.h
@@ -8,6 +8,11 @@ class ReadingStatsActivity final : public Activity {
   bool backLongPressFired = false;
   int scrollOffset = 0;
   int maxScrollOffset = 0;
+  // One swipe's worth of scroll, in px. render() owns it because the visible
+  // height is only known once the header and button hints have been measured;
+  // it stays 0 until the first frame, which is also when maxScrollOffset is
+  // still 0, so an early swipe is a no-op either way.
+  int scrollPageHeight = 0;
   // Calendar month navigation
   uint16_t calYear = 0;
   uint8_t calMonth = 1;


### PR DESCRIPTION
## Problem

`ReadingStatsActivity` has no touch handling at all — scrolling is Up/Down keys only. On a touch board it is the one screen where a swipe does nothing, and its content is taller than the panel (the month calendar runs past the bottom edge at 800x480), so it reads as content that simply cannot be reached.

Found while testing the iPhone build of the simulator, but it is not iOS-specific — an X4 Pro behaves the same way.

## Change

Handle `SwipeDir::Up`/`Down` the way `UiListActivity` already does: a page per swipe, same direction (swipe up goes forward), clamped to the existing `maxScrollOffset`. The keys keep their 40px fine step.

`render()` publishes the page size, since the visible height is only known once the header and button hints have been measured. It stays 0 until the first frame — which is also when `maxScrollOffset` is still 0 — so a swipe before the first render is a no-op either way.

Left/right swipes are deliberately not bound. The Left/Right *keys* step the calendar month, but a horizontal swipe is a page turn elsewhere in the firmware (reader, BMP viewer), so overloading it here would be inconsistent. Happy to add it if you'd rather have it.

## Testing

Exercised on the iOS simulator build (X4 Pro profile):

- swipe up scrolls to the end of the calendar, revealing the rows that were clipped
- swipe down returns to the top
- both clamp at the ends
- the Up/Down keys still step by 40px, unchanged

Note on the build: `develop` does not currently compile against the simulator fork — `UsbDriveActivity.h` errors on an unstubbed `UsbDriveState`, which is pre-existing and unrelated. The runtime testing above was done on the `merge/upstream-develop-2026-08-26` tree, where the identical change builds and runs. Against `develop` this file was verified with a standalone `-fsyntax-only` compile using its own build flags.

## Note
Improves #160 