### PR TITLE
fix: stop a long press re-firing when its action rotates the screen

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -15,9 +15,21 @@ namespace fui = freeink::ui;
 
 void MappedInputManager::update() const {
   gpio.update();
-  for (uint8_t value = 0; value <= static_cast<uint8_t>(Button::ScreenDown); ++value) {
-    if (!isPressed(static_cast<Button>(value))) longPressFiredButtons &= ~(1u << value);
+  longPressFiredButtons &= pressedRawButtons();
+}
+
+// The physical buttons held right now. Long-press bookkeeping is keyed on these rather than on the
+// logical Button the caller asked about, because the logical-to-physical mapping is not stable
+// across a single hold: an action can rotate the screen (the ORIENTATION_CHANGE long press), and
+// isNavDirectionSwapped() then hands the still-held button to a DIFFERENT logical name. Latching
+// logically let that renamed button re-arm and fire again, rotating over and over for as long as it
+// was held.
+uint16_t MappedInputManager::pressedRawButtons() const {
+  uint16_t mask = 0;
+  for (uint8_t raw = 0; raw <= HalGPIO::BTN_POWER; ++raw) {
+    if (gpio.isPressed(raw)) mask |= 1u << raw;
   }
+  return mask;
 }
 
 bool MappedInputManager::isNavDirectionSwapped() const {
@@ -368,24 +380,22 @@ bool MappedInputManager::wasReleased(const Button button) const {
 
 bool MappedInputManager::wasLongPressed(const Button button, const unsigned long thresholdMs) const {
   if (!isPressed(button)) return false;
-  const uint16_t bit = 1u << static_cast<uint8_t>(button);
-  if ((longPressFiredButtons & bit) != 0 || getHeldTime() < thresholdMs) return false;
-  longPressFiredButtons |= bit;
-  suppressNextRelease(button);
+  const uint16_t held = pressedRawButtons();
+  if ((longPressFiredButtons & held) != 0 || getHeldTime() < thresholdMs) return false;
+  longPressFiredButtons |= held;
+  suppressNextRelease(held);
   return true;
 }
 
-void MappedInputManager::suppressNextRelease(const Button button) const {
-  suppressedReleaseButtons |= 1u << static_cast<uint8_t>(button);
+void MappedInputManager::suppressNextRelease(const uint16_t rawButtons) const {
+  suppressedReleaseButtons |= rawButtons;
 }
 
 bool MappedInputManager::consumeSuppressedRelease() const {
   uint16_t released = 0;
-  for (uint8_t value = 0; value <= static_cast<uint8_t>(Button::ScreenDown); ++value) {
-    const uint16_t bit = 1u << value;
-    if ((suppressedReleaseButtons & bit) != 0 && mapButton(static_cast<Button>(value), &HalGPIO::wasReleased)) {
-      released |= bit;
-    }
+  for (uint8_t raw = 0; raw <= HalGPIO::BTN_POWER; ++raw) {
+    const uint16_t bit = 1u << raw;
+    if ((suppressedReleaseButtons & bit) != 0 && gpio.wasReleased(raw)) released |= bit;
   }
   suppressedReleaseButtons &= ~released;
   return released != 0;

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -157,11 +157,15 @@ class MappedInputManager {
   bool wasPowerConfirmClick() const;
 #endif
   void rememberTouchHeldTime() const;
-  void suppressNextRelease(Button button) const;
+  // Bitmask of HalGPIO button indices, not of Button values -- see pressedRawButtons().
+  uint16_t pressedRawButtons() const;
+  void suppressNextRelease(uint16_t rawButtons) const;
 
   mutable bool touchHeldOverrideValid = false;
   mutable unsigned long touchHeldOverrideMs = 0;
   mutable unsigned long touchHeldOverrideAt = 0;
+  // Both are masks of PHYSICAL HalGPIO button indices. A hold keeps its identity across an action
+  // that remaps the logical buttons (orientation change), which a logical mask cannot.
   mutable uint16_t longPressFiredButtons = 0;
   mutable uint16_t suppressedReleaseButtons = 0;
 #if FREEINK_CAP_TOUCH


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes the "screen rotates three times" report on the X4 Pro ([#160 comment](https://github.com/eszter007/matcha-reader/issues/160#issuecomment-5622628025), [#209 comment](https://github.com/eszter007/matcha-reader/issues/209#issuecomment-5589054665)). With **Long press behaviour = Orientation change** and **Side button layout = Next/Prev**, holding the side button mapped to "next" rotated the screen over and over instead of once. The other side button behaved correctly.
* **What changes are included?** `MappedInputManager` now keys its long-press latch and its release-suppression mask on physical `HalGPIO` button indices instead of logical `Button` values. Two files, `src/MappedInputManager.cpp` and `src/MappedInputManager.h`.

### Root cause

`wasLongPressed()` latched "already fired" against the **logical** button, and `update()` re-armed that latch as soon as the logical button stopped being pressed. The orientation change breaks that assumption: `isNavDirectionSwapped()` flips for `INVERTED` and `LANDSCAPE_CCW`, so the still-held physical button lands under a different logical name. The old latch clears, the new name has none, the held time is already past the 700 ms threshold, and it fires again on the next poll.

Only one direction breaks because only one crosses a swap boundary. Prev goes `PORTRAIT -> LANDSCAPE_CW`, neither of which swaps, so nothing is remapped. Next goes `PORTRAIT -> LANDSCAPE_CCW`, which does, and then it ping-pongs between those two for as long as the button is down. On the panel the e-ink refresh throttles that to the three flips the report describes.

One physical hold now produces one long press, whatever the action does to the mapping in between. The release mask had to move with it: after a rotation the release no longer matches the suppressed logical button, so it would otherwise leak through as a page turn.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

Bug fix in existing reader input handling, no new feature. It touches neither `freeink-sdk/` nor `lib/hal/`.

## Additional Context

Reproduced and verified in the simulator (`simulator_x4_pro`), driving the side buttons through `CROSSPOINT_SIM_INPUT_SCRIPT`. Before the fix, a 3 second hold on "next":

```
[9339] [ROT] orientation 3 -> 0 (prev=1 next=0 held=2304)
[9373] [ROT] orientation 0 -> 3 (prev=0 next=1 held=2338)
[9407] [ROT] orientation 3 -> 0 (prev=1 next=0 held=2372)
... 20+ more
```

After: one rotation per hold, in both directions. Neighbouring behaviour checked too, since the latch is shared across every long-press call site: short presses still turn pages (1/3 -> 3/3), a chapter-skip hold still skips exactly one chapter, a Confirm hold still opens the reader menu, and the page number survives the rotation.

Risk is concentrated in the change of granularity. Previously two different logical names resolving to the same held physical button could each fire their own long press; now the first one claims the hold. No current call site polls an overlapping pair, and the same reasoning applies to the release mask.

Memory / flash impact: none worth measuring. The per-button loops it replaces ran over 15 logical values and now run over 7 physical ones.

Building the simulator against current develop needed matching HAL stubs, which went to crosspoint-simulator-ios separately (`getController()`, the `freeink::Grayscale*` types with `grayscaleCapabilities()`, and `HalGPIO::rawInputActive()`). Nothing in this PR depends on them.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_