### PR TITLE
fix: Manga: make the chapter list touchable and the tap zones follow the page

### DIFF
--- a/src/activities/reader/MangaChapterSelectionActivity.cpp
+++ b/src/activities/reader/MangaChapterSelectionActivity.cpp
@@ -21,14 +21,12 @@ MangaChapterSelectionActivity::MangaChapterSelectionActivity(GfxRenderer& render
       break;
     }
   }
-  labels.reserve(this->tocEntries.size());
+  // The rows borrow their labels from tocEntries, which outlives them and is not touched again
+  // after this: a second copy of every chapter title is heap this device would rather keep.
   items.reserve(this->tocEntries.size());
-  for (const auto& entry : this->tocEntries) {
-    labels.push_back(entry.title);
-  }
-  for (size_t i = 0; i < labels.size(); i++) {
+  for (size_t i = 0; i < this->tocEntries.size(); i++) {
     fui::ListItem item;
-    item.label = labels[i].c_str();
+    item.label = this->tocEntries[i].title.c_str();
     // The row's identity travels in actionValue -- list() registers the tap
     // target as hit(rect, action, item.actionValue), so leaving it at its
     // default reported every row as index 0 and every tap opened the first
@@ -47,11 +45,10 @@ void MangaChapterSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band drawChrome paints the title in.
-  screen.setContentMarginFromScreen(
-      fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                  static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                  static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                  static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (listCount() == 0) {

--- a/src/activities/reader/MangaChapterSelectionActivity.cpp
+++ b/src/activities/reader/MangaChapterSelectionActivity.cpp
@@ -95,11 +95,12 @@ bool MangaChapterSelectionActivity::handleButtons() {
   return false;
 }
 
+// Header only: UiListActivity::render() calls drawFooter() for the button hints, and it draws the
+// same four labels. Painting them here as well drew them twice -- three times on the pass where a
+// wrapped row makes the list re-layout and drawChrome() runs again.
 void MangaChapterSelectionActivity::drawChrome() {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   GUI.drawHeader(renderer, Rect{safe.x, safe.y + metrics.topPadding, safe.width, metrics.headerHeight},
                  tr(STR_SELECT_CHAPTER));
-  const auto labelSet = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, labelSet.btn1, labelSet.btn2, labelSet.btn3, labelSet.btn4);
 }

--- a/src/activities/reader/MangaChapterSelectionActivity.cpp
+++ b/src/activities/reader/MangaChapterSelectionActivity.cpp
@@ -7,67 +7,102 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 
+namespace fui = freeink::ui;
+
+MangaChapterSelectionActivity::MangaChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
+                                                             std::vector<manga::TocEntry> tocEntries,
+                                                             const uint32_t currentPage)
+    : UiListActivity("MangaChapterSelection", renderer, mappedInput), tocEntries(std::move(tocEntries)) {
+  // Pre-select whichever chapter the current page falls within.
+  for (size_t i = 0; i < this->tocEntries.size(); i++) {
+    if (this->tocEntries[i].pageIndex <= currentPage) {
+      nav.selected = static_cast<int>(i);
+    } else {
+      break;
+    }
+  }
+  labels.reserve(this->tocEntries.size());
+  items.reserve(this->tocEntries.size());
+  for (const auto& entry : this->tocEntries) {
+    labels.push_back(entry.title);
+  }
+  for (size_t i = 0; i < labels.size(); i++) {
+    fui::ListItem item;
+    item.label = labels[i].c_str();
+    // The row's identity travels in actionValue -- list() registers the tap
+    // target as hit(rect, action, item.actionValue), so leaving it at its
+    // default reported every row as index 0 and every tap opened the first
+    // chapter.
+    item.actionValue = static_cast<int16_t>(i);
+    items.push_back(item);
+  }
+}
+
 void MangaChapterSelectionActivity::onEnter() {
-  Activity::onEnter();
+  UiListActivity::onEnter();
   requestUpdate();
 }
 
-void MangaChapterSelectionActivity::onExit() { Activity::onExit(); }
+void MangaChapterSelectionActivity::buildScreen(UiScreen& screen) {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+  // Content: the safe area minus the header band drawChrome paints the title in.
+  screen.setContentMarginFromScreen(
+      fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+                  static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+                  static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
+                  static_cast<int16_t>(safe.x)});
+  screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
-void MangaChapterSelectionActivity::loop() {
-  const int totalItems = static_cast<int>(tocEntries.size());
-  const int pageItems = UITheme::getInstance().getNumberOfItemsPerPage(renderer, true, false, true, false);
-
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    if (selectorIndex >= 0 && selectorIndex < totalItems) {
-      setResult(PageResult{tocEntries[selectorIndex].pageIndex});
-      finish();
-    }
+  if (listCount() == 0) {
+    screen.centeredText(tr(STR_NO_CHAPTERS), screen.theme().bodyText);
     return;
+  }
+
+  fui::ListProps props;
+  props.count = static_cast<uint16_t>(listCount());
+  props.action = ACTION_ROW;
+  props.inputMask = fui::InputTouch;  // physical buttons stay in handleButtons()
+  syncListViewport(screen, props);
+  props.items = items.data();
+  props.itemsWindowFirst = 0;
+  screen.list(props);
+}
+
+void MangaChapterSelectionActivity::activateIndex(const int index) {
+  if (index < 0 || index >= listCount()) {
+    return;
+  }
+  // The activated row leaves this screen (finish); a lingering flash would gray
+  // an unrelated element on the next render.
+  app.clearTapFlash();
+  nav.selected = index;
+  setResult(PageResult{tocEntries[index].pageIndex});
+  finish();
+}
+
+bool MangaChapterSelectionActivity::handleButtons() {
+  // Confirm activates on RELEASE, matching the EPUB picker: the press that
+  // opened this screen must not also select the row under the cursor.
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    activateIndex(nav.selected);
+    return true;
   }
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     ActivityResult result;
     result.isCancelled = true;
     setResult(std::move(result));
     finish();
-    return;
+    return true;
   }
-
-  buttonNavigator.onNextRelease([this, totalItems] {
-    selectorIndex = ButtonNavigator::nextIndex(selectorIndex, totalItems);
-    requestUpdate();
-  });
-  buttonNavigator.onPreviousRelease([this, totalItems] {
-    selectorIndex = ButtonNavigator::previousIndex(selectorIndex, totalItems);
-    requestUpdate();
-  });
-  buttonNavigator.onNextContinuous([this, totalItems, pageItems] {
-    selectorIndex = ButtonNavigator::nextPageIndex(selectorIndex, totalItems, pageItems);
-    requestUpdate();
-  });
-  buttonNavigator.onPreviousContinuous([this, totalItems, pageItems] {
-    selectorIndex = ButtonNavigator::previousPageIndex(selectorIndex, totalItems, pageItems);
-    requestUpdate();
-  });
+  return false;
 }
 
