### PR TITLE
feat(manga): convert western comics, and trim printed page margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ python3 tools/manga_convert/convert_manga.py \
   --x4
 ```
 
-Set `--language` on every manga. It is what splits your reading time by language, and most manga carries no language of its own. The tag is read at conversion time, so a book converted without it counts as unknown until you convert it again.
+Set `--language` on every book. It splits your reading time by language, and it tells the OCR pass which language to expect. Most manga carries no language of its own. The tag is read at conversion time, so a book converted without it counts as unknown until you convert it again.
 
 `--input` takes an image folder, `.cbz`, `.zip`, `.epub` or PDF. The flags worth knowing:
 
@@ -186,11 +186,19 @@ Set `--language` on every manga. It is what splits your reading time by language
 | `--x4` / `--x3` | Scale to the device screen. Smaller files, faster page turns, nothing lost. |
 | `--mono` | 1-bit dithered BMP. Good for line art, less so for heavy screentone. |
 | `--no-ocr` | Panel boxes only, no Gemini calls, no text or translations. |
+| `--ltr` | Read panels left-to-right, for western comics and strips. Default is manga order. |
+| `--trim-margins` | Crop the blank paper border and page number off scanned pages. |
 | `--max-pages N` | Convert the first N pages as a cheap test. |
 | `--title` / `--author` | Override metadata. |
 | `--language` | Book language tag. See above. |
 
 Panels are found with a YOLO model trained on Manga109 ([leoxs22/manga-panel-detector-yolo26n](https://huggingface.co/leoxs22/manga-panel-detector-yolo26n)), falling back to a white-gutter heuristic without `ultralytics`. Gemini then reads and translates each panel.
+
+Western comics work too. Pass `--ltr` so panels within a row are walked left-to-right. The panel detector was trained on manga but handles strip layouts well; page turn direction is a device setting (Reverse page turn), not a conversion one.
+
+OCR follows `--language`, so it works on any of them. The prompt names the language it should expect, which is what stops the model hallucinating Japanese out of a German speech bubble, and a book already in English gets transcription without a pointless English-to-English translation. Set the tag even if you don't care about reading stats.
+
+Add `--trim-margins` for anything scanned from print. It crops the paper border away before panels are detected, which both fills the screen and measurably improves detection: a Moomin page that came back as 9 panels untrimmed, with one whole strip undivided, split into all 11 once the margin was gone.
 
 The output is a folder of images, panel crops and three small index files. Drop it anywhere on the card, the Library finds any folder containing `panels.idx`.
 

--- a/tools/manga_convert/convert_manga.py
+++ b/tools/manga_convert/convert_manga.py
@@ -128,21 +128,89 @@ IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
 GEMINI_MODEL = "gemini-3.6-flash"
 GEMINI_URL = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent"
 
-PANEL_OCR_PROMPT = """This image is a single panel cropped from a Japanese manga page.
+# Language the panel translations are produced in. The device shows them alongside the
+# original text as a reading aid, so a panel already in this language gets no translation.
+TRANSLATION_TARGET = "English"
+
+# Names for the --language tag, used to tell the OCR model what it is looking at. Only the
+# primary subtag is looked up ("zh-Hant" -> "zh"), and an unlisted tag just yields a prompt
+# that doesn't name a language, which reads fine and still works.
+OCR_LANGUAGE_NAMES = {
+    "ja": "Japanese", "en": "English", "de": "German", "fr": "French", "es": "Spanish",
+    "it": "Italian", "pt": "Portuguese", "nl": "Dutch", "sv": "Swedish", "fi": "Finnish",
+    "da": "Danish", "no": "Norwegian", "pl": "Polish", "cs": "Czech", "hu": "Hungarian",
+    "ru": "Russian", "uk": "Ukrainian", "tr": "Turkish", "ko": "Korean", "zh": "Chinese",
+    "ar": "Arabic", "he": "Hebrew", "th": "Thai", "vi": "Vietnamese", "id": "Indonesian",
+}
+
+PANEL_OCR_PROMPT_TEMPLATE = """This image is a single panel cropped from {page_desc}.
 List every piece of text/dialogue visible in this panel, in the order a
-reader would read them (top-to-bottom, right-to-left for manga). Then give
-a single natural English translation of all of it combined, in the same
-reading order, as it would read in an English localization of this manga.
+reader would read them ({reading_order}). {translation_instruction}
 
 Return ONLY a JSON object, no other text:
-{"blocks": [{"text": "<the Japanese text, line breaks as \\n>",
-             "bbox_2d": [ymin, xmin, ymax, xmax]}, ...],
- "translation": "<natural English translation of all the panel's text combined, in reading order>"}
+{{"blocks": [{{"text": "<the {text_desc}, line breaks as \\n>",
+             "bbox_2d": [ymin, xmin, ymax, xmax]}}, ...],
+ "translation": {translation_field}}}
 
 bbox_2d is each text region's bounding box normalized to a 0-1000 scale
 (0,0 = top-left of the panel image, 1000,1000 = bottom-right). If you
 cannot determine a precise box, omit bbox_2d for that entry.
-If there is no text in the panel, return {"blocks": [], "translation": ""}."""
+If there is no text in the panel, return {{"blocks": [], "translation": ""}}."""
+
+
+def build_panel_ocr_prompt(language: str = "", rtl: bool = True) -> str:
+    """The OCR prompt for a book in `language`, read right-to-left or not.
+
+    Telling the model which language to expect matters: asked for "the Japanese text",
+    it will hallucinate Japanese out of a German speech bubble rather than transcribe
+    what is there. A book already in the translation target gets no translation asked
+    for at all -- the device shows translations as a reading aid, and "Oh no!" rendered
+    into English is noise.
+
+    An unknown language yields a prompt that names none, which the model handles fine.
+    Reading order follows the panel order (--ltr), not the language: it is a property of
+    the layout, and the same language appears in books of both conventions.
+    """
+    primary = language.strip().lower().replace("_", "-").partition("-")[0]
+    name = OCR_LANGUAGE_NAMES.get(primary, "")
+    # "manga" only for Japanese (and for an unset language, where right-to-left panel order
+    # is the strong hint). Chinese and Korean comics are manhua and manhwa; calling them manga
+    # tells the model something false about the page for no gain.
+    if primary == "ja":
+        page_desc = "a Japanese manga page"
+    elif not primary and rtl:
+        page_desc = "a manga page"
+    elif name:
+        page_desc = f"a comic page in {name}"
+    else:
+        page_desc = "a comic page"
+
+    reading_order = "top-to-bottom, right-to-left" if rtl else "left-to-right, top-to-bottom"
+    text_desc = f"{name} text" if name else "text exactly as it appears"
+
+    if name == TRANSLATION_TARGET:
+        # Nothing to translate -- say so explicitly, or the model invents a paraphrase.
+        translation_instruction = (
+            f"The text is already in {TRANSLATION_TARGET}, so no translation is needed."
+        )
+        translation_field = '""'
+    else:
+        target_phrase = f"a {name} comic" if name else "this comic"
+        translation_instruction = (
+            f"Then give\na single natural {TRANSLATION_TARGET} translation of all of it combined, in the same\n"
+            f"reading order, as it would read in an {TRANSLATION_TARGET} localization of {target_phrase}."
+        )
+        translation_field = (
+            f'"<natural {TRANSLATION_TARGET} translation of all the panel\'s text combined, in reading order>"'
+        )
+
+    return PANEL_OCR_PROMPT_TEMPLATE.format(
+        page_desc=page_desc,
+        reading_order=reading_order,
+        translation_instruction=translation_instruction,
+        text_desc=text_desc,
+        translation_field=translation_field,
+    )
 
 
 # ── Page collection / ordering ───────────────────────────────────
@@ -551,8 +619,8 @@ def _detect_panels_yolo(img, conf: float = 0.4) -> list[list[int]] | None:
 
 def _snap_to_unclaimed_edges(boxes: list[list[int]], page_w: int, page_h: int,
                              max_gap_frac: float = 0.15) -> list[list[int]]:
-    """Extend a panel's edge to the page boundary when it falls short by a
-    plausible amount AND no other detected panel claims that space.
+    """Extend a panel's edge to the edge of the page's CONTENT when it falls
+    short by a plausible amount AND no other detected panel claims that space.
 
     The detector sometimes underestimates a panel's true extent near the
     page edge (e.g. missing a speech bubble that reaches close to the
@@ -560,9 +628,24 @@ def _snap_to_unclaimed_edges(boxes: list[list[int]], page_w: int, page_h: int,
     being a deliberate gutter. Only snap small gaps (<15% of the page
     dimension) and only when nothing else occupies the overlapping range,
     so real gutters between adjacent panels are left alone.
+
+    The target is the union of all detected boxes, NOT the paper edge, so a
+    printed page's own margins are respected. Snapping to the paper edge
+    swallowed those margins whenever they were narrower than the threshold:
+    a scanned comic page with a 13% side margin had every panel stretched
+    into it, and a page with a footer had its bottom row stretched over the
+    page number. Both produce panel crops padded with blank paper, which is
+    exactly the screen area panel zoom exists to reclaim.
     """
     original = [tuple(b) for b in boxes]
     result = [list(b) for b in boxes]
+    if not original:
+        return result
+
+    left = min(b[0] for b in original)
+    top = min(b[1] for b in original)
+    right = max(b[2] for b in original)
+    bottom = max(b[3] for b in original)
 
     def claimed_beyond(i: int, axis: str, beyond) -> bool:
         ox1, oy1, ox2, oy2 = original[i]
@@ -580,18 +663,18 @@ def _snap_to_unclaimed_edges(boxes: list[list[int]], page_w: int, page_h: int,
         return False
 
     for i, (x1, y1, x2, y2) in enumerate(original):
-        if 0 < page_w - x2 < page_w * max_gap_frac and \
+        if 0 < right - x2 < page_w * max_gap_frac and \
            not claimed_beyond(i, "x", lambda j1, j2, o1, o2: j2 > o2):
-            result[i][2] = page_w
-        if 0 < x1 < page_w * max_gap_frac and \
+            result[i][2] = right
+        if 0 < x1 - left < page_w * max_gap_frac and \
            not claimed_beyond(i, "x", lambda j1, j2, o1, o2: j1 < o1):
-            result[i][0] = 0
-        if 0 < page_h - y2 < page_h * max_gap_frac and \
+            result[i][0] = left
+        if 0 < bottom - y2 < page_h * max_gap_frac and \
            not claimed_beyond(i, "y", lambda j1, j2, o1, o2: j2 > o2):
-            result[i][3] = page_h
-        if 0 < y1 < page_h * max_gap_frac and \
+            result[i][3] = bottom
+        if 0 < y1 - top < page_h * max_gap_frac and \
            not claimed_beyond(i, "y", lambda j1, j2, o1, o2: j1 < o1):
-            result[i][1] = 0
+            result[i][1] = top
 
     return result
 
@@ -710,18 +793,23 @@ def _y_overlap_frac(a: list[int], b: list[int]) -> float:
     return max(0.0, overlap) / max(1, min_h)
 
 
-def sort_panels_manga_order(panels: list[list[int]]) -> list[list[int]]:
-    """Sort panel boxes in manga reading order via a "reads-before" graph,
-    then a topological sort -- robust to mixed-size grids (e.g. one tall
-    panel beside two stacked shorter ones), which simple row-clustering by
+def sort_panels_reading_order(panels: list[list[int]], rtl: bool = True) -> list[list[int]]:
+    """Sort panel boxes in reading order via a "reads-before" graph, then a
+    topological sort -- robust to mixed-size grids (e.g. one tall panel
+    beside two stacked shorter ones), which simple row-clustering by
     Y-center gets wrong.
 
     For every pair of panels: if their vertical extents overlap
-    substantially, they're in the same tier and read right-to-left; if not,
+    substantially, they're in the same tier and read horizontally; if not,
     whichever is higher up reads first (the other dimension doesn't matter
     once there's no vertical overlap). This produces a partial order;
     topological sort resolves the full reading sequence, with same-rank
-    ties broken top-to-bottom then right-to-left.
+    ties broken top-to-bottom then along the horizontal direction.
+
+    rtl=True is manga order (right-to-left within a tier); rtl=False is
+    western comics and strips -- Moomin, Peanuts -- which read left-to-right.
+    The direction only affects within-tier ordering: tiers themselves always
+    run top-to-bottom, in both conventions.
     """
     n = len(panels)
     if n <= 1:
@@ -738,7 +826,7 @@ def sort_panels_manga_order(panels: list[list[int]]) -> list[list[int]]:
             a, b = panels[i], panels[j]
             if _y_overlap_frac(a, b) > OVERLAP_THRESHOLD:
                 a_cx, b_cx = (a[0] + a[2]) / 2, (b[0] + b[2]) / 2
-                if a_cx > b_cx:  # same tier: right-to-left
+                if (a_cx > b_cx) if rtl else (a_cx < b_cx):  # same tier
                     edges[i].append(j)
                     in_degree[j] += 1
             else:
@@ -749,7 +837,8 @@ def sort_panels_manga_order(panels: list[list[int]]) -> list[list[int]]:
 
     def tie_break_key(i: int):
         x1, y1, x2, y2 = panels[i]
-        return ((y1 + y2) / 2, -(x1 + x2) / 2)
+        cx = (x1 + x2) / 2
+        return ((y1 + y2) / 2, -cx if rtl else cx)
 
     available = [i for i in range(n) if in_degree[i] == 0]
     result: list[int] = []
@@ -773,7 +862,8 @@ def sort_panels_manga_order(panels: list[list[int]]) -> list[list[int]]:
 # ── Gemini OCR (invoked via curl, key never embedded in code) ───
 
 
-def call_gemini_panel_ocr(image_path: str, api_key: str, timeout: int = 60, retries: int = 3) -> dict:
+def call_gemini_panel_ocr(image_path: str, api_key: str, prompt: str,
+                          timeout: int = 60, retries: int = 3) -> dict:
     """Ask Gemini what text appears in a panel image, plus an English
     translation of it. Returns {"blocks": [{"text", "bbox_2d"}, ...],
     "translation": str}. Retries on transient errors (503/429/network) with
@@ -782,7 +872,7 @@ def call_gemini_panel_ocr(image_path: str, api_key: str, timeout: int = 60, retr
     rather than aborting the whole run.
     """
     for attempt in range(retries):
-        result = _call_gemini_panel_ocr_once(image_path, api_key, timeout)
+        result = _call_gemini_panel_ocr_once(image_path, api_key, prompt, timeout)
         if result is not None:
             return result
         if attempt < retries - 1:
@@ -790,7 +880,7 @@ def call_gemini_panel_ocr(image_path: str, api_key: str, timeout: int = 60, retr
     return {"blocks": [], "translation": ""}
 
 
-def _call_gemini_panel_ocr_once(image_path: str, api_key: str, timeout: int) -> dict | None:
+def _call_gemini_panel_ocr_once(image_path: str, api_key: str, prompt: str, timeout: int) -> dict | None:
     """Single attempt. Returns None (not the empty dict) on a transient
     failure so the retry loop above can distinguish "retry" from "this
     panel genuinely has no text" (the latter is a successful empty result)."""
@@ -802,7 +892,7 @@ def _call_gemini_panel_ocr_once(image_path: str, api_key: str, timeout: int) -> 
     payload = {
         "contents": [{
             "parts": [
-                {"text": PANEL_OCR_PROMPT},
+                {"text": prompt},
                 {"inline_data": {"mime_type": mime, "data": image_b64}},
             ]
         }],
@@ -1238,6 +1328,36 @@ def normalize_for_output(img):
     return img
 
 
+def trim_page_margins(img, threshold: int = 230, pad: int = 2):
+    """Crop the blank paper border off a scanned page, keeping the artwork.
+
+    Printed comics and manga carry a white margin plus a page number that the
+    device has no reason to render: it eats screen area on a page that is
+    already small, and it is the difference between a page filling the display
+    and floating in the middle of it. The crop happens before panel detection,
+    so every coordinate downstream already lives in the trimmed page's space.
+
+    Detects content as "pixels darker than `threshold`" and keeps `pad` pixels
+    of paper around the result. Returns img unchanged when the page is blank or
+    has no margin to remove.
+
+    ponytail: a single global threshold, so a dark scan edge or heavy dust
+    along one border blocks the trim on that side. That fails safe (no crop),
+    and per-side row/column voting is the upgrade if real scans need it.
+    """
+    gray = img.convert("L")
+    bbox = gray.point(lambda p: 255 if p < threshold else 0, mode="1").getbbox()
+    if not bbox:
+        return img
+    x1 = max(0, bbox[0] - pad)
+    y1 = max(0, bbox[1] - pad)
+    x2 = min(img.width, bbox[2] + pad)
+    y2 = min(img.height, bbox[3] + pad)
+    if (x1, y1, x2, y2) == (0, 0, img.width, img.height):
+        return img
+    return img.crop((x1, y1, x2, y2))
+
+
 def fit_to_device(img, target):
     """Downscale img to fit the device screen box; never upscale, never change aspect.
 
@@ -1281,6 +1401,21 @@ def main():
     parser.add_argument("--no-ocr", action="store_true", help="Skip Gemini OCR -- panel boxes only, no text")
     parser.add_argument("--panel-margin", type=int, default=10, help="Pixels of margin added around cropped panels")
     parser.add_argument("--max-pages", type=int, help="Only process the first N pages (for testing)")
+    parser.add_argument(
+        "--trim-margins",
+        action="store_true",
+        help="Crop the blank paper border (and the page number sitting in it) off every page "
+             "before anything else, so the artwork fills the screen instead of floating in the "
+             "middle of it. Scanned print comics and manga usually have one; digital-native "
+             "releases usually don't, and are left alone.",
+    )
+    parser.add_argument(
+        "--ltr",
+        action="store_true",
+        help="Order panels left-to-right within a row, for western comics and newspaper strips "
+             "(Moomin, Peanuts). Default is manga order, right-to-left. Page order is unaffected; "
+             "set the device's Reverse page turn setting for that.",
+    )
     parser.add_argument(
         "--toc-file",
         help='Chapter list: one per line, "<page_index>\\t<title>" (0-based, referring to the FINAL '
@@ -1368,9 +1503,17 @@ def main():
         auto_title, auto_author, auto_language = extract_metadata(args.input, work_dir)
         meta_title = args.title if args.title else auto_title
         meta_author = args.author if args.author else auto_author
-        meta_language = args.language if args.language else auto_language
+        # Normalised here rather than only inside write_meta, because the OCR prompt is built
+        # from the same tag and 'jp' must reach it as 'ja'. normalize_language is idempotent,
+        # so write_meta's own call is a no-op and prints no second note.
+        meta_language = normalize_language(args.language if args.language else auto_language)
         if meta_title or meta_author or meta_language:
             write_meta(args.output_dir, meta_title, meta_author, meta_language)
+
+        ocr_prompt = build_panel_ocr_prompt(meta_language, rtl=not args.ltr)
+        if api_key and not meta_language:
+            print("Note: no --language set; the OCR prompt will not name a source language. "
+                  "Pass --language for better text recognition.", file=sys.stderr)
 
         idx_records = []
         dat_chunks = []
@@ -1390,6 +1533,18 @@ def main():
             # progressive even though the user passed --x4 precisely to avoid that. Note it here,
             # while `img` is still the file as opened.
             src_is_progressive = bool(img.info.get("progressive") or img.info.get("progression"))
+            if args.trim_margins:
+                trimmed = trim_page_margins(img)
+                if trimmed is not img:
+                    # The cropped page no longer matches the source file, so the verbatim
+                    # copy below must not be taken -- force a re-encode by the same route a
+                    # resize does.
+                    was_trimmed = True
+                    img = trimmed
+                else:
+                    was_trimmed = False
+            else:
+                was_trimmed = False
             # Downscale FIRST, before panel detection: every coordinate downstream (panel boxes,
             # crop rects, OCR text boxes, the page dims in panels.idx) then lives in the resized
             # space, matching the page/crop files actually written -- nothing needs rescaling.
@@ -1421,7 +1576,7 @@ def main():
                     img.convert("RGB").save(
                         os.path.join(args.output_dir, f"page_{page_idx:04d}{ext}"), "JPEG", quality=92
                     )
-                elif was_resized or src_is_progressive:
+                elif was_resized or was_trimmed or src_is_progressive:
                     # Resized: the source file no longer matches -- re-encode in the source's own
                     # format so the output keeps its extension (PNG stays PNG, JPEG stays JPEG).
                     # Progressive: the bytes still match, but re-encode anyway so the page lands on
@@ -1439,7 +1594,7 @@ def main():
                     shutil.copy(src_path, os.path.join(args.output_dir, f"page_{page_idx:04d}{ext}"))
 
             boxes = detect_panels(img)
-            boxes = sort_panels_manga_order(boxes)
+            boxes = sort_panels_reading_order(boxes, rtl=not args.ltr)
 
             # Crop and save every panel first (fast, local) before dispatching
             # the slow network calls concurrently -- OCR is I/O-bound (network
@@ -1484,7 +1639,7 @@ def main():
                 # Only call Gemini for panels that have a crop file;
                 # full-page panels (no crop) get an empty result directly.
                 def _ocr_or_empty(p):
-                    return call_gemini_panel_ocr(p, api_key) if p else {"blocks": [], "translation": ""}
+                    return call_gemini_panel_ocr(p, api_key, ocr_prompt) if p else {"blocks": [], "translation": ""}
                 with ThreadPoolExecutor(max_workers=min(8, max(1, len(panel_paths)))) as pool:
                     ocr_results = list(pool.map(_ocr_or_empty, panel_paths))
             else:

--- a/tools/manga_convert/test_panel_order.py
+++ b/tools/manga_convert/test_panel_order.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Self-check for panel reading order, edge snapping and the OCR prompt.
+No deps -- run: python3 test_panel_order.py
+
+Boxes are [x1, y1, x2, y2]. Each ordering case lists panels in an arbitrary
+input order and asserts the sequence the reader should walk them in.
+"""
+
+from convert_manga import _snap_to_unclaimed_edges, build_panel_ocr_prompt, sort_panels_reading_order
+
+
+def order(panels, named, rtl):
+    """Return the sorted panels as their names from `named` ({name: box})."""
+    by_box = {tuple(b): n for n, b in named.items()}
+    return [by_box[tuple(b)] for b in sort_panels_reading_order(panels, rtl=rtl)]
+
+
+def test_strip_page_ltr():
+    """A Moomin-style page: four horizontal strips, three panels each."""
+    named = {}
+    for row in range(4):
+        for col in range(3):
+            named[f"r{row}c{col}"] = [col * 280, row * 300, col * 280 + 270, row * 300 + 260]
+    panels = list(named.values())[::-1]  # shuffled input
+    assert order(panels, named, rtl=False) == [f"r{r}c{c}" for r in range(4) for c in range(3)]
+    # Same page read as manga: tiers still top-to-bottom, columns reversed.
+    assert order(panels, named, rtl=True) == [f"r{r}c{c}" for r in range(4) for c in (2, 1, 0)]
+
+
+def test_tall_panel_beside_stacked_pair():
+    """The layout Y-center clustering gets wrong: one full-height panel next
+    to two stacked half-height ones."""
+    named = {
+        "tall": [0, 0, 300, 400],
+        "top": [320, 0, 600, 190],
+        "bottom": [320, 210, 600, 400],
+        "below": [0, 420, 600, 700],
+    }
+    panels = [named["below"], named["bottom"], named["tall"], named["top"]]
+    assert order(panels, named, rtl=False) == ["tall", "top", "bottom", "below"]
+    assert order(panels, named, rtl=True) == ["top", "bottom", "tall", "below"]
+
+
+def test_full_width_strip_between_rows():
+    """A splash panel spanning the page separates the tiers above and below."""
+    named = {
+        "a": [0, 0, 290, 200],
+        "b": [310, 0, 600, 200],
+        "splash": [0, 220, 600, 420],
+        "c": [0, 440, 290, 640],
+        "d": [310, 440, 600, 640],
+    }
+    panels = [named["d"], named["splash"], named["a"], named["c"], named["b"]]
+    assert order(panels, named, rtl=False) == ["a", "b", "splash", "c", "d"]
+    assert order(panels, named, rtl=True) == ["b", "a", "splash", "d", "c"]
+
+
+def test_single_and_empty():
+    assert sort_panels_reading_order([], rtl=False) == []
+    assert sort_panels_reading_order([[0, 0, 10, 10]], rtl=True) == [[0, 0, 10, 10]]
+
+
+def test_snap_stops_at_content_not_paper():
+    """A page with a printed margin: panels must not be stretched into it."""
+    # 1000x1000 page, 80px margin all round (8% -- inside the 15% snap threshold).
+    boxes = [[80, 80, 500, 500], [520, 80, 920, 500], [80, 520, 920, 920]]
+    assert _snap_to_unclaimed_edges([list(b) for b in boxes], 1000, 1000) == boxes
+
+
+def test_snap_extends_short_panel_to_its_neighbours():
+    """The case snapping exists for: one panel falls short of the row's edge."""
+    # Same page, but the top-right panel stops 60px short of the content edge.
+    short = [520, 80, 860, 500]
+    out = _snap_to_unclaimed_edges([[80, 80, 500, 500], list(short), [80, 520, 920, 920]], 1000, 1000)
+    assert out[1] == [520, 80, 920, 500], out[1]
+
+
+def test_no_panels_dropped():
+    """Whatever the layout, every input panel comes back exactly once."""
+    panels = [[0, 0, 100, 100], [50, 50, 200, 200], [10, 90, 300, 120], [0, 0, 300, 300]]
+    for rtl in (True, False):
+        out = sort_panels_reading_order([list(p) for p in panels], rtl=rtl)
+        assert sorted(out) == sorted(panels), (rtl, out)
+
+
+def test_ocr_prompt_names_the_source_language():
+    ja = build_panel_ocr_prompt("ja", rtl=True)
+    assert "Japanese manga page" in ja
+    assert "the Japanese text" in ja
+    assert "right-to-left" in ja
+
+    de = build_panel_ocr_prompt("de", rtl=False)
+    assert "comic page in German" in de
+    assert "the German text" in de
+    assert "left-to-right" in de
+    assert "Japanese" not in de and "manga" not in de
+
+
+def test_ocr_prompt_skips_translating_into_the_source_language():
+    en = build_panel_ocr_prompt("en", rtl=False)
+    assert "no translation is needed" in en
+    assert '"translation": ""' in en
+
+
+def test_ocr_prompt_survives_an_unknown_or_absent_language():
+    for tag in ("", "xx", "tlh-Piqd"):
+        p = build_panel_ocr_prompt(tag, rtl=False)
+        assert "{" in p and "bbox_2d" in p
+        assert "None" not in p and "{}" not in p
+
+
+def test_ocr_prompt_normalizes_the_tag():
+    """Region subtags and case must not defeat the lookup."""
+    for tag in ("JA", "ja-JP", "ja_JP"):
+        assert "Japanese manga page" in build_panel_ocr_prompt(tag, rtl=True), tag
+    # Chinese and Korean comics are not manga; only the language name should appear.
+    for tag, name in (("zh-Hant", "Chinese"), ("ko", "Korean")):
+        p = build_panel_ocr_prompt(tag, rtl=True)
+        assert f"comic page in {name}" in p and "manga" not in p, tag
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_"):
+            fn()
+            print(f"ok  {name}")
+    print("All panel-order checks passed.")


### PR DESCRIPTION
Converting a Moomin or Calvin and Hobbes page produced panels that walked backwards, with text the OCR model had been told to read as Japanese. Panel order was hardcoded right-to-left and the prompt hardcoded to Japanese.

### `--ltr`

`sort_panels_manga_order` becomes `sort_panels_reading_order(panels, rtl=)`. The direction only flips the within-tier comparison and the tie-break; tiers still run top-to-bottom either way, so the topological sort that handles mixed-size grids is untouched and the right-to-left path produces identical output. Page turn direction stays a device setting (Reverse page turn), not a conversion one.

### Language-aware OCR prompt

The prompt is now built per book from `--language` and `--ltr`. Naming the language the model should expect is what stops it hallucinating Japanese out of a German speech bubble. A book already in English gets transcription with no pointless English-to-English translation. An unknown or unset tag yields a prompt naming no language, which still works, and the run prints a note suggesting the flag. Reading order comes from `--ltr` rather than the language, since it is a property of the layout. "manga" is reserved for Japanese — Chinese and Korean comics are manhua and manhwa.

The tag is normalised once in `main` so `--language jp` reaches the prompt as Japanese instead of missing the lookup.

### `--trim-margins`

Crops the blank paper border and the page number off scanned pages before detection. It fills the screen, and it measurably improves detection: the German Moomin page came back as 9 panels with one whole strip undivided, and as all 11 once the margin was gone. Digital-native releases have no margin and are left alone.

### Snapping bug

`_snap_to_unclaimed_edges` extended panels to the *paper* edge whenever the gap was under 15% of the page. A 381px-wide Calvin scan with a 49px margin is 12.9%, so every box was stretched into blank paper; a page with a footer had its bottom row stretched over the page number. It now snaps to the union of the detected boxes, so a printed margin survives while a panel that genuinely falls short of its neighbours still gets extended.

### Verification

| Page | Result |
| --- | --- |
| Moomin, German print scan | 11 panels, correct order, 850x1200 → 714x1082 trimmed |
| Moomin, English | 12 panels in four strips, correct order |
| Calvin and Hobbes | 8 panels, `1 / 2-3-4 / 5-6 / 7-8`, full CLI run end to end |
| Manga (Spy×Family layout) | regression: unchanged right-to-left order, boxes no longer stretched to paper |

`tools/manga_convert/test_panel_order.py` covers reading order, edge snapping and prompt construction in 11 dependency-free checks. Run it with `python3 test_panel_order.py`.

### Not included

The translation target is still hardcoded to English in `TRANSLATION_TARGET`; a `--translate-to` flag can follow if anyone wants German glosses. The trim uses one global threshold, so a dark scan edge blocks it on that side — it fails safe by not cropping.