### PR TITLE
fix: Library: swipe scrolls the grid, and the selector is key-only

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -299,8 +299,8 @@ int RecentBooksActivity::shelvesVisibleItems(const int contentHeight) const {
 }
 
 int RecentBooksActivity::shelvesScrollOffset(const int visibleItems) const {
-  const int selectedItem = contentIndex - 1;  // index 0 is the tab bar
-  return selectedItem >= visibleItems ? selectedItem - visibleItems + 1 : 0;
+  const int maxOffset = std::max(0, static_cast<int>(shelves.size()) - visibleItems);
+  return std::clamp(shelvesScroll, 0, maxOffset);
 }
 
 // The Shelves tab is a list of full-width rows, NOT the cover grid: hit-testing it with
@@ -962,6 +962,7 @@ void RecentBooksActivity::onEnter() {
   selectedTab = 0;
   contentIndex = 0;
   scrollRow = 0;
+  shelvesScroll = 0;
   openShelfIndex = -1;
   requestUpdate();
 }
@@ -1147,14 +1148,22 @@ void RecentBooksActivity::loop() {
   const auto swipe = mappedInput.wasSwipe();
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
     hideSelector();  // a swipe is a touch on either tab
-    // Books tab only: the Shelves tab is a list that scrolls by its own offset, derived from the
-    // selection in renderShelvesTab. scrollRow drives the cover grid alone, so moving it there
-    // would scroll nothing on screen while quietly displacing the grid's viewport.
+    // Each tab scrolls its own viewport: the cover grid by rows of GRID_COLS, the Shelves list by
+    // single rows. Neither moves the selection -- that is what the gesture means here.
+    const int step = swipe == MappedInputManager::SwipeDir::Up ? 1 : -1;
     if (selectedTab == 0) {
       const int maxRow = maxScrollRow(gridContentHeight());
-      const int moved = std::clamp(scrollRow + (swipe == MappedInputManager::SwipeDir::Up ? 1 : -1), 0, maxRow);
+      const int moved = std::clamp(scrollRow + step, 0, maxRow);
       if (moved != scrollRow) {
         scrollRow = moved;
+        requestUpdate();
+      }
+    } else {
+      const int visibleItems = shelvesVisibleItems(gridContentHeight());
+      const int maxOffset = std::max(0, static_cast<int>(shelves.size()) - visibleItems);
+      const int moved = std::clamp(shelvesScroll + step, 0, maxOffset);
+      if (moved != shelvesScroll) {
+        shelvesScroll = moved;
         requestUpdate();
       }
     }
@@ -1190,6 +1199,7 @@ void RecentBooksActivity::loop() {
         if (selectedTab == 1 && !shelvesLoaded) loadShelves();
         contentIndex = 0;
         scrollRow = 0;
+        shelvesScroll = 0;
         requestUpdate();
       }
       // The bar swallows the contact either way: a tap that lands in the gap between
@@ -1256,6 +1266,7 @@ void RecentBooksActivity::loop() {
     if (contentIndex > 0) {
       contentIndex = 0;
       scrollRow = 0;
+      shelvesScroll = 0;
       selectorVisible = true;
       requestUpdate();
     } else {
@@ -1293,6 +1304,7 @@ void RecentBooksActivity::loop() {
   if (hasChangedTab) {
     contentIndex = (contentIndex == 0) ? 0 : 1;
     scrollRow = 0;
+    shelvesScroll = 0;
     // Only the keys reach here -- a tab tap is handled in the touch block and returns -- so the
     // cursor comes back on, wherever a touch left it.
     selectorVisible = true;
@@ -1589,6 +1601,13 @@ void RecentBooksActivity::renderShelvesTab(int contentTop, int contentHeight) {
   const int visibleItems = shelvesVisibleItems(contentHeight);
   const int selectedItem = contentIndex - 1;
   const int shelfCount = static_cast<int>(shelves.size());
+
+  // Only the key cursor drags the list with it; after a swipe the offset is the user's. Same
+  // split as renderBooksTab's, and for the same reason -- see the comment there.
+  if (selectorVisible && selectedItem >= 0) {
+    if (selectedItem < shelvesScroll) shelvesScroll = selectedItem;
+    if (selectedItem >= shelvesScroll + visibleItems) shelvesScroll = selectedItem - visibleItems + 1;
+  }
   const int scrollOffset = shelvesScrollOffset(visibleItems);
 
   // Prewarm the font cache with all visible folder names before drawing. Folder names are drawn

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -276,6 +276,22 @@ int RecentBooksActivity::getVisibleRows(int cellHeight, int contentHeight) const
   return std::max(1, (contentHeight + GRID_ROW_GAP) / (cellHeight + GRID_ROW_GAP));
 }
 
+int RecentBooksActivity::gridContentHeight() const {
+  const auto& m = UITheme::getInstance().getMetrics();
+  const int gridTop = m.topPadding + m.headerHeight + m.tabBarHeight + m.verticalSpacing;
+  return renderer.getScreenHeight() - gridTop - m.buttonHintsHeight - m.verticalSpacing;
+}
+
+int RecentBooksActivity::maxScrollRow(const int contentHeight) const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const int cellWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / GRID_COLS;
+  if (cellWidth <= 0) return 0;
+  const int visibleRows = getVisibleRows(getCellHeight(cellWidth), contentHeight);
+  const int itemCount = getContentItemCount();
+  const int totalRows = (itemCount + GRID_COLS - 1) / GRID_COLS;
+  return std::max(0, totalRows - visibleRows);
+}
+
 int RecentBooksActivity::gridIndexAtPoint(const int x, const int y, const int contentTop, const int contentHeight,
                                           const int scrollRowIn, const int itemCount) const {
   if (itemCount <= 0) return -1;
@@ -1073,15 +1089,19 @@ void RecentBooksActivity::loop() {
   }
 
   // Upstream's flat recents list (selectorIndex + handleListTouch) doesn't exist here: this
-  // screen is a tabbed cover GRID addressed by contentIndex/scrollRow. Swipes move one grid
-  // row; Back stays with the tab/shelf-aware handler below rather than always going home.
+  // screen is a tabbed cover GRID addressed by contentIndex/scrollRow. Back stays with the
+  // tab/shelf-aware handler below rather than always going home.
+  //
+  // A swipe scrolls the viewport and leaves the selection alone, the way a phone does.
+  // Moving the selector by GRID_COLS instead, as this used to, skipped two of every three
+  // books: the covers between the old and new row could not be reached by swiping at all.
   const auto swipe = mappedInput.wasSwipe();
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
-    const int totalItems = getContentItemCount() + 1;
-    const int delta = (swipe == MappedInputManager::SwipeDir::Up) ? GRID_COLS : -GRID_COLS;
-    const int moved = std::clamp(contentIndex + delta, 0, std::max(0, totalItems - 1));
-    if (moved != contentIndex) {
-      contentIndex = moved;
+    const int maxRow = maxScrollRow(gridContentHeight());
+    const int moved = std::clamp(scrollRow + (swipe == MappedInputManager::SwipeDir::Up ? 1 : -1), 0, maxRow);
+    selectorVisible = false;
+    if (moved != scrollRow) {
+      scrollRow = moved;
       requestUpdate();
     }
     return;
@@ -1096,7 +1116,7 @@ void RecentBooksActivity::loop() {
     const int tabBarY = m.topPadding + m.headerHeight;
     // The tabbed views start BELOW the tab bar, unlike the loop-local contentTop above.
     const int gridTop = tabBarY + m.tabBarHeight + m.verticalSpacing;
-    const int gridHeight = renderer.getScreenHeight() - gridTop - m.buttonHintsHeight - m.verticalSpacing;
+    const int gridHeight = gridContentHeight();
     const int itemCount = getContentItemCount();
 
     // Tab bar: two equal columns across the full width, matching GUI.drawTabBar's rect.
@@ -1128,6 +1148,7 @@ void RecentBooksActivity::loop() {
     }
     if (mappedInput.wasScreenTouchDown(gx, gy)) {
       const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      selectorVisible = false;
       if (hit >= 0 && contentIndex != hit + 1) {
         contentIndex = hit + 1;  // index 0 is the tab bar
         requestUpdate();
@@ -1174,11 +1195,13 @@ void RecentBooksActivity::loop() {
 
   buttonNavigator.onNextRelease([this, totalItems] {
     contentIndex = ButtonNavigator::nextIndex(contentIndex, totalItems);
+    selectorVisible = true;
     requestUpdate();
   });
 
   buttonNavigator.onPreviousRelease([this, totalItems] {
     contentIndex = ButtonNavigator::previousIndex(contentIndex, totalItems);
+    selectorVisible = true;
     requestUpdate();
   });
 
@@ -1362,9 +1385,15 @@ void RecentBooksActivity::renderBooksTab(int contentTop, int contentHeight) {
   const int totalRows = (bookCount + GRID_COLS - 1) / GRID_COLS;
   const int selectedItem = contentIndex - 1;
 
+  // Only the key selector drags the viewport with it. After a swipe the scroll position is
+  // the user's, and snapping it back to wherever the selection happens to sit would undo the
+  // gesture on the very next frame.
   const int selectedRow = selectedItem >= 0 ? selectedItem / GRID_COLS : 0;
-  if (selectedRow < scrollRow) scrollRow = selectedRow;
-  if (selectedRow >= scrollRow + visibleRows) scrollRow = selectedRow - visibleRows + 1;
+  if (selectorVisible) {
+    if (selectedRow < scrollRow) scrollRow = selectedRow;
+    if (selectedRow >= scrollRow + visibleRows) scrollRow = selectedRow - visibleRows + 1;
+  }
+  scrollRow = std::clamp(scrollRow, 0, std::max(0, totalRows - visibleRows));
 
   // One extra row peeks behind the button bar as a "more below" hint (covers and badges show;
   // the hint bar overdraws the bottom). Its titles sit fully under the hints, so they are
@@ -1398,7 +1427,7 @@ void RecentBooksActivity::renderBooksTab(int contentTop, int contentHeight) {
     const int cellY = contentTop + row * rowStride;
     const int pct = idx < static_cast<int>(bookProgress.size()) ? bookProgress[idx].percent : -1;
     drawGridCell(cellX, cellY, cellWidth, cellHeight, recentBooks[idx].coverBmpPath, recentBooks[idx].title, pct,
-                 idx == selectedItem, /*drawTitle=*/idx <= titledLastIdx);
+                 selectorVisible && idx == selectedItem, /*drawTitle=*/idx <= titledLastIdx);
   }
 
   // Release the page slots claimed by the prewarm above -- see the matching comment in
@@ -1716,7 +1745,8 @@ void RecentBooksActivity::render(RenderLock&&) {
   tabs.push_back({tr(STR_TAB_BOOKS), selectedTab == 0});
   tabs.push_back({tr(STR_TAB_SHELVES), selectedTab == 1});
   const int tabBarY = metrics.topPadding + metrics.headerHeight;
-  GUI.drawTabBar(renderer, Rect{0, tabBarY, pageWidth, metrics.tabBarHeight}, tabs, contentIndex == 0);
+  GUI.drawTabBar(renderer, Rect{0, tabBarY, pageWidth, metrics.tabBarHeight}, tabs,
+                 selectorVisible && contentIndex == 0);
 
   const int contentTop = tabBarY + metrics.tabBarHeight + metrics.verticalSpacing;
   const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight - metrics.verticalSpacing;

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -292,6 +292,35 @@ int RecentBooksActivity::maxScrollRow(const int contentHeight) const {
   return std::max(0, totalRows - visibleRows);
 }
 
+int RecentBooksActivity::shelvesVisibleItems(const int contentHeight) const {
+  const int rowHeight = UITheme::getInstance().getMetrics().listWithSubtitleRowHeight;
+  if (rowHeight <= 0) return 1;
+  return std::max(1, contentHeight / rowHeight);
+}
+
+int RecentBooksActivity::shelvesScrollOffset(const int visibleItems) const {
+  const int selectedItem = contentIndex - 1;  // index 0 is the tab bar
+  return selectedItem >= visibleItems ? selectedItem - visibleItems + 1 : 0;
+}
+
+// The Shelves tab is a list of full-width rows, NOT the cover grid: hit-testing it with
+// gridIndexAtPoint's three columns and tall cells mapped a tap to whichever cover cell it
+// happened to fall in, so it opened the wrong shelf or none at all.
+int RecentBooksActivity::shelfRowAtPoint(const int x, const int y, const int contentTop,
+                                         const int contentHeight) const {
+  const int rowHeight = UITheme::getInstance().getMetrics().listWithSubtitleRowHeight;
+  const int shelfCount = static_cast<int>(shelves.size());
+  if (rowHeight <= 0 || shelfCount <= 0) return -1;
+  if (x < 0 || x >= renderer.getScreenWidth()) return -1;
+  const int localY = y - contentTop;
+  if (localY < 0) return -1;
+  const int visibleItems = shelvesVisibleItems(contentHeight);
+  const int row = localY / rowHeight;
+  if (row >= visibleItems) return -1;
+  const int index = shelvesScrollOffset(visibleItems) + row;
+  return index < shelfCount ? index : -1;
+}
+
 int RecentBooksActivity::gridIndexAtPoint(const int x, const int y, const int contentTop, const int contentHeight,
                                           const int scrollRowIn, const int itemCount) const {
   if (itemCount <= 0) return -1;
@@ -1171,8 +1200,14 @@ void RecentBooksActivity::loop() {
     int gy = 0;
     // Long press first: wasScreenLongPress suppresses the rest of the contact, so the lift
     // cannot also tap the screen this opens.
+    // Books is a cover grid, Shelves a row list -- each answers to its own geometry.
+    const auto hitAtPoint = [&](const int px, const int py) {
+      return selectedTab == 0 ? gridIndexAtPoint(px, py, gridTop, gridHeight, scrollRow, itemCount)
+                              : shelfRowAtPoint(px, py, gridTop, gridHeight);
+    };
+
     if (mappedInput.wasScreenLongPress(gx, gy)) {
-      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      const int hit = hitAtPoint(gx, gy);
       hideSelector();
       // Stats are for books; a shelf has none.
       if (hit >= 0 && selectedTab == 0 && hit < static_cast<int>(recentBooks.size())) {
@@ -1182,7 +1217,7 @@ void RecentBooksActivity::loop() {
       return;
     }
     if (mappedInput.wasScreenTouchDown(gx, gy)) {
-      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      const int hit = hitAtPoint(gx, gy);
       hideSelector();
       if (hit >= 0 && contentIndex != hit + 1) {
         contentIndex = hit + 1;  // index 0 is the tab bar
@@ -1191,7 +1226,7 @@ void RecentBooksActivity::loop() {
       return;
     }
     if (mappedInput.wasScreenTapped(gx, gy)) {
-      const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      const int hit = hitAtPoint(gx, gy);
       hideSelector();
       if (hit >= 0) {
         contentIndex = hit + 1;
@@ -1546,14 +1581,10 @@ void RecentBooksActivity::renderShelvesTab(int contentTop, int contentHeight) {
   }
 
   const int rowHeight = metrics.listWithSubtitleRowHeight;
-  const int visibleItems = std::max(1, contentHeight / rowHeight);
+  const int visibleItems = shelvesVisibleItems(contentHeight);
   const int selectedItem = contentIndex - 1;
   const int shelfCount = static_cast<int>(shelves.size());
-
-  int scrollOffset = 0;
-  if (selectedItem >= visibleItems) {
-    scrollOffset = selectedItem - visibleItems + 1;
-  }
+  const int scrollOffset = shelvesScrollOffset(visibleItems);
 
   // Prewarm the font cache with all visible folder names before drawing. Folder names are drawn
   // unconditionally on every render (unlike cover-fallback titles below), so without this, non-Latin

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1116,13 +1116,19 @@ void RecentBooksActivity::loop() {
   // books: the covers between the old and new row could not be reached by swiping at all.
   const auto swipe = mappedInput.wasSwipe();
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
-    const int maxRow = maxScrollRow(gridContentHeight());
-    const int moved = std::clamp(scrollRow + (swipe == MappedInputManager::SwipeDir::Up ? 1 : -1), 0, maxRow);
-    hideSelector();
-    if (moved != scrollRow) {
-      scrollRow = moved;
-      requestUpdate();
+    hideSelector();  // a swipe is a touch on either tab
+    // Books tab only: the Shelves tab is a list that scrolls by its own offset, derived from the
+    // selection in renderShelvesTab. scrollRow drives the cover grid alone, so moving it there
+    // would scroll nothing on screen while quietly displacing the grid's viewport.
+    if (selectedTab == 0) {
+      const int maxRow = maxScrollRow(gridContentHeight());
+      const int moved = std::clamp(scrollRow + (swipe == MappedInputManager::SwipeDir::Up ? 1 : -1), 0, maxRow);
+      if (moved != scrollRow) {
+        scrollRow = moved;
+        requestUpdate();
+      }
     }
+    // Consumed either way: a swipe must not fall through and read as a tap on whatever it ended on.
     return;
   }
 

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -990,6 +990,7 @@ void RecentBooksActivity::loop() {
     int shelfTouchY = 0;
     if (mappedInput.wasScreenLongPress(shelfTouchX, shelfTouchY)) {
       const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      hideSelector();
       if (hit >= 0) {
         shelfContentIndex = hit;
         showBookStats(shelfBooks[hit].path, shelfBooks[hit].title);
@@ -998,6 +999,7 @@ void RecentBooksActivity::loop() {
     }
     if (mappedInput.wasScreenTouchDown(shelfTouchX, shelfTouchY)) {
       const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      hideSelector();
       if (hit >= 0 && hit != shelfContentIndex) {
         shelfContentIndex = hit;
         requestUpdate();
@@ -1006,6 +1008,7 @@ void RecentBooksActivity::loop() {
     }
     if (mappedInput.wasScreenTapped(shelfTouchX, shelfTouchY)) {
       const int hit = gridIndexAtPoint(shelfTouchX, shelfTouchY, contentTop, contentHeight, shelfScrollRow, shelfCount);
+      hideSelector();
       if (hit >= 0) {
         shelfContentIndex = hit;
         LOG_DBG("RBA", "Tapped shelf book: %s", shelfBooks[hit].path.c_str());
@@ -1036,10 +1039,12 @@ void RecentBooksActivity::loop() {
     if (shelfItemCount > 0) {
       buttonNavigator.onNextRelease([this, shelfItemCount] {
         shelfContentIndex = ButtonNavigator::nextIndex(shelfContentIndex, shelfItemCount);
+        selectorVisible = true;
         requestUpdate();
       });
       buttonNavigator.onPreviousRelease([this, shelfItemCount] {
         shelfContentIndex = ButtonNavigator::previousIndex(shelfContentIndex, shelfItemCount);
+        selectorVisible = true;
         requestUpdate();
       });
     }
@@ -1560,7 +1565,7 @@ void RecentBooksActivity::renderShelvesTab(int contentTop, int contentHeight) {
 
   for (int i = scrollOffset; i < std::min(scrollOffset + visibleItems, shelfCount); i++) {
     const int itemY = contentTop + (i - scrollOffset) * rowHeight;
-    drawShelfRow(i, itemY, i == selectedItem);
+    drawShelfRow(i, itemY, selectorVisible && i == selectedItem);
   }
 
   if (shelfCount > visibleItems) {
@@ -1624,7 +1629,7 @@ void RecentBooksActivity::renderShelfBooksView(int contentTop, int contentHeight
     const int cellY = contentTop + row * rowStride;
     const int pct = idx < static_cast<int>(shelfBookProgress.size()) ? shelfBookProgress[idx].percent : -1;
     drawGridCell(cellX, cellY, cellWidth, cellHeight, shelfBooks[idx].coverBmpPath, shelfBooks[idx].title, pct,
-                 idx == shelfContentIndex, /*drawTitle=*/idx <= titledLastIdx);
+                 selectorVisible && idx == shelfContentIndex, /*drawTitle=*/idx <= titledLastIdx);
   }
 
   // Release the page slots claimed by the prewarm above -- see the matching comment in
@@ -1636,6 +1641,9 @@ void RecentBooksActivity::renderShelfBooksView(int contentTop, int contentHeight
 
 bool RecentBooksActivity::tryPartialSelectionRedraw() {
   if (!lastRendered.valid) return false;
+  // This path only ever moves a selection border. With the cursor hidden there is no border to
+  // move, and taking it after a touch would paint one back onto a screen that must not show it.
+  if (!selectorVisible) return false;
   if (openShelfIndex != lastRendered.openShelf || selectedTab != lastRendered.tab) return false;
 
   const auto& metrics = UITheme::getInstance().getMetrics();

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1785,9 +1785,10 @@ bool RecentBooksActivity::tryPartialSelectionRedraw() {
   // offset put them -- not at a position derived from the selection. Bail unless the frame on
   // screen was drawn at this offset and the move stays inside it; renderShelvesTab would scroll.
   if (shelvesScroll != lastRendered.shelvesScroll) return false;
-  for (const int idx : {oldIdx - 1, newIdx - 1}) {
-    if (idx < scrollOffset || idx >= scrollOffset + visibleItems) return false;
-  }
+  const auto offScreen = [scrollOffset, visibleItems](const int idx) {
+    return idx < scrollOffset || idx >= scrollOffset + visibleItems;
+  };
+  if (offScreen(oldIdx - 1) || offScreen(newIdx - 1)) return false;
 
   if (fcm) {
     renderer.prewarmText(UI_10_FONT_ID, (shelves[oldIdx - 1].folderName + ' ' + shelves[newIdx - 1].folderName).c_str(),

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1779,12 +1779,15 @@ bool RecentBooksActivity::tryPartialSelectionRedraw() {
   // Shelves list rows.
   if (newIdx > static_cast<int>(shelves.size()) || oldIdx > static_cast<int>(shelves.size())) return false;
   const int rowHeight = metrics.listWithSubtitleRowHeight;
-  const int visibleItems = std::max(1, contentHeight / rowHeight);
-  auto scrollOffsetFor = [visibleItems](const int selectedItem) {
-    return selectedItem >= visibleItems ? selectedItem - visibleItems + 1 : 0;
-  };
-  if (scrollOffsetFor(newIdx - 1) != scrollOffsetFor(oldIdx - 1)) return false;
-  const int scrollOffset = scrollOffsetFor(newIdx - 1);
+  const int visibleItems = shelvesVisibleItems(contentHeight);
+  const int scrollOffset = shelvesScrollOffset(visibleItems);
+  // The list scrolls on its own now (a swipe moves shelvesScroll), so the rows are wherever that
+  // offset put them -- not at a position derived from the selection. Bail unless the frame on
+  // screen was drawn at this offset and the move stays inside it; renderShelvesTab would scroll.
+  if (shelvesScroll != lastRendered.shelvesScroll) return false;
+  for (const int idx : {oldIdx - 1, newIdx - 1}) {
+    if (idx < scrollOffset || idx >= scrollOffset + visibleItems) return false;
+  }
 
   if (fcm) {
     renderer.prewarmText(UI_10_FONT_ID, (shelves[oldIdx - 1].folderName + ' ' + shelves[newIdx - 1].folderName).c_str(),
@@ -1827,7 +1830,7 @@ void RecentBooksActivity::render(RenderLock&&) {
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-    lastRendered = {true, openShelfIndex, selectedTab, contentIndex, scrollRow, shelfContentIndex, shelfScrollRow};
+    rememberRendered();
     renderer.displayBuffer();
     return;
   }
@@ -1849,6 +1852,6 @@ void RecentBooksActivity::render(RenderLock&&) {
   const auto labels = mappedInput.mapLabels(tr(STR_HOME), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
-  lastRendered = {true, openShelfIndex, selectedTab, contentIndex, scrollRow, shelfContentIndex, shelfScrollRow};
+  rememberRendered();
   renderer.displayBuffer();
 }

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1099,7 +1099,7 @@ void RecentBooksActivity::loop() {
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
     const int maxRow = maxScrollRow(gridContentHeight());
     const int moved = std::clamp(scrollRow + (swipe == MappedInputManager::SwipeDir::Up ? 1 : -1), 0, maxRow);
-    selectorVisible = false;
+    hideSelector();
     if (moved != scrollRow) {
       scrollRow = moved;
       requestUpdate();
@@ -1123,6 +1123,7 @@ void RecentBooksActivity::loop() {
     int tab = -1;
     const auto tabTouch = mappedInput.colTouch(tab, 0, renderer.getScreenWidth() / TAB_COUNT, TAB_COUNT, tabBarY,
                                                tabBarY + m.tabBarHeight);
+    if (tabTouch != MappedInputManager::RowTouch::None) hideSelector();
     if (tabTouch == MappedInputManager::RowTouch::Tap && tab >= 0 && tab != selectedTab) {
       selectedTab = tab;
       if (selectedTab == 1 && !shelvesLoaded) loadShelves();
@@ -1139,6 +1140,7 @@ void RecentBooksActivity::loop() {
     // cannot also tap the screen this opens.
     if (mappedInput.wasScreenLongPress(gx, gy)) {
       const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      hideSelector();
       // Stats are for books; a shelf has none.
       if (hit >= 0 && selectedTab == 0 && hit < static_cast<int>(recentBooks.size())) {
         contentIndex = hit + 1;
@@ -1148,7 +1150,7 @@ void RecentBooksActivity::loop() {
     }
     if (mappedInput.wasScreenTouchDown(gx, gy)) {
       const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
-      selectorVisible = false;
+      hideSelector();
       if (hit >= 0 && contentIndex != hit + 1) {
         contentIndex = hit + 1;  // index 0 is the tab bar
         requestUpdate();
@@ -1157,6 +1159,7 @@ void RecentBooksActivity::loop() {
     }
     if (mappedInput.wasScreenTapped(gx, gy)) {
       const int hit = gridIndexAtPoint(gx, gy, gridTop, gridHeight, scrollRow, itemCount);
+      hideSelector();
       if (hit >= 0) {
         contentIndex = hit + 1;
         if (selectedTab == 0) {

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1103,6 +1103,7 @@ void RecentBooksActivity::loop() {
           shelfConfirmPressSeen = false;
           shelfContentIndex = 0;
           shelfScrollRow = 0;
+          selectorVisible = true;  // opened with a key, so the shelf opens with its cursor shown
           loadShelfBooks(shelves[itemIdx].folderPath);
           requestUpdate();
           return;
@@ -1255,6 +1256,7 @@ void RecentBooksActivity::loop() {
     if (contentIndex > 0) {
       contentIndex = 0;
       scrollRow = 0;
+      selectorVisible = true;
       requestUpdate();
     } else {
       onGoHome();
@@ -1291,6 +1293,9 @@ void RecentBooksActivity::loop() {
   if (hasChangedTab) {
     contentIndex = (contentIndex == 0) ? 0 : 1;
     scrollRow = 0;
+    // Only the keys reach here -- a tab tap is handled in the touch block and returns -- so the
+    // cursor comes back on, wherever a touch left it.
+    selectorVisible = true;
     if (selectedTab == 1 && !shelvesLoaded) loadShelves();
   }
 

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -150,10 +150,24 @@ class RecentBooksActivity final : public Activity {
     int tab = -1;
     int contentIndex = -1;
     int scrollRow = -1;
+    int shelvesScroll = -1;
     int shelfContentIndex = -1;
     int shelfScrollRow = -1;
   };
   RenderedState lastRendered;
+  // The one place that snapshots what the frame on screen shows. Both render paths call it, so a
+  // new piece of view state cannot be added to the renderer and forgotten here -- which is exactly
+  // how the partial redraw came to read the Shelves list at an offset it was no longer drawn at.
+  void rememberRendered() {
+    lastRendered.valid = true;
+    lastRendered.openShelf = openShelfIndex;
+    lastRendered.tab = selectedTab;
+    lastRendered.contentIndex = contentIndex;
+    lastRendered.scrollRow = scrollRow;
+    lastRendered.shelvesScroll = shelvesScroll;
+    lastRendered.shelfContentIndex = shelfContentIndex;
+    lastRendered.shelfScrollRow = shelfScrollRow;
+  }
 
   // Background library scan (stale-while-revalidate): onEnter() shows the persisted book list
   // instantly; loop() re-walks the SD card one directory entry per slice and applies/saves changes

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -21,7 +21,8 @@ class RecentBooksActivity final : public Activity {
 
   int selectedTab = 0;
   int contentIndex = 0;
-  int scrollRow = 0;
+  int scrollRow = 0;       // Books tab: first visible grid row
+  int shelvesScroll = 0;   // Shelves tab: first visible list row
 
   bool longPressFired = false;
   // A shelf opens on the Confirm PRESS, so the release of that same physical click arrives with

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -106,6 +106,12 @@ class RecentBooksActivity final : public Activity {
   // labels and the touch targets cannot drift apart.
   [[nodiscard]] std::vector<TabInfo> buildTabs() const;
   [[nodiscard]] Rect tabBarRect() const;
+  // Same idea for the Shelves list, which is rows rather than the cover grid: the renderer and
+  // the hit test below share this geometry instead of each deriving its own.
+  [[nodiscard]] int shelvesVisibleItems(int contentHeight) const;
+  [[nodiscard]] int shelvesScrollOffset(int visibleItems) const;
+  // Shelf index under a screen point in the Shelves list, or -1 for a miss.
+  [[nodiscard]] int shelfRowAtPoint(int x, int y, int contentTop, int contentHeight) const;
   void loadShelves();
   void loadShelfBooks(const std::string& folderPath);
   int readProgressPercent(const std::string& bookPath) const;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -93,6 +93,14 @@ class RecentBooksActivity final : public Activity {
   // touch, so a highlight sitting on some other cover is just noise -- and worse, it
   // implies the swipe moved it. Set by the nav keys, cleared by any touch.
   bool selectorVisible = false;
+  // Clearing the flag is not enough: the frame still showing the selector has to be replaced,
+  // and a touch that changes nothing else (a swipe against the end stop, a tap on the current
+  // cover, a tap on the active tab) requests no redraw of its own.
+  void hideSelector() {
+    if (!selectorVisible) return;
+    selectorVisible = false;
+    requestUpdate();
+  }
   void loadShelves();
   void loadShelfBooks(const std::string& folderPath);
   int readProgressPercent(const std::string& bookPath) const;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -71,6 +71,10 @@ class RecentBooksActivity final : public Activity {
 
   int getVisibleRows(int cellHeight, int contentHeight) const;
   int getCellHeight(int cellWidth) const;
+  // The grid's viewport height, below the tab bar and above the button hints.
+  [[nodiscard]] int gridContentHeight() const;
+  // Highest scrollRow that still fills the viewport, for the swipe that scrolls it.
+  [[nodiscard]] int maxScrollRow(int contentHeight) const;
   // Absolute grid item index under a screen point, or -1 for a miss. Derives the cell grid the
   // same way renderBooksTab()/renderShelvesTab()/renderShelfBooksView() do, so the hit targets
   // are exactly the drawn cells. Deliberately stops at visibleRows: those renderers draw one
@@ -85,6 +89,10 @@ class RecentBooksActivity final : public Activity {
 
   void loadRecentBooks();
   void loadBookProgress();
+  // A pointer-style selector belongs to key navigation. Touch users act on what they
+  // touch, so a highlight sitting on some other cover is just noise -- and worse, it
+  // implies the swipe moved it. Set by the nav keys, cleared by any touch.
+  bool selectorVisible = false;
   void loadShelves();
   void loadShelfBooks(const std::string& folderPath);
   int readProgressPercent(const std::string& bookPath) const;

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -21,8 +21,8 @@ class RecentBooksActivity final : public Activity {
 
   int selectedTab = 0;
   int contentIndex = 0;
-  int scrollRow = 0;       // Books tab: first visible grid row
-  int shelvesScroll = 0;   // Shelves tab: first visible list row
+  int scrollRow = 0;      // Books tab: first visible grid row
+  int shelvesScroll = 0;  // Shelves tab: first visible list row
 
   bool longPressFired = false;
   // A shelf opens on the Confirm PRESS, so the release of that same physical click arrives with


### PR DESCRIPTION
Two changes to how the Library's cover grid answers touch. Follows on from #233, which fixed the tab bar's hit areas.

## Swipe scrolls the viewport, not the selection

A swipe moved the selection by `GRID_COLS`:

```cpp
const int delta = (swipe == SwipeDir::Up) ? GRID_COLS : -GRID_COLS;
```

One whole row per swipe, which means **two of every three books cannot be reached by swiping at all** — the covers between the old row and the new one are skipped, and the only way to land on them is to switch to the keys.

Scroll the viewport instead and leave the selection alone, which is what the gesture means on a touch screen. `renderBooksTab`'s follow-the-selection clamp now runs only for the key selector; leaving it unconditional would snap the scroll back to whatever row the selection sat on and undo the swipe on the very next frame.

## The selector is a key cursor, so only key users see it

A highlight parked on some unrelated cover tells a touch user nothing — and while the swipe walked it, it actively implied the gesture had moved the *selection* rather than the *view*. Any touch (tap or swipe) clears it, the nav keys set it, and the tab bar's own focus highlight follows the same rule.

## Also

Adds `gridContentHeight()` and `maxScrollRow()` so the swipe handler, the touch hit test and the renderer derive the grid's viewport from one place rather than three copies of the same arithmetic.

## Testing

On the iOS simulator build with the X4 Pro profile:

- swiping scrolls one row at a time, with no selector drawn
- a key press restores the selector and pulls the view back to it
- tapping a cover still opens the book; shelf rows and the tab bar are unaffected

## Note on scope

This is a deliberate behaviour change, not a bug fix, so it is separate from #233. On hardware with side keys the old row-jump was arguably useful as a fast traversal — if you would rather keep that for button boards, the swipe branch is the only place to gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)