### PR TITLE
chore: bump version to 1.6.0-nightly-3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.6.0-nightly-2
+version = 1.6.0-nightly-3
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Move the version to the next nightly.
* **What changes are included?** One line in `platformio.ini`: `version = 1.6.0-nightly-2` → `1.6.0-nightly-3`.

Every environment reads `CROSSPOINT_VERSION` from `${crosspoint.version}`, so the single key covers all of them, plus the `-rc`, `-slim`, `-x4pro`, `-x4c` and `-papermono` suffixed variants.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — n/a, this is a version bump.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No behavioural change beyond the string the About screen and the build banner report.
* Memory / flash impact: none.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdvaBWbBEVp3JaKnVjC4A9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdvaBWbBEVp3JaKnVjC4A9)_