### PR TITLE
fix: coalesce the heap before Home rebuilds a book's cover and CSS cache

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -124,6 +124,16 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
       if (coverMissing) {
         // If epub, try to load the metadata for title/author and cover
         if (FsHelpers::hasEpubExtension(book.path)) {
+          // Coalesce the heap BEFORE the load, not just before the cover extraction below. Both
+          // halves of this block are heap-hungry and both fail the same way arriving here from a
+          // reader: the stylesheet parse gates on 64KB free per file, and the cover inflates
+          // through a 32KB zip window. Measured on device: the parse skipped its last stylesheet
+          // at 45904 bytes free and then DISCARDED the whole parse (correctly -- a partial rule
+          // set must not be cached as complete), throwing away ~3.5s of work that would be redone
+          // and re-discarded on the next visit. The XTC branch below does the same release for the
+          // same reason. Font caches reload on demand.
+          if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
+
           Epub epub(book.path, "/.crosspoint");
           // Build the CSS cache alongside the first cover while the loading UI is already
           // active, so the later book click does not synchronously parse every stylesheet.
@@ -135,14 +145,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
             popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
           }
           GUI.fillPopupProgress(renderer, popupRect, 10 + progress * (90 / recentBooks.size()));
-          // Same coalescing the XTC branch below does, for the same reason: extracting the cover
-          // inflates it through a 32KB zip window, and arriving here straight from a reader leaves
-          // the heap fragmented enough that the window cannot be placed -- measured on device as
-          // "Inflate window OOM (32768 bytes): heap 11584 free/6132 max". The failure is
-          // recoverable (the path is kept and retried), but the retry re-runs the epub.load()
-          // above, which costs ~3.5s of CSS parsing on the way back to Home and then fails the
-          // same way. Releasing the font caches first turns that loop into one success: measured
-          // maxAlloc 57332 -> 114676 for the same release in the reader.
+          // Again before the extraction itself: the load above may have refilled the heap with
+          // rule data, and the 32KB inflate window is what failed here on device ("Inflate window
+          // OOM (32768 bytes): heap 11584 free/6132 max"). That failure is recoverable by design
+          // -- the cover path is kept rather than recording "no cover" -- but the retry repeats
+          // the whole load first, so it is worth not failing in the first place.
           if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
           const bool success = epub.generateThumbBmp(coverHeight);
           if (success) {

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -135,6 +135,15 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
             popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
           }
           GUI.fillPopupProgress(renderer, popupRect, 10 + progress * (90 / recentBooks.size()));
+          // Same coalescing the XTC branch below does, for the same reason: extracting the cover
+          // inflates it through a 32KB zip window, and arriving here straight from a reader leaves
+          // the heap fragmented enough that the window cannot be placed -- measured on device as
+          // "Inflate window OOM (32768 bytes): heap 11584 free/6132 max". The failure is
+          // recoverable (the path is kept and retried), but the retry re-runs the epub.load()
+          // above, which costs ~3.5s of CSS parsing on the way back to Home and then fails the
+          // same way. Releasing the font caches first turns that loop into one success: measured
+          // maxAlloc 57332 -> 114676 for the same release in the reader.
+          if (auto* fcm = renderer.getFontCacheManager()) fcm->releaseAllFontMemory();
           const bool success = epub.generateThumbBmp(coverHeight);
           if (success) {
             // Also covers the recovery case: a book whose path was cleared by an earlier build


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop Home's cover/stylesheet rebuild failing on a fragmented heap, which made returning from a book cost ~12s *repeatedly* instead of once.
* **What changes are included?** Two `releaseAllFontMemory()` calls in `HomeActivity::loadRecentCovers` — one before `epub.load()`, one before `generateThumbBmp()` — mirroring what the XTC branch a few lines below already does.

Instrumenting the transition showed `exitActivity()` at 60ms and `Home onEnter()` at 12ms, so none of the cost was leaving the book. It was Home rebuilding the book's cover thumbnail and stylesheet cache, and failing at both:

```
Loading ePub …
Insufficient heap for CSS parsing (45904 bytes free, need 65536), skipping: style-check.css
CSS parse incomplete on low heap; discarding partial cache for retry next open
Loaded 0 CSS style rules from 6 files
Generating thumb BMP from JPG cover image
[ZIP] Inflate window OOM (32768 bytes): heap 11584 free/6132 max
[HOME] Cover thumb failed; keeping path to retry
```

Both halves are heap-hungry and both fail the same way when reached straight from a reader, where the heap is at its most fragmented. The stylesheet parse gates on 64KB free per file; the cover inflates through a 32KB zip window.

Both failures are *handled* correctly — a partial rule set is not cached as complete, and a cover that did not fit is retried rather than recorded as "this book has no cover". But each retry repeats the whole ~3.5s parse and then fails identically, so the cost recurred on every return to Home until the heap happened to cooperate. The pre-warm that exists so the later book click does not pay that parse never got the chance to finish.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the adjacent XTC branch handles it, the EPUB branch was simply missing the same treatment.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact:** none. No new allocation; this releases existing caches earlier. Font caches reload on demand, which is already the behaviour after the XTC branch does the same thing.

**Risk:** the release happens while Home is mid-paint, so the glyphs for the loading popup are dropped and reloaded. That path already exists and is exercised by the XTC branch; the following render logs a normal `Prewarm: 18 glyphs`.

**Testing** — on an X4 (ESP32-C3) with `/.crosspoint/epub_<hash>/` cleared to reproduce the failing state:

- stylesheet parse now completes and persists: `Saved 1787 rules to cache (incremental)`, no skipped file, no discard
- cover generates on the first attempt: no `Inflate window OOM`, no `Cover thumb failed`

Both artifacts persist, so subsequent returns to Home skip the block entirely rather than re-running and re-failing it.

**Focus area for review:** whether releasing the font caches before `epub.load()` is safe on boards where Home's first paint has not completed yet. I only exercised the return-from-reader path.

**Not addressed here:** even when it succeeds, this work runs on the navigation path — the main task blocks in `exitActivity()` for its duration (measured `RenderLock wait = 12247 ms` while the render task rebuilt cover and CSS). That is the lock doing its job around genuinely slow work, not a locking defect. Moving cover regeneration off the path the user is navigating through is a separate, larger change.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
