### PR TITLE
(archive PR) fix: drop the Resume shortcut from the home screen

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -332,14 +332,6 @@ void HomeActivity::loop() {
     return;
   }
 
-  // Back is otherwise unused on the home menu: open the most recently read
-  // book directly (recentBooks is most-recent-first and already pruned of
-  // files missing from the SD card).
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && !recentBooks.empty()) {
-    onSelectBook(recentBooks[0].path);
-    return;
-  }
-
   const int coverColumnCount = std::max(1, metrics.homeRecentBooksCount);
   const int recentCount = std::min(static_cast<int>(recentBooks.size()), coverColumnCount);
   const int coverColumnWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / coverColumnCount;
@@ -470,8 +462,10 @@ void HomeActivity::render(RenderLock&&) {
       [&menuItems](int index) { return std::string(menuItems[index]); },
       [&menuIcons](int index) { return menuIcons[index]; });
 
-  const auto labels = mappedInput.mapLabels(recentBooks.empty() ? "" : tr(STR_RESUME), tr(STR_SELECT), tr(STR_DIR_UP),
-                                            tr(STR_DIR_DOWN));
+  // Back carries no action on the home menu, so it gets no hint. It used to open
+  // the most recent book, which sits under a button the reader otherwise treats
+  // as "go back" and was too easy to hit by accident.
+  const auto labels = mappedInput.mapLabels("", tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 
   lastRenderValid = true;


### PR DESCRIPTION
Note: This is an archive PR, this PR will get closed later on and a new PR with the same content of the code will be opened.

## Summary

* **What is the goal of this PR?** Preserve a standalone fix — dropping the Resume shortcut from the home screen — as a reviewable change with its own history, independent of where it has since been merged.
* **What changes are included?** One commit touching one file.

The home menu bound Back to "open the most recently read book" and showed a **Resume** hint for it. Back is the one button a reader presses without looking, expecting to go back, so the shortcut fired by accident and dropped them into a book.

The binding and the hint are removed. Nothing is lost: the same book is one press away through the Reading Mode menu entry and the cover tile, both of which are deliberate targets.

`STR_RESUME` deliberately stays in the translation files — `.cplang` language packs index strings positionally and carry a `key_count`, so removing a key would shift every later index and invalidate packs written by older builds.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the accidental-activation behaviour is what this removes.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

The base branch is the commit this change was originally written against, so the diff shows exactly the one file it touches. Memory and flash impact: negligible — a removed input branch and a shortened hint string.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
