### PR TITLE
perf: buffer the JPEG decoder's source reads

### DIFF
--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -9,6 +9,7 @@
 #include <Memory.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <new>
 
@@ -65,22 +66,43 @@ struct JpegContext {
   uint32_t lastYieldMs{0};  // throttle state for yieldDuringDecode()
 };
 
-// File I/O callbacks use pFile->fHandle to access the HalFile*,
-// avoiding the need for global file state.
+// Buffered source for the decoder's file reads, reached through pFile->fHandle (no global state).
+//
+// JPEGDEC refills its own 2KB window (JPEG_FILE_BUF_SIZE) and asks for whatever is left of it, so
+// a 660KB image arrives as ~420 reads averaging 1.5KB. Each HalFile::read costs ~4ms almost
+// regardless of size -- measured 3.97ms for these 1.5KB reads and 3.9ms for the 4KB reads on the
+// .pxc path -- because the storage mutex, SdFat's cache block and the interleaved .pxc writes are
+// all per-call costs. That made SD reads HALF of a 3341ms decode. Refilling in one large read
+// collapses the call count instead.
+constexpr int32_t JPEG_SOURCE_BUF_SIZE = 8192;
+
+struct JpegSource {
+  HalFile file;
+  std::unique_ptr<uint8_t[]> buf;
+  int32_t bufFileOff = 0;  // file offset of buf[0]
+  int32_t bufLen = 0;      // valid bytes in buf
+  int32_t pos = 0;         // logical file position handed to the decoder
+  int32_t size = 0;
+};
+
 void* jpegOpen(const char* filename, int32_t* size) {
-  HalFile* f = new HalFile();
-  if (!Storage.openFileForRead("JPG", std::string(filename), *f)) {
-    delete f;
+  JpegSource* s = new (std::nothrow) JpegSource();
+  if (!s) return nullptr;
+  if (!Storage.openFileForRead("JPG", std::string(filename), s->file)) {
+    delete s;
     return nullptr;
   }
-  *size = f->size();
-  return f;
+  s->size = s->file.size();
+  *size = s->size;
+  // Optional: a null buffer just means every read goes straight to SD, exactly as before.
+  s->buf = makeUniqueNoThrow<uint8_t[]>(JPEG_SOURCE_BUF_SIZE);
+  return s;
 }
 
 void jpegClose(void* handle) {
-  HalFile* f = reinterpret_cast<HalFile*>(handle);
+  JpegSource* f = reinterpret_cast<JpegSource*>(handle);
   if (f) {
-    f->close();
+    f->file.close();
     delete f;
   }
 }
@@ -90,18 +112,48 @@ void jpegClose(void* handle) {
 // MUST maintain iPos to match the actual file position, otherwise progressive
 // JPEGs with large headers fail during parsing.
 int32_t jpegRead(JPEGFILE* pFile, uint8_t* pBuf, int32_t len) {
-  HalFile* f = reinterpret_cast<HalFile*>(pFile->fHandle);
-  if (!f) return 0;
-  int32_t bytesRead = f->read(pBuf, len);
-  if (bytesRead < 0) return 0;
-  pFile->iPos += bytesRead;
-  return bytesRead;
+  JpegSource* f = reinterpret_cast<JpegSource*>(pFile->fHandle);
+  if (!f || len <= 0) return 0;
+
+  if (!f->buf) {  // unbuffered fallback (allocation declined at open)
+    const int32_t n = f->file.read(pBuf, len);
+    if (n <= 0) return 0;
+    f->pos += n;
+    pFile->iPos = f->pos;
+    return n;
+  }
+
+  int32_t done = 0;
+  while (done < len) {
+    const int32_t inBuf = f->pos - f->bufFileOff;  // consumed offset within buf
+    if (inBuf >= 0 && inBuf < f->bufLen) {
+      int32_t take = f->bufLen - inBuf;
+      if (take > len - done) take = len - done;
+      memcpy(pBuf + done, f->buf.get() + inBuf, (size_t)take);
+      done += take;
+      f->pos += take;
+      continue;
+    }
+    if (f->pos >= f->size) break;  // EOF
+
+    // Refill: one large read replaces the many small ones the decoder would otherwise make.
+    if (!f->file.seek(f->pos)) break;
+    const int32_t n = f->file.read(f->buf.get(), JPEG_SOURCE_BUF_SIZE);
+    if (n <= 0) break;
+    f->bufFileOff = f->pos;
+    f->bufLen = n;
+  }
+
+  pFile->iPos = f->pos;
+  return done;
 }
 
 int32_t jpegSeek(JPEGFILE* pFile, int32_t pos) {
-  HalFile* f = reinterpret_cast<HalFile*>(pFile->fHandle);
+  JpegSource* f = reinterpret_cast<JpegSource*>(pFile->fHandle);
   if (!f) return -1;
-  if (!f->seek(pos)) return -1;
+  // Seeking inside the buffered window costs nothing; the next read serves from RAM. Anything
+  // else just moves the logical position and lets the next read refill.
+  f->pos = pos;
   pFile->iPos = pos;
   return pos;
 }
@@ -109,7 +161,9 @@ int32_t jpegSeek(JPEGFILE* pFile, int32_t pos) {
 // JPEGDEC object is ~17 KB due to internal decode buffers.
 // Heap-allocate on demand so memory is only used during active decode.
 constexpr size_t JPEG_DECODER_APPROX_SIZE = 20 * 1024;
-constexpr size_t MIN_FREE_HEAP_FOR_JPEG = JPEG_DECODER_APPROX_SIZE + 16 * 1024;
+// Includes the source read buffer: it is allocated for the length of the decode, so the gate has
+// to cover it or a decode is admitted that cannot afford its own input path.
+constexpr size_t MIN_FREE_HEAP_FOR_JPEG = JPEG_DECODER_APPROX_SIZE + JPEG_SOURCE_BUF_SIZE + 16 * 1024;
 
 // Choose JPEGDEC's built-in scale factor for coarse downscaling.
 // Returns the scale denominator (1, 2, 4, or 8) and sets jpegScaleOption.


### PR DESCRIPTION
Opening a book with a cover image was taking ~6s on a cold cache, and half of that was one JPEG decode. Instrumenting the decode split it three ways:

```
total=3341ms  read=1659ms (418 calls, 661015 B, avg 3969us)  draw=712ms  other=970ms
```

SD reads were half the decode. JPEGDEC refills its own 2KB window (`JPEG_FILE_BUF_SIZE`) and asks for whatever is left of it, so a 660KB image arrives as 418 reads averaging 1581 bytes — and a `HalFile::read` costs roughly the same regardless of size, because the storage mutex, SdFat's cache block, and the `.pxc` cache writes interleaved with those reads are all per-call costs. The `.pxc` streaming path measured 3.9ms for 4KB reads against 3.97ms for these 1.5KB ones, which is what pinned it down.

Serving the decoder from an 8KB buffer collapses 418 calls to 81:

| | before | after |
|---|---|---|
| total | 3341 ms | **2624 ms** |
| read | 1659 ms, 418 calls | **963 ms, 81 calls** |
| draw | 712 ms | 673 ms |
| other | 970 ms | 988 ms |

A cold image decode is ~22% faster for 8KB of heap held only for the length of the decode.

## Why 8KB and not more

Fitting the two measured points (1581 B/call at 3969us, 8161 B/call at 11895us) gives **~2.07ms fixed per call plus ~1.2us/byte** (≈830 KB/s). At 81 calls the fixed overhead is already down to ~167ms against ~796ms of irreducible transfer. 16KB would recover perhaps 80ms more for another 8KB of heap — not a trade worth making here.

## What is left, and why this stops here

Of the remaining 2624ms: ~963ms is SD transfer near its floor, ~988ms is JPEGDEC's huffman pass, and ~673ms is the output loop. Huffman does not scale — every coefficient in the source is parsed even though `jpegScale 1/2` discards most of them — so the only lever there is optimisation level. I measured that too: `-O2` moved `other` by 1ms (988 → 989) because JPEGDEC is a `lib_deps` library and the flag never reached it. It moved the output loop 658 → 608ms. Neither is in this PR.

I also tried hoisting `ctx->config->lightenBy` out of the inner pixel loops on the theory that `uint8_t*` aliasing forced a reload per pixel. It was worth 15ms of 673 — noise. Reverted.

## Notes

The buffer is optional: if `makeUniqueNoThrow` declines, reads go straight to SD exactly as before. `MIN_FREE_HEAP_FOR_JPEG` now accounts for it, since it stays resident for the decode.

`jpegSeek` no longer touches the file — it moves the logical position and lets the next read refill, so a seek inside the buffered window is served from RAM.

## Testing

Built and flashed to an X4 (ESP32-C3). Cold-cache decode of the same 1393x2048 cover measured repeatedly: 2624ms and 2555ms against a 3341ms baseline, with read time and call counts as above. Page renders correctly; no new errors in the serial log.

Not covered: a progressive JPEG, which is the case that would exercise the rewritten `jpegSeek` hardest (JPEGDEC seeks more during progressive parsing). The buffered path handles backward and forward seeks, but I had no progressive image to hand.
