### PR TITLE
fix: Dictionary: long-press to look up, tap outside to close, page as the reader is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ In vertical text, lookup opens on the page itself: the current word is highlight
 
 A word broken across a page break still resolves. The lookup reads a few characters past the end of the page, so the half you can see finds the whole word; the highlight stays on the page and covers only the characters that are there.
 
+On a touch device, long-pressing a word on the page opens its definition directly — no setting to turn on, and no cursor to move first. A press that lands between words opens ordinary word selection instead. The panel pages by touch however the reader is set to turn pages, and a tap outside it puts it away.
+
 The definition itself opens as a panel floating over the page you were reading: the word sits above a divider at the top, the entry fills the middle, and the dictionary it came from is named along the bottom. In vertical text and in English books the entry is paged a screenful at a time with a page counter in the top right; horizontal Japanese and manga scroll the entry freely and show your position among the page's words instead.
 
 Vocabulary, names and grammar each come from their own dictionary. If the book itself annotated a reading, the entry opens with "In this book: はやし" and remembers it for the rest of the book. See [Setup](#setup) for the files, and [§6.2](USER_GUIDE.md#62-word-lookup) for how to drive it.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -694,6 +694,8 @@ If the device goes to sleep or you close the book while viewing a footnote, the 
 
 Words on the current page can be looked up in an offline StarDict dictionary stored on the SD card. Copy a dictionary to the `/dictionaries/` folder, select it in **Settings → Reader → Dictionary**, then start a lookup by choosing **Look Up** in the **[Reader Menu](#5-reader-menu)** (or by holding **Confirm**, if the **Long-press Menu** setting in **[Controls Settings](#363-controls)** is set to "Dictionary"). Use **Left/Right** to highlight a word and press **Confirm** to show its definition.
 
+On a touch device you can skip all of that: **long-press a word on the page** and its definition opens directly, with no setting to turn on first. A press between words opens ordinary word selection instead. The definition card pages by touch the way the reader is set to turn pages in **Touch Reader Controls**, and a tap outside it puts it away.
+
 See [docs/dictionary.md](docs/dictionary.md) for supported formats, setup, and where to find dictionaries.
 
 ### System Navigation

--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -25,8 +25,11 @@ The Fallback dictionary row only appears when at least one usable dictionary fol
 
 ## Looking Up a Word
 
-Two ways to start a lookup while reading:
+Three ways to start a lookup while reading:
 
+- **Long-press a word on the screen** (touch devices). The definition opens straight away, with no setting to turn
+  on first. A press that lands between words opens ordinary word selection instead, so the gesture is never a dead
+  end. Closing a definition opened this way returns to the page.
 - Open the reader menu (**Confirm**) and choose **Look Up**.
 - Or set **Settings → Controls → Long-press Menu** to "Dictionary", then hold **Confirm** (~0.4s) on the reading page.
 
@@ -58,6 +61,9 @@ HTML dictionaries that declare `sametypesequence=h` use the EPUB text-layout eng
 
 - **Left/Right** or side **Up/Down** — previous / next page
 - **Back** — return to word selection
+- **Touch** — the card pages the same way the reader itself is set to turn pages (**Settings → Controls → Touch
+  Reader Controls**): tap zones, inverted zones, swipes, inverted swipes, or nothing at all when touch page turns
+  are off. A tap outside the card puts it away.
 
 
 

--- a/src/activities/reader/DictionaryDefinitionActivity.cpp
+++ b/src/activities/reader/DictionaryDefinitionActivity.cpp
@@ -251,6 +251,15 @@ void DictionaryDefinitionActivity::loop() {
   int tx = 0;
   int ty = 0;
   if (mappedInput.wasScreenTapped(tx, ty)) {
+    // Outside the card is "put it away": the panel floats over the page, so a
+    // tap on the page around it reads as dismissing it rather than as paging
+    // a definition the finger is not even on. Paging keeps the card itself.
+    const auto layout = DictionaryPanel::compute(renderer);
+    if (tx < layout.box.x || tx >= layout.box.x + layout.box.width || ty < layout.box.y ||
+        ty >= layout.box.y + layout.box.height) {
+      finish();
+      return;
+    }
     if (tx < renderer.getScreenWidth() / 3) {
       if (currentPage > 0) {
         currentPage--;

--- a/src/activities/reader/DictionaryDefinitionActivity.cpp
+++ b/src/activities/reader/DictionaryDefinitionActivity.cpp
@@ -246,26 +246,30 @@ void DictionaryDefinitionActivity::loop() {
     return;
   }
 
-  // Same tap zones as the reader page turns: left third = previous page,
-  // the rest = next. Back is the usual left-edge swipe.
+  // Outside the card is "put it away": the panel floats over the page, so a tap
+  // on the page around it reads as dismissing it rather than as paging a
+  // definition the finger is not even on. Checked before paging so the two
+  // cannot both claim the same contact.
   int tx = 0;
   int ty = 0;
   if (mappedInput.wasScreenTapped(tx, ty)) {
-    // Outside the card is "put it away": the panel floats over the page, so a
-    // tap on the page around it reads as dismissing it rather than as paging
-    // a definition the finger is not even on. Paging keeps the card itself.
-    const auto layout = DictionaryPanel::compute(renderer);
-    if (tx < layout.box.x || tx >= layout.box.x + layout.box.width || ty < layout.box.y ||
-        ty >= layout.box.y + layout.box.height) {
+    const auto box = DictionaryPanel::compute(renderer).box;
+    if (tx < box.x || tx >= box.x + box.width || ty < box.y || ty >= box.y + box.height) {
       finish();
       return;
     }
-    if (tx < renderer.getScreenWidth() / 3) {
-      if (currentPage > 0) {
-        currentPage--;
-        requestUpdate();
-      }
-    } else if (currentPage + 1 < totalPages) {
+  }
+
+  // Paging follows whatever the reader is set to, rather than a second scheme
+  // to learn: tap zones, inverted zones, swipes or inverted swipes, and nothing
+  // at all when touch reader controls are off. Same helper the page turns use,
+  // so the definition answers the gesture the reader already taught.
+  const auto touchTurn = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
+  if (touchTurn.prev || touchTurn.next) {
+    if (touchTurn.prev && currentPage > 0) {
+      currentPage--;
+      requestUpdate();
+    } else if (touchTurn.next && currentPage + 1 < totalPages) {
       currentPage++;
       requestUpdate();
     }

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -66,6 +66,11 @@ void DictionaryWordSelectActivity::onEnter() {
       performLookup();
       return;
     }
+    // Missed: from here this is ordinary selection, which the reader is now driving themselves.
+    // Forgetting the press keeps the close behaviour ordinary too -- otherwise a definition they
+    // opened by hand would still return to the page instead of back to the words.
+    lookupAtX = -1;
+    lookupAtY = -1;
   }
   requestUpdate();
 }

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -55,6 +55,18 @@ void DictionaryWordSelectActivity::onEnter() {
     const int initial = closestInRow(rowCount / 2, renderer.getScreenWidth() / 2);
     if (initial >= 0) selected = initial;
   }
+  // Opened by a long press on a word: start there and show the definition
+  // straight away. A miss (the press landed between words) falls through to
+  // ordinary selection rather than closing, so the gesture is never a dead end.
+  if (!words.empty() && lookupAtX >= 0 && lookupAtY >= 0) {
+    const int hit = wordAt(lookupAtX, lookupAtY);
+    if (hit >= 0) {
+      selected = hit;
+      requestUpdate();
+      performLookup();
+      return;
+    }
+  }
   requestUpdate();
 }
 
@@ -260,6 +272,13 @@ void DictionaryWordSelectActivity::performLookup() {
                              // The definition view cancels when its power click asked to leave the dictionary
                              // entirely, rather than step back to this selection.
                              if (result.isCancelled) {
+                               finish();
+                               return;
+                             }
+                             // A long press opened the definition directly, so closing it returns to the
+                             // page. Word selection was never a step the reader asked for, and stopping
+                             // here would strand them in a screen they did not open.
+                             if (lookupAtX >= 0 && lookupAtY >= 0) {
                                finish();
                                return;
                              }

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -17,14 +17,23 @@ class DictionaryWordSelectActivity final : public Activity {
  public:
   explicit DictionaryWordSelectActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                         std::unique_ptr<Page> page, int marginLeft, int marginTop,
-                                        std::string folderName, std::string language, int baseFontId)
+                                        std::string folderName, std::string language, int baseFontId,
+                                        int lookupAtX = -1, int lookupAtY = -1)
       : Activity("DictionaryWordSelect", renderer, mappedInput),
+        lookupAtX(lookupAtX),
+        lookupAtY(lookupAtY),
         page(std::move(page)),
         marginLeft(marginLeft),
         marginTop(marginTop),
         fontId(baseFontId),
         folderName(std::move(folderName)),
         language(std::move(language)) {}
+
+  // Screen point to open on: the word under it is selected and looked up
+  // immediately, so a long press on the page goes straight to the definition
+  // instead of dropping the reader into word selection. -1 = normal entry.
+  int lookupAtX = -1;
+  int lookupAtY = -1;
 
   void onEnter() override;
   void loop() override;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -470,8 +470,7 @@ void EpubReaderActivity::showBuildPopup() {
   buildPopupPending = false;
 }
 
-void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen, const int lookupAtX,
-                                                 const int lookupAtY) {
+void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen, const int lookupAtX, const int lookupAtY) {
   if (isJapaneseBook()) {
     openWordLookupPanel(pageOnScreen);
     return;
@@ -500,8 +499,7 @@ void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen, const
   // long-press): the user is mid-reading, not mid-menu.
   startActivityForResult(std::make_unique<DictionaryWordSelectActivity>(
                              renderer, mappedInput, std::move(page), orientedMarginLeft, orientedMarginTop,
-                             std::move(dictionaryFolder), bookLanguage, effectiveReaderFontId(), lookupAtX,
-                             lookupAtY),
+                             std::move(dictionaryFolder), bookLanguage, effectiveReaderFontId(), lookupAtX, lookupAtY),
                          [this](const ActivityResult&) { requestUpdate(); });
 }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -470,7 +470,8 @@ void EpubReaderActivity::showBuildPopup() {
   buildPopupPending = false;
 }
 
-void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen) {
+void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen, const int lookupAtX,
+                                                 const int lookupAtY) {
   if (isJapaneseBook()) {
     openWordLookupPanel(pageOnScreen);
     return;
@@ -499,7 +500,8 @@ void EpubReaderActivity::openDictionaryWordSelect(const bool pageOnScreen) {
   // long-press): the user is mid-reading, not mid-menu.
   startActivityForResult(std::make_unique<DictionaryWordSelectActivity>(
                              renderer, mappedInput, std::move(page), orientedMarginLeft, orientedMarginTop,
-                             std::move(dictionaryFolder), bookLanguage, effectiveReaderFontId()),
+                             std::move(dictionaryFolder), bookLanguage, effectiveReaderFontId(), lookupAtX,
+                             lookupAtY),
                          [this](const ActivityResult&) { requestUpdate(); });
 }
 
@@ -821,6 +823,21 @@ void EpubReaderActivity::readerLoop() {
       case CrossPointSettings::LP_MENU_DISABLED:
       default:
         break;
+    }
+  }
+
+  // A long press on a word looks it up. Deliberately not behind
+  // longPressMenuFunction: that setting assigns the *key* hold (Confirm, or the
+  // Home key on boards without one), and a press on the glass is a different
+  // gesture that means "what is this word". Ahead of the link and menu zones so
+  // a hold never reads as the tap those handle. Japanese books keep their own
+  // vertical panel, which segments rather than splitting on spaces.
+  if (!atEndOfBook && mappedInput.hasTouch() && !isJapaneseBook()) {
+    int pressX = 0;
+    int pressY = 0;
+    if (mappedInput.wasScreenLongPress(pressX, pressY)) {
+      openDictionaryWordSelect(/*pageOnScreen=*/true, pressX, pressY);
+      return;
     }
   }
 

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -454,7 +454,9 @@ class EpubReaderActivity final : public ReaderActivity {
   // pageOnScreen: the framebuffer still holds the reader page, so the vertical word-lookup panel
   // can draw its cursor straight onto it instead of paying for a page repaint first. False when
   // something else was on screen (the reader menu).
-  void openDictionaryWordSelect(bool pageOnScreen);
+  // lookupAtX/Y: screen point of a long press on a word. -1 opens ordinary word
+  // selection; a point selects that word and shows its definition immediately.
+  void openDictionaryWordSelect(bool pageOnScreen, int lookupAtX = -1, int lookupAtY = -1);
   // Returns true if sync acted (launched, or surfaced a save error); false if it was a no-op
   // because no KOReader credentials are stored.
   bool launchKOReaderSync();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the dictionary usable by touch: a long press looks a word up, a tap outside the card closes it, and the card pages the way the reader is already set to page.
* **What changes are included?** A long-press lookup path through `DictionaryWordSelectActivity` positioned at the touched point, a dismiss check against `DictionaryPanel::compute()`'s own bounds, and `ReaderUtils::detectTouchPageTurn` in place of the card's hardcoded tap zones.

Found while testing the reader on the iPhone build; none of it is iOS-specific, an X4 Pro behaves the same.

### Long-press a word to look it up

Long-pressing a word on the page opens its definition, **without any setting**.

Deliberately not behind `longPressMenuFunction`: that setting assigns the *key* hold (Confirm, or the Home key on boards without a front one), and a press on the glass is a different gesture that already means "what is this word". Requiring a setting also made the dictionary effectively undiscoverable — nothing on the page suggests it exists, and the default is `Disabled`.

The press opens word select already positioned on the word under the finger and shows the definition straight away, so the gesture is one step rather than three (hold Home → move the cursor with the keys → tap the word). A press that lands *between* words falls through to ordinary selection rather than doing nothing, so it is never a dead end, and closing a definition opened this way returns to the page rather than stranding the reader in a selection screen they did not open.

Japanese books keep their own vertical panel, which segments text rather than splitting on spaces.

### Tap outside the card to close it

The panel floats over the page, but every tap was treated as a page-turn zone — so a tap on the page around it paged a definition the finger was not on, and there was no way to dismiss it by touch at all. The bounds come from `DictionaryPanel::compute()`, the same geometry the panel draws from, so the two cannot disagree.

### Page it the way the reader is set to

The card had its own hardcoded scheme (left third back, the rest forward), so a reader who turns pages by swiping had to switch to tapping for the definition, and one who has turned touch page-turns off entirely still got them here. It now routes through `ReaderUtils::detectTouchPageTurn` — tap zones, inverted zones, swipes, inverted swipes, or nothing when touch reader controls are off.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — stock has no dictionary at all, and this fork's own dictionary was reachable only through a key hold behind a setting that defaults to `Disabled`.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **The ordering between the three touch consumers is the part worth reviewing.** The dismiss check runs before paging so the two cannot claim the same contact, and the long press falls through to ordinary selection on a miss rather than swallowing it.
* **Nothing new is drawn**, so the panel's appearance is unchanged; only which contacts it answers to.
* **Device-tested** on the iOS simulator build with the X4 Pro profile and an `en-de` dictionary: a long press on "book" opens its definition with no setting changed; a tap outside returns to the reading page rather than to word select; with the reader in swipe mode a swipe inside the card pages the entry 1/4 → 2/4; a tap inside pages it in tap mode; a long press between words still opens ordinary selection.
* Memory / flash impact: none of note — two ints of lookup position passed into an activity that was already constructed on this path, and no new allocations.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)