### PR TITLE
fix: Library: swipe scrolls the shelf grid too

### DIFF
--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -282,13 +282,13 @@ int RecentBooksActivity::gridContentHeight() const {
   return renderer.getScreenHeight() - gridTop - m.buttonHintsHeight - m.verticalSpacing;
 }
 
-int RecentBooksActivity::maxScrollRow(const int contentHeight) const {
+int RecentBooksActivity::maxScrollRow(const int contentHeight, const int itemCount) const {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const int cellWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / GRID_COLS;
   if (cellWidth <= 0) return 0;
   const int visibleRows = getVisibleRows(getCellHeight(cellWidth), contentHeight);
-  const int itemCount = getContentItemCount();
-  const int totalRows = (itemCount + GRID_COLS - 1) / GRID_COLS;
+  const int count = itemCount >= 0 ? itemCount : getContentItemCount();
+  const int totalRows = (count + GRID_COLS - 1) / GRID_COLS;
   return std::max(0, totalRows - visibleRows);
 }
 
@@ -1046,6 +1046,22 @@ void RecentBooksActivity::loop() {
       }
       return;
     }
+    // A swipe scrolls this grid's viewport, exactly as it does on the Library's own
+    // grid. Without it the shelf was reachable only by the keys: a shelf of any depth
+    // showed its first page and nothing a finger did moved past it.
+    const auto shelfSwipe = mappedInput.wasSwipe();
+    if (shelfSwipe == MappedInputManager::SwipeDir::Up || shelfSwipe == MappedInputManager::SwipeDir::Down) {
+      hideSelector();
+      const int step = shelfSwipe == MappedInputManager::SwipeDir::Up ? 1 : -1;
+      const int maxRow = maxScrollRow(contentHeight, shelfCount);
+      const int moved = std::clamp(shelfScrollRow + step, 0, maxRow);
+      if (moved != shelfScrollRow) {
+        shelfScrollRow = moved;
+        requestUpdate();
+      }
+      // Consumed either way, so a swipe cannot also read as a tap on the cover it ended on.
+      return;
+    }
 
     // The click that opened this shelf is still down: only a press that STARTS here may act, or
     // its release opens the focused book the instant the shelf appears (see shelfConfirmPressSeen).
@@ -1660,9 +1676,15 @@ void RecentBooksActivity::renderShelfBooksView(int contentTop, int contentHeight
   const int bookCount = static_cast<int>(shelfBooks.size());
   const int totalRows = (bookCount + GRID_COLS - 1) / GRID_COLS;
 
+  // Same rule as renderBooksTab: only the key selector drags the viewport with it. After a
+  // swipe the scroll position is the user's, and snapping it back to the selection would undo
+  // the gesture on the very next frame.
   const int selectedRow = shelfContentIndex >= 0 ? shelfContentIndex / GRID_COLS : 0;
-  if (selectedRow < shelfScrollRow) shelfScrollRow = selectedRow;
-  if (selectedRow >= shelfScrollRow + visibleRows) shelfScrollRow = selectedRow - visibleRows + 1;
+  if (selectorVisible) {
+    if (selectedRow < shelfScrollRow) shelfScrollRow = selectedRow;
+    if (selectedRow >= shelfScrollRow + visibleRows) shelfScrollRow = selectedRow - visibleRows + 1;
+  }
+  shelfScrollRow = std::clamp(shelfScrollRow, 0, std::max(0, totalRows - visibleRows));
 
   // See renderBooksTab: one peek row, no titles on it, badges filled synchronously.
   const int renderRows = std::min(totalRows - shelfScrollRow, visibleRows + 1);

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -76,7 +76,9 @@ class RecentBooksActivity final : public Activity {
   // The grid's viewport height, below the tab bar and above the button hints.
   [[nodiscard]] int gridContentHeight() const;
   // Highest scrollRow that still fills the viewport, for the swipe that scrolls it.
-  [[nodiscard]] int maxScrollRow(int contentHeight) const;
+  // itemCount defaults to the tabbed view's; the shelf detail view passes its own,
+  // since it scrolls its own grid of shelfBooks rather than the Library's.
+  [[nodiscard]] int maxScrollRow(int contentHeight, int itemCount = -1) const;
   // Absolute grid item index under a screen point, or -1 for a miss. Derives the cell grid the
   // same way renderBooksTab()/renderShelvesTab()/renderShelfBooksView() do, so the hit targets
   // are exactly the drawn cells. Deliberately stops at visibleRows: those renderers draw one


### PR DESCRIPTION
Follow-up to #234, found while regression-testing the merged branch on the iPhone build.

## Problem

A shelf's book grid answered taps, touch-downs and long presses, but had **no swipe handler at all**. So a shelf deeper than one screen showed its first page and nothing a finger did moved past it — the keys were the only way through. A 60-book shelf stayed on items 01–09 no matter how you swiped.

#234 gave the tabbed Library grid its swipe-scrolls-the-viewport gesture; the shelf detail view is a separate branch with its own `shelfContentIndex` / `shelfScrollRow` and was missed.

## Change

Same gesture, same meaning as the tabbed grid: the swipe scrolls the viewport a row at a time and leaves the selection alone, and any touch hides the key selector.

`renderShelfBooks`' follow-the-selection clamp now runs only for the key selector, exactly as `renderBooksTab`'s does. Unguarded it snaps the scroll back to wherever the selection sits and undoes the swipe on the very next frame — the same trap as in #234.

`maxScrollRow()` takes an explicit item count so the shelf can size its own grid; it defaults to the tabbed view's count, so the existing caller is unchanged.

## Testing

On the iOS simulator build with a 60-item shelf:

- swipe scrolls items 01–09 → 04–12, one row per swipe, no selector drawn
- tapping a cover still opens the book, and long-press still opens its stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)