### PR TITLE
chore(manga): drop _snap_to_unclaimed_edges, which nothing calls

### DIFF
--- a/tools/manga_convert/convert_manga.py
+++ b/tools/manga_convert/convert_manga.py
@@ -617,68 +617,6 @@ def _detect_panels_yolo(img, conf: float = 0.4) -> list[list[int]] | None:
     return boxes
 
 
-def _snap_to_unclaimed_edges(boxes: list[list[int]], page_w: int, page_h: int,
-                             max_gap_frac: float = 0.15) -> list[list[int]]:
-    """Extend a panel's edge to the edge of the page's CONTENT when it falls
-    short by a plausible amount AND no other detected panel claims that space.
-
-    The detector sometimes underestimates a panel's true extent near the
-    page edge (e.g. missing a speech bubble that reaches close to the
-    border), leaving a gap that should belong to that panel rather than
-    being a deliberate gutter. Only snap small gaps (<15% of the page
-    dimension) and only when nothing else occupies the overlapping range,
-    so real gutters between adjacent panels are left alone.
-
-    The target is the union of all detected boxes, NOT the paper edge, so a
-    printed page's own margins are respected. Snapping to the paper edge
-    swallowed those margins whenever they were narrower than the threshold:
-    a scanned comic page with a 13% side margin had every panel stretched
-    into it, and a page with a footer had its bottom row stretched over the
-    page number. Both produce panel crops padded with blank paper, which is
-    exactly the screen area panel zoom exists to reclaim.
-    """
-    original = [tuple(b) for b in boxes]
-    result = [list(b) for b in boxes]
-    if not original:
-        return result
-
-    left = min(b[0] for b in original)
-    top = min(b[1] for b in original)
-    right = max(b[2] for b in original)
-    bottom = max(b[3] for b in original)
-
-    def claimed_beyond(i: int, axis: str, beyond) -> bool:
-        ox1, oy1, ox2, oy2 = original[i]
-        for j, (jx1, jy1, jx2, jy2) in enumerate(original):
-            if j == i:
-                continue
-            if axis == "x":
-                overlaps = not (jy2 <= oy1 or jy1 >= oy2)
-                if overlaps and beyond(jx1, jx2, ox1, ox2):
-                    return True
-            else:
-                overlaps = not (jx2 <= ox1 or jx1 >= ox2)
-                if overlaps and beyond(jy1, jy2, oy1, oy2):
-                    return True
-        return False
-
-    for i, (x1, y1, x2, y2) in enumerate(original):
-        if 0 < right - x2 < page_w * max_gap_frac and \
-           not claimed_beyond(i, "x", lambda j1, j2, o1, o2: j2 > o2):
-            result[i][2] = right
-        if 0 < x1 - left < page_w * max_gap_frac and \
-           not claimed_beyond(i, "x", lambda j1, j2, o1, o2: j1 < o1):
-            result[i][0] = left
-        if 0 < bottom - y2 < page_h * max_gap_frac and \
-           not claimed_beyond(i, "y", lambda j1, j2, o1, o2: j2 > o2):
-            result[i][3] = bottom
-        if 0 < y1 - top < page_h * max_gap_frac and \
-           not claimed_beyond(i, "y", lambda j1, j2, o1, o2: j1 < o1):
-            result[i][1] = top
-
-    return result
-
-
 def _merge_small_gaps(splits: list[int], min_size: int) -> list[int]:
     """Collapse boundary points that would create a too-small segment.
 

--- a/tools/manga_convert/test_panel_order.py
+++ b/tools/manga_convert/test_panel_order.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Self-check for panel reading order, edge snapping and the OCR prompt.
+"""Self-check for panel reading order and the OCR prompt.
 No deps -- run: python3 test_panel_order.py
 
 Boxes are [x1, y1, x2, y2]. Each ordering case lists panels in an arbitrary
 input order and asserts the sequence the reader should walk them in.
 """
 
-from convert_manga import _snap_to_unclaimed_edges, build_panel_ocr_prompt, sort_panels_reading_order
+from convert_manga import build_panel_ocr_prompt, sort_panels_reading_order
 
 
 def order(panels, named, rtl):
@@ -58,21 +58,6 @@ def test_full_width_strip_between_rows():
 def test_single_and_empty():
     assert sort_panels_reading_order([], rtl=False) == []
     assert sort_panels_reading_order([[0, 0, 10, 10]], rtl=True) == [[0, 0, 10, 10]]
-
-
-def test_snap_stops_at_content_not_paper():
-    """A page with a printed margin: panels must not be stretched into it."""
-    # 1000x1000 page, 80px margin all round (8% -- inside the 15% snap threshold).
-    boxes = [[80, 80, 500, 500], [520, 80, 920, 500], [80, 520, 920, 920]]
-    assert _snap_to_unclaimed_edges([list(b) for b in boxes], 1000, 1000) == boxes
-
-
-def test_snap_extends_short_panel_to_its_neighbours():
-    """The case snapping exists for: one panel falls short of the row's edge."""
-    # Same page, but the top-right panel stops 60px short of the content edge.
-    short = [520, 80, 860, 500]
-    out = _snap_to_unclaimed_edges([[80, 80, 500, 500], list(short), [80, 520, 920, 920]], 1000, 1000)
-    assert out[1] == [520, 80, 920, 500], out[1]
 
 
 def test_no_panels_dropped():


### PR DESCRIPTION
`_snap_to_unclaimed_edges` has had no caller since the commit that introduced it (75a06b3f). `main` goes straight from `detect_panels()` to `sort_panels_reading_order()`, and nothing else in the tool references it:

```
$ grep -n _snap_to_unclaimed_edges tools/manga_convert/convert_manga.py
620:def _snap_to_unclaimed_edges(boxes: list[list[int]], page_w: int, page_h: int,
```

### Correcting #246

This also means the behaviour change in #246 was to dead code. That PR claimed a scanned comic page "had every panel stretched into blank paper" — that described a test harness calling this function by hand while I was evaluating detection, not the converter, which has always written the detector's own boxes straight out. The overlay images in that PR's comment were produced by the same harness, so they show snapping the tool never applies.

The `--trim-margins` measurements in #246 are unaffected: 9 panels untrimmed versus 11 trimmed came from real conversion runs, and so did every panel count and ordering result.

### What changes

62 lines of the function, and the two tests that only ever exercised it. No behaviour change, because there was no behaviour. Calvin and Hobbes still converts to 8 panels; the remaining 9 checks in `test_panel_order.py` pass.

If panel boxes should be extended toward their neighbours, that wants deciding on evidence from real output and wiring into the pipeline deliberately — not left as an unreferenced function that looks live to the next reader.