### PR TITLE
fix: Library: hit-test the tab bar where the labels are drawn

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -798,6 +798,20 @@ void RecentBooksActivity::warmOnePendingProgress() {
   // No requestUpdate: visible entries are still filled synchronously during their render.
 }
 
+std::vector<TabInfo> RecentBooksActivity::buildTabs() const {
+  std::vector<TabInfo> tabs;
+  tabs.reserve(TAB_COUNT);
+  tabs.push_back({tr(STR_TAB_BOOKS), selectedTab == 0});
+  tabs.push_back({tr(STR_TAB_SHELVES), selectedTab == 1});
+  return tabs;
+}
+
+Rect RecentBooksActivity::tabBarRect() const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  return Rect{0, static_cast<int16_t>(metrics.topPadding + metrics.headerHeight),
+              static_cast<int16_t>(renderer.getScreenWidth()), static_cast<int16_t>(metrics.tabBarHeight)};
+}
+
 void RecentBooksActivity::loadShelves() {
   shelvesLoaded = true;
   shelves.clear();
@@ -1099,19 +1113,27 @@ void RecentBooksActivity::loop() {
     const int gridHeight = renderer.getScreenHeight() - gridTop - m.buttonHintsHeight - m.verticalSpacing;
     const int itemCount = getContentItemCount();
 
-    // Tab bar: two equal columns across the full width, matching GUI.drawTabBar's rect.
-    int tab = -1;
-    const auto tabTouch = mappedInput.colTouch(tab, 0, renderer.getScreenWidth() / TAB_COUNT, TAB_COUNT, tabBarY,
-                                               tabBarY + m.tabBarHeight);
-    if (tabTouch == MappedInputManager::RowTouch::Tap && tab >= 0 && tab != selectedTab) {
-      selectedTab = tab;
-      if (selectedTab == 1 && !shelvesLoaded) loadShelves();
-      contentIndex = 0;
-      scrollRow = 0;
-      requestUpdate();
+    // Tab bar: hit-test through the theme, which lays the targets out exactly as
+    // drawTabBar draws the labels -- same scroll offset, same skip rule, same text
+    // widths. Two equal columns across the full width did not match: the labels are
+    // packed to the left, so "Shelves" ignored a tap on the word and answered to one
+    // on empty space in the right half instead.
+    const Rect barRect = tabBarRect();
+    int tabX = 0;
+    int tabY = 0;
+    if (mappedInput.wasScreenTapped(tabX, tabY) && tabY >= barRect.y && tabY < barRect.y + barRect.height) {
+      int tab = -1;
+      if (GUI.tabIndexFromPoint(renderer, barRect, buildTabs(), tabX, tabY, tab) && tab != selectedTab) {
+        selectedTab = tab;
+        if (selectedTab == 1 && !shelvesLoaded) loadShelves();
+        contentIndex = 0;
+        scrollRow = 0;
+        requestUpdate();
+      }
+      // The bar swallows the contact either way: a tap that lands in the gap between
+      // labels must not fall through to the grid below.
       return;
     }
-    if (tabTouch != MappedInputManager::RowTouch::None) return;
 
     int gx = 0;
     int gy = 0;
@@ -1711,12 +1733,8 @@ void RecentBooksActivity::render(RenderLock&&) {
 
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, tr(STR_MENU_RECENT_BOOKS));
 
-  std::vector<TabInfo> tabs;
-  tabs.reserve(TAB_COUNT);
-  tabs.push_back({tr(STR_TAB_BOOKS), selectedTab == 0});
-  tabs.push_back({tr(STR_TAB_SHELVES), selectedTab == 1});
   const int tabBarY = metrics.topPadding + metrics.headerHeight;
-  GUI.drawTabBar(renderer, Rect{0, tabBarY, pageWidth, metrics.tabBarHeight}, tabs, contentIndex == 0);
+  GUI.drawTabBar(renderer, tabBarRect(), buildTabs(), contentIndex == 0);
 
   const int contentTop = tabBarY + metrics.tabBarHeight + metrics.verticalSpacing;
   const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "RecentBooksStore.h"
+#include "components/UITheme.h"  // TabInfo, Rect
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
@@ -85,6 +86,10 @@ class RecentBooksActivity final : public Activity {
 
   void loadRecentBooks();
   void loadBookProgress();
+  // One definition of the tab bar, used by both the renderer and the hit test, so the
+  // labels and the touch targets cannot drift apart.
+  [[nodiscard]] std::vector<TabInfo> buildTabs() const;
+  [[nodiscard]] Rect tabBarRect() const;
   void loadShelves();
   void loadShelfBooks(const std::string& folderPath);
   int readProgressPercent(const std::string& bookPath) const;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -11,8 +11,8 @@
 #include <vector>
 
 #include "RecentBooksStore.h"
-#include "components/UITheme.h"  // TabInfo, Rect
 #include "activities/Activity.h"
+#include "components/UITheme.h"  // TabInfo, Rect
 #include "util/ButtonNavigator.h"
 
 class RecentBooksActivity final : public Activity {


### PR DESCRIPTION
## Problem

The Library's tab bar split its touch targets into two equal columns across the full panel width:

```cpp
mappedInput.colTouch(tab, 0, renderer.getScreenWidth() / TAB_COUNT, TAB_COUNT, ...)
```

but `drawTabBar` packs the labels to the left. On an 800x480 panel in portrait that puts **"Shelves" at roughly x 107–183 while its hit area is x 240–479**. Tapping the word does nothing; the tab switches only on a tap somewhere in the empty right half. Because the Books half absorbs taps on either label, and Books is the default tab, the bar looks simply dead.

Found while testing the Library on the iPhone build, but it is not iOS-specific — an X4 Pro behaves the same.

## Change

Use the theme's own `tabIndexFromPoint`. It walks the same positions `drawTabBar` does — same scroll offset, same skip rule for off-screen tabs, same measured text widths — so the targets follow the labels by construction rather than by two layouts happening to agree. It was already implemented on `BaseTheme`, `LyraTheme` and `RoundedRaffTheme`, with nothing calling it.

The bar now swallows the contact whether or not a tab was hit, so a tap in the gap between labels cannot fall through to the grid below.

Also gives the tab list and the bar rect one definition each (`buildTabs()`, `tabBarRect()`), used by both `render()` and the hit test, so they cannot drift apart again.

## Testing

On the iOS simulator build with the X4 Pro profile:

- tapping the **"Shelves"** label switches to Shelves (previously did nothing)
- tapping the **"Books"** label switches back
- covers still open books, shelf rows still open shelves, and key navigation is unchanged