-void MangaChapterSelectionActivity::render(RenderLock&&) {
-  renderer.clearScreen();
-
-  auto metrics = UITheme::getInstance().getMetrics();
-  Rect screen = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
-
-  GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
+void MangaChapterSelectionActivity::drawChrome() {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+  GUI.drawHeader(renderer, Rect{safe.x, safe.y + metrics.topPadding, safe.width, metrics.headerHeight},
                  tr(STR_SELECT_CHAPTER));
-
-  const int contentTop = screen.y + metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing;
-  const int contentHeight = screen.height - contentTop - metrics.verticalSpacing;
-
-  GUI.drawList(renderer, Rect{screen.x, contentTop, screen.width, contentHeight}, static_cast<int>(tocEntries.size()),
-               selectorIndex, [this](int index) { return tocEntries[index].title; });
-
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
-  GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-
-  renderer.displayBuffer();
+  const auto labelSet = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+  GUI.drawButtonHints(renderer, labelSet.btn1, labelSet.btn2, labelSet.btn3, labelSet.btn4);
 }

--- a/src/activities/reader/MangaChapterSelectionActivity.cpp
+++ b/src/activities/reader/MangaChapterSelectionActivity.cpp
@@ -13,10 +13,11 @@ MangaChapterSelectionActivity::MangaChapterSelectionActivity(GfxRenderer& render
                                                              std::vector<manga::TocEntry> tocEntries,
                                                              const uint32_t currentPage)
     : UiListActivity("MangaChapterSelection", renderer, mappedInput), tocEntries(std::move(tocEntries)) {
-  // Pre-select whichever chapter the current page falls within.
+  // Which chapter the current page falls within. Applied in onEnter(), not here: the base
+  // class resets the nav there, so a selection made in the constructor never survives.
   for (size_t i = 0; i < this->tocEntries.size(); i++) {
     if (this->tocEntries[i].pageIndex <= currentPage) {
-      nav.selected = static_cast<int>(i);
+      initialSelected = static_cast<int>(i);
     } else {
       break;
     }
@@ -38,6 +39,9 @@ MangaChapterSelectionActivity::MangaChapterSelectionActivity(GfxRenderer& render
 
 void MangaChapterSelectionActivity::onEnter() {
   UiListActivity::onEnter();
+  // After the base, which resets the nav: the first screen build then pulls the viewport to the
+  // chapter the reader is in, the same way the EPUB picker does.
+  nav.selected = initialSelected;
   requestUpdate();
 }
 

--- a/src/activities/reader/MangaChapterSelectionActivity.h
+++ b/src/activities/reader/MangaChapterSelectionActivity.h
@@ -23,7 +23,6 @@ class MangaChapterSelectionActivity final : public UiListActivity {
   // fui::ListItem points at label storage that must outlive the build, and a
   // manga TOC is a handful of chapters rather than the hundreds an EPUB can
   // carry -- so the whole list is materialised rather than windowed.
-  std::vector<std::string> labels;
   std::vector<freeink::ui::ListItem> items;
 
   int listCount() const override { return static_cast<int>(tocEntries.size()); }

--- a/src/activities/reader/MangaChapterSelectionActivity.h
+++ b/src/activities/reader/MangaChapterSelectionActivity.h
@@ -24,6 +24,7 @@ class MangaChapterSelectionActivity final : public UiListActivity {
   // manga TOC is a handful of chapters rather than the hundreds an EPUB can
   // carry -- so the whole list is materialised rather than windowed.
   std::vector<freeink::ui::ListItem> items;
+  int initialSelected = 0;  // chapter holding the page the reader is on; applied in onEnter()
 
   int listCount() const override { return static_cast<int>(tocEntries.size()); }
   void buildScreen(UiScreen& screen) override;

--- a/src/activities/reader/MangaChapterSelectionActivity.h
+++ b/src/activities/reader/MangaChapterSelectionActivity.h
@@ -2,34 +2,33 @@
 
 #include <MangaPanel.h>
 
+#include <string>
 #include <vector>
 
 #include "MappedInputManager.h"
-#include "activities/Activity.h"
-#include "util/ButtonNavigator.h"
+#include "activities/UiListActivity.h"
 
-class MangaChapterSelectionActivity final : public Activity {
+// UiListActivity, like the EPUB and XTC chapter pickers: it brings the touch
+// routing (row taps, swipe scrolling) the hand-rolled button-only list this
+// replaced never had, so the chapter list answers a finger on a touch board.
+class MangaChapterSelectionActivity final : public UiListActivity {
  public:
   explicit MangaChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                         std::vector<manga::TocEntry> tocEntries, const uint32_t currentPage)
-      : Activity("MangaChapterSelection", renderer, mappedInput), tocEntries(std::move(tocEntries)) {
-    // Pre-select whichever chapter the current page falls within.
-    for (size_t i = 0; i < this->tocEntries.size(); i++) {
-      if (this->tocEntries[i].pageIndex <= currentPage) {
-        selectorIndex = static_cast<int>(i);
-      } else {
-        break;
-      }
-    }
-  }
+                                         std::vector<manga::TocEntry> tocEntries, uint32_t currentPage);
 
   void onEnter() override;
-  void onExit() override;
-  void loop() override;
-  void render(RenderLock&&) override;
 
  private:
   std::vector<manga::TocEntry> tocEntries;
-  int selectorIndex = 0;
-  ButtonNavigator buttonNavigator;
+  // fui::ListItem points at label storage that must outlive the build, and a
+  // manga TOC is a handful of chapters rather than the hundreds an EPUB can
+  // carry -- so the whole list is materialised rather than windowed.
+  std::vector<std::string> labels;
+  std::vector<freeink::ui::ListItem> items;
+
+  int listCount() const override { return static_cast<int>(tocEntries.size()); }
+  void buildScreen(UiScreen& screen) override;
+  void activateIndex(int index) override;
+  bool handleButtons() override;
+  void drawChrome() override;
 };

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -546,14 +546,26 @@ void MangaReaderActivity::loop() {
   // is on screen, and the outer thirds land on the wrong edges of a rotated page.
   // Both the tap point (tapToLogical) and the screen dims come from the renderer's
   // current orientation, so setting it around the read gives a consistent frame.
-  const auto touchOrientation = renderer.getOrientation();
-  if (displayedRotated_) {
-    renderer.setOrientation(static_cast<GfxRenderer::Orientation>((touchOrientation + 3) % 4));
-  }
-  const auto touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
-  const bool touchMenu = ReaderUtils::isTouchMenuGesture(renderer, mappedInput);
-  if (displayedRotated_) {
-    renderer.setOrientation(touchOrientation);
+  //
+  // Under a Try lock, because render() runs on its own task: flipping the renderer's orientation
+  // while a frame is in flight would tear it, and displayedRotated_ is written by that same task.
+  // Taking the lock makes both safe, and taking it non-blocking keeps the input loop off the
+  // render's critical path -- on a miss this tick simply resolves in the base orientation, which
+  // is what it did before.
+  ReaderUtils::TouchPageTurn touch{};
+  bool touchMenu = false;
+  {
+    RenderLock touchLock{RenderLock::Try{}};
+    const auto touchOrientation = renderer.getOrientation();
+    const bool rotateTouch = touchLock.held() && displayedRotated_;
+    if (rotateTouch) {
+      renderer.setOrientation(static_cast<GfxRenderer::Orientation>((touchOrientation + 3) % 4));
+    }
+    touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
+    touchMenu = ReaderUtils::isTouchMenuGesture(renderer, mappedInput);
+    if (rotateTouch) {
+      renderer.setOrientation(touchOrientation);
+    }
   }
 
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -493,6 +493,7 @@ bool MangaReaderActivity::handleEndOfBookPageTurn(const bool prevTriggered, cons
 
 bool MangaReaderActivity::renderEndOfBook() {
   if (!isAtEndOfBook()) return false;
+  displayedRotated_ = false;  // this screen is drawn in the base orientation, whatever preceded it
   if (!endOfBookOptions) {
     endOfBookOptions = makeUniqueNoThrow<EndOfBookOptions>(renderer);
     if (!endOfBookOptions) LOG_ERR("MRA", "OOM: EndOfBookOptions");
@@ -848,6 +849,11 @@ bool MangaReaderActivity::fullPageGeomFromCache(const PixelCacheIO::Reader& cach
 
 void MangaReaderActivity::renderFullPage() {
   renderer.clearScreen();
+  // Cleared up front, not just assigned once the geometry works out: the paths below display a
+  // placeholder and return early (no image, no decoder, an unreadable header), and a stale true
+  // from the last rotated page would have touch resolving rotated over an unrotated screen. The
+  // geometry sets the real value further down.
+  displayedRotated_ = false;
 
   std::string imgPath = book->getPageImagePath(currentPage);
   if (imgPath.empty()) {
@@ -1029,6 +1035,7 @@ void MangaReaderActivity::prefetchNextPageCache() {
 }
 
 void MangaReaderActivity::renderPanelZoom() {
+  displayedRotated_ = false;  // see renderFullPage(): every early return below falls back to it
   // Deferred-grayscale phase (see the panelGray* flags in the header). true means the BW image is
   // already displayed on the e-ink from the initial entry, so this pass skips the BW refresh wave
   // and only adds the 4-level gray wave; false is a fresh entry that shows BW and re-defers the gray

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -1510,6 +1510,7 @@ void MangaReaderActivity::workerWarmPanel() {
 
 void MangaReaderActivity::renderTextOverlay() {
   renderer.clearScreen();
+  displayedRotated_ = false;  // see renderFullPage(): text is laid out in the base orientation
 
   if (currentPanel < 0 || currentPanel >= static_cast<int>(panels.size())) {
     viewMode = ViewMode::PanelZoom;

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -557,15 +557,18 @@ void MangaReaderActivity::loop() {
   bool touchMenu = false;
   {
     RenderLock touchLock{RenderLock::Try{}};
-    const auto touchOrientation = renderer.getOrientation();
     const bool rotateTouch = touchLock.held() && displayedRotated_;
+    auto baseOrientation = GfxRenderer::Orientation::Portrait;
     if (rotateTouch) {
-      renderer.setOrientation(static_cast<GfxRenderer::Orientation>((touchOrientation + 3) % 4));
+      // Read inside the lock too: the render task writes this field while it draws a rotated
+      // page, so reading it unguarded would be a race in its own right.
+      baseOrientation = renderer.getOrientation();
+      renderer.setOrientation(static_cast<GfxRenderer::Orientation>((baseOrientation + 3) % 4));
     }
     touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
     touchMenu = ReaderUtils::isTouchMenuGesture(renderer, mappedInput);
     if (rotateTouch) {
-      renderer.setOrientation(touchOrientation);
+      renderer.setOrientation(baseOrientation);
     }
   }
 

--- a/src/activities/reader/MangaReaderActivity.cpp
+++ b/src/activities/reader/MangaReaderActivity.cpp
@@ -539,8 +539,22 @@ void MangaReaderActivity::loop() {
   // the menu. Both helpers gate on SETTINGS.touchReaderControls and hasTouch(), so tap-vs-swipe
   // mode and the global opt-out are inherited and non-touch boards see no change. Read once per
   // tick, before any early return can swallow the gesture.
+  // Resolve touch in the orientation the page is actually displayed in. A page or
+  // panel whose aspect does not match the screen is drawn rotated, and the render
+  // path restores the base orientation before returning -- so without this the
+  // zones follow the Reading Orientation setting no matter which way the content
+  // is on screen, and the outer thirds land on the wrong edges of a rotated page.
+  // Both the tap point (tapToLogical) and the screen dims come from the renderer's
+  // current orientation, so setting it around the read gives a consistent frame.
+  const auto touchOrientation = renderer.getOrientation();
+  if (displayedRotated_) {
+    renderer.setOrientation(static_cast<GfxRenderer::Orientation>((touchOrientation + 3) % 4));
+  }
   const auto touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
   const bool touchMenu = ReaderUtils::isTouchMenuGesture(renderer, mappedInput);
+  if (displayedRotated_) {
+    renderer.setOrientation(touchOrientation);
+  }
 
   if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
     showBookmarkMessage = false;
@@ -873,6 +887,7 @@ void MangaReaderActivity::renderFullPage() {
 
   const auto savedOrientation = static_cast<GfxRenderer::Orientation>(g.savedOrientation);
   const bool rotatePage = g.rotated;
+  displayedRotated_ = rotatePage;
   const int x = g.x, y = g.y;
   const int destWidth = g.destWidth, destHeight = g.destHeight;
   const int screenW = g.screenW, screenH = g.screenH;
@@ -1057,6 +1072,7 @@ void MangaReaderActivity::renderPanelZoom() {
 
   const PanelGeom g = applyPanelGeometry(panelDims[currentPanel].w, panelDims[currentPanel].h);
   const bool rotatePanel = g.rotated;
+  displayedRotated_ = rotatePanel;
   const auto savedOrientation = static_cast<GfxRenderer::Orientation>(g.savedOrientation);
   const int screenW = renderer.getScreenWidth();
   const int screenH = renderer.getScreenHeight();

--- a/src/activities/reader/MangaReaderActivity.h
+++ b/src/activities/reader/MangaReaderActivity.h
@@ -91,6 +91,13 @@ class MangaReaderActivity final : public Activity {
   };
   // NOTE: sets the renderer orientation when rotation is needed -- the caller must restore
   // savedOrientation when done.
+  // Whether what is currently on screen was drawn rotated. The render paths
+  // apply the rotation and restore the base orientation before returning, so by
+  // the time loop() runs the renderer no longer knows -- and the touch zones
+  // were being split along the reading orientation's axis rather than the one
+  // the page is actually displayed on.
+  bool displayedRotated_ = false;
+
   FullPageGeom applyFullPageGeometry(int imgWidth, int imgHeight);
   // Pure fit/rotate math shared by applyFullPageGeometry (render path) and the prefetch worker.
   // Touches NO renderer state: rotation is just a screen-dim swap here, which matches what


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix two touch bugs in the manga reader: the chapter list ignored taps (and any row that did respond opened the first chapter), and the page-turn zones landed on the wrong edges whenever a page or panel was displayed rotated.
* **What changes are included?** `MangaChapterSelectionActivity` ported onto `UiListActivity` with each row carrying its index in `ListItem::actionValue`, and `MangaReaderActivity` resolving touch in the orientation the content is actually displayed in.

Both were found on the iPhone build, but neither is iOS-specific — an X4 Pro behaves the same.

### The chapter list ignored taps

`MangaChapterSelectionActivity` extended plain `Activity` with a hand-rolled, button-only list, while the EPUB and XTC chapter pickers extend `UiListActivity` — which is where row routing and swipe scrolling live. Ported onto the same base.

The subtle part: each row must carry its index in `ListItem::actionValue`. `list()` registers the tap target as

```cpp
frame.hit(rect, props.action, item.actionValue, ...)
```

so leaving it at its default reported **every** row as index 0, and every tap opened the first chapter. The EPUB picker sets it in `refreshTocWindow`; this one now sets it too.

### The page-turn zones followed the setting, not the display

A page or panel whose aspect does not match the screen is drawn rotated, but the render paths restore the base orientation before returning (`setOrientation(savedOrientation)` in all three). By the time `loop()` reads the touch, the renderer no longer knows the content is rotated — so `detectTouchPageTurn` split the outer thirds along the *Reading Orientation* axis, which lands on the wrong edges of a rotated page.

Record whether the last render rotated, and resolve the touch in that orientation. Both the tap point (via `tapToLogical`) and the screen dimensions come from the renderer's current orientation, so setting it around the read gives one consistent frame — rather than a hand-rolled axis swap that would have to guess which way `(o + 3) % 4` maps coordinates.

The swap happens under a **non-blocking `RenderLock::Try`**: `render()` runs on its own task and writes the rotation flag, so turning the renderer under an in-flight frame would tear it. A failed acquire costs nothing — that tick resolves in the base orientation, which is what it did before this PR.

Worth noting the buttons already avoided the zone bug, by the opposite route: they resolve against `SETTINGS.orientation` deliberately, per the comment about a rotated panel inverting the front pair and walking backwards through panels. Touch never got the equivalent treatment.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the manga reader is this fork's own, and both behaviours are bugs in it rather than missing features.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* **Where to look first:** the `RenderLock::Try` block in `MangaReaderActivity::loop()`. It is the only place this PR touches shared renderer state from the input task, and the fallback path (lock busy → base orientation) is deliberately the pre-PR behaviour rather than a swallowed gesture.
* **Memory:** slightly lower than before. The chapter rows now borrow their labels from `tocEntries` instead of copying every title into a second `std::vector<std::string>` — one allocation per chapter saved, and `tocEntries` outlives the rows and is untouched after the constructor. `MangaReaderActivity` grows by one `bool`.
* **Behaviour that is unchanged:** button navigation resolves against `SETTINGS.orientation` exactly as before, and non-touch boards see nothing new — both touch helpers gate on `touchReaderControls` and `hasTouch()`.
* **Device-tested** on the iOS simulator build, X4 Pro profile, on a volume with panel crops: tapping "Mission 2" jumps to page 81/219 (previously any row opened the Cover); on a panel displayed rotated the page-turn gesture follows the panel's own axis, advancing 1/4 → 2/4; and the list scrolls and key-navigates like the other chapter pickers now that it shares their base class.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)